### PR TITLE
Fix checkbox layout in time slot and date override sections

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -487,8 +487,9 @@
 }
 
 .fp-override-checkbox input[type="checkbox"] {
-    margin: 0;
-    transform: scale(1.1);
+    margin: 0 4px 0 0;
+    transform: none;
+    flex-shrink: 0;
 }
 
 /* Number input styling for capacity and prices */
@@ -721,8 +722,9 @@
 }
 
 .fp-override-checkbox input[type="checkbox"] {
-    margin: 0;
-    transform: scale(1.1);
+    margin: 0 4px 0 0;
+    transform: none;
+    flex-shrink: 0;
 }
 
 .fp-override-checkbox label {
@@ -1438,8 +1440,9 @@
 }
 
 .fp-override-toggle input[type="checkbox"] {
-    margin: 0;
-    transform: scale(1.1);
+    margin: 0 4px 0 0;
+    transform: none;
+    flex-shrink: 0;
 }
 
 .fp-override-toggle .description {
@@ -2992,6 +2995,8 @@ body.fp-reduced-animations .fp-loading::after {
 
 .fp-day-pill-clean input[type="checkbox"] {
     position: absolute;
+    top: 0;
+    left: 0;
     opacity: 0;
     width: 100%;
     height: 100%;
@@ -3242,6 +3247,11 @@ body.fp-reduced-animations .fp-loading::after {
     display: flex;
     align-items: center;
     gap: 8px;
+}
+
+.fp-override-checkbox-clean input[type="checkbox"] {
+    margin: 0 4px 0 0;
+    flex-shrink: 0;
 }
 
 .fp-override-checkbox-clean label {


### PR DESCRIPTION
## Summary
- normalize checkbox spacing in time slot overview and override sections
- ensure hidden day-of-week inputs align correctly inside pills

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b98af518c0832fb1c8ca8832c4a2c8