### PR TITLE
Clear cleanup cron on deactivation

### DIFF
--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -45,6 +45,9 @@ class Installer {
      * Plugin deactivation
      */
     public static function deactivate(): void {
+        // Clear scheduled cleanup holds event
+        wp_clear_scheduled_hook('fp_esperienze_cleanup_holds');
+
         // Flush rewrite rules
         flush_rewrite_rules();
     }


### PR DESCRIPTION
## Summary
- clear `fp_esperienze_cleanup_holds` cron event when plugin deactivates

## Testing
- `php /tmp/cron_test.php`
- `composer test` *(fails: Unexpected item 'parameters \u00a0\u203a\u00a0bootstrap')*
- `phpcs --standard=WordPress includes/Core/Installer.php` *(fails: FOUND 509 ERRORS AND 56 WARNINGS AFFECTING 266 LINES)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe6bb4b84832fa8a4bdf55cdb4686