### PR TITLE
Handle extras with wp_unslash and integer sanitization

### DIFF
--- a/includes/Booking/Cart_Hooks.php
+++ b/includes/Booking/Cart_Hooks.php
@@ -66,7 +66,7 @@ class Cart_Hooks {
         $lang = sanitize_text_field($_POST['fp_lang'] ?? '');
         $qty_adult = absint($_POST['fp_qty_adult'] ?? 0);
         $qty_child = absint($_POST['fp_qty_child'] ?? 0);
-        $extras_json = sanitize_text_field($_POST['fp_extras'] ?? '');
+        $extras_data = json_decode(wp_unslash($_POST['fp_extras'] ?? ''), true);
         
         // Get gift data from POST
         $is_gift = !empty($_POST['fp_is_gift']);
@@ -78,12 +78,9 @@ class Cart_Hooks {
 
         if ($slot_start) {
             $extras = [];
-            if (!empty($extras_json)) {
-                $extras_data = json_decode($extras_json, true);
-                if (is_array($extras_data)) {
-                    foreach ($extras_data as $extra_id => $quantity) {
-                        $extras[absint($extra_id)] = absint($quantity);
-                    }
+            if (is_array($extras_data)) {
+                foreach ($extras_data as $extra_id => $quantity) {
+                    $extras[absint($extra_id)] = absint($quantity);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Use `wp_unslash` to read extra selections from POST data
- Decode extras JSON and sanitize IDs and quantities with `absint`

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe8214ca4832fb1ace299e61f5241