### PR TITLE
Refactor client IP handling for mobile API

### DIFF
--- a/includes/Core/RateLimiter.php
+++ b/includes/Core/RateLimiter.php
@@ -48,7 +48,7 @@ class RateLimiter {
      *
      * @return string Client IP address
      */
-    private static function getClientIP(): string {
+    public static function getClientIP(): string {
         $remote_addr = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
 
         $trusted_proxies = apply_filters('fp_trusted_proxies', []);

--- a/includes/REST/MobileAPIManager.php
+++ b/includes/REST/MobileAPIManager.php
@@ -1322,24 +1322,13 @@ class MobileAPIManager {
     }
 
     /**
-     * Get client IP address
+     * Get client IP address.
+     *
+     * Uses RateLimiter helper to respect trusted proxy whitelist.
      *
      * @return string Client IP address
      */
     private function getClientIP(): string {
-        $ip_keys = ['HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR'];
-        
-        foreach ($ip_keys as $key) {
-            if (array_key_exists($key, $_SERVER) === true) {
-                foreach (explode(',', $_SERVER[$key]) as $ip) {
-                    $ip = trim($ip);
-                    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                        return $ip;
-                    }
-                }
-            }
-        }
-        
-        return $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+        return RateLimiter::getClientIP();
     }
 }


### PR DESCRIPTION
## Summary
- expose `RateLimiter::getClientIP` for reuse
- delegate mobile API IP detection to `RateLimiter` with trusted proxy support

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/Core/RateLimiter.php includes/REST/MobileAPIManager.php` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf3746270832f947b9adaab64ded4