### PR TITLE
Validate webhook URLs and use wp_safe_remote_post

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -4333,12 +4333,13 @@ class MenuManager {
         }
         
         $webhook_url = esc_url_raw($_POST['webhook_url'] ?? '');
-        
-        if (!$webhook_url) {
+        $validated_url = wp_http_validate_url($webhook_url);
+
+        if (!$validated_url || !in_array(wp_parse_url($validated_url, PHP_URL_SCHEME), ['http', 'https'], true)) {
             wp_send_json_error(['message' => __('Invalid webhook URL.', 'fp-esperienze')]);
         }
-        
-        $result = WebhookManager::testWebhook($webhook_url);
+
+        $result = WebhookManager::testWebhook($validated_url);
         
         if ($result['success']) {
             wp_send_json_success($result);


### PR DESCRIPTION
## Summary
- validate webhook URLs and restrict to http/https before sending or testing webhooks
- replace wp_remote_post with wp_safe_remote_post for webhook requests
- validate webhook URL in AJAX test handler

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: WordPress standard not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf4102164832fb6dc08a570766acc