### PR TITLE
Schedule holds cleanup cron after interval registration

### DIFF
--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -456,12 +456,13 @@ class Plugin {
      * Initialize holds cleanup cron
      */
     public function initHoldsCron(): void {
+        // Add custom cron interval first
+        add_filter('cron_schedules', [$this, 'addHoldsCronInterval']);
+
+        // Schedule the event only after the interval is available
         if (!wp_next_scheduled('fp_esperienze_cleanup_holds')) {
             wp_schedule_event(time(), 'fp_esperienze_every_5_minutes', 'fp_esperienze_cleanup_holds');
         }
-        
-        // Add custom cron interval
-        add_filter('cron_schedules', [$this, 'addHoldsCronInterval']);
     }
     
     /**


### PR DESCRIPTION
## Summary
- ensure holds cleanup cron interval is registered before scheduling

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs includes/Core/Plugin.php` *(fails: referenced sniff "WordPress" does not exist)*
- `php -l includes/Core/Plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_68bbe547c24c832fad67e7d8d7de86a6