### PR TITLE
Clear cron hooks on plugin deactivation

### DIFF
--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -45,8 +45,23 @@ class Installer {
      * Plugin deactivation
      */
     public static function deactivate(): void {
-        // Clear scheduled cleanup holds event
-        wp_clear_scheduled_hook('fp_esperienze_cleanup_holds');
+        $hooks = [
+            'fp_esperienze_cleanup_holds',
+            'fp_check_abandoned_carts',
+            'fp_send_upselling_emails',
+            'fp_daily_ai_analysis',
+            'fp_esperienze_prebuild_availability',
+        ];
+
+        // Clear all scheduled events for the plugin
+        foreach ($hooks as $hook) {
+            wp_clear_scheduled_hook($hook);
+
+            // Verify that no events remain scheduled for this hook
+            while ($timestamp = wp_next_scheduled($hook)) {
+                wp_unschedule_event($timestamp, $hook);
+            }
+        }
 
         // Flush rewrite rules
         flush_rewrite_rules();


### PR DESCRIPTION
## Summary
- ensure plugin deactivation clears all plugin-scheduled cron hooks and verifies none remain

## Testing
- `php -l includes/Core/Installer.php`
- `vendor/bin/phpstan analyse -c /tmp/phpstan.neon --memory-limit=1G` (fails: Function __ not found etc., 4286 errors)
- `composer phpcs` (fails: WordPress coding standard not installed)


------
https://chatgpt.com/codex/tasks/task_e_68bbf11b54c4832faaedf09c1e647ad8