### PR TITLE
Harden diagnostic scripts and exclude from releases

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,13 @@
+debug-product-type.php
+setup-wizard-diagnostic.php
+override-rows-diagnostic.php
+performance-test.php
+security-test.php
+verify-product-type-fix.php
+test-autoloading-fix.php
+test-brevo-integration.php
+test-gift-voucher.php
+test-schedules.php
+accessibility-test.py
+dev-tools.sh
+security-validate.sh

--- a/debug-product-type.php
+++ b/debug-product-type.php
@@ -4,12 +4,13 @@
  * Place this in the wp-content/plugins/fp-esperienze/ directory and access via admin
  */
 
-// This should be included or called from within WordPress context
+defined( 'ABSPATH' ) || exit;
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    return;
+}
 
 function fp_debug_product_type() {
-    if (!current_user_can('manage_options')) {
-        return;
-    }
     
     echo "<h2>FP Esperienze Product Type Debug</h2>";
     

--- a/override-rows-diagnostic.php
+++ b/override-rows-diagnostic.php
@@ -1,20 +1,15 @@
 <?php
 /**
  * Diagnostic Script: Override Rows Fix Verification
- * 
+ *
  * This script helps verify that the override rows fix is working correctly.
  * Usage: Load this in WordPress admin to check for potential issues.
  */
 
-// Prevent direct access
-if (!defined('ABSPATH')) {
-    // For standalone testing, define basic constants
-    if (!defined('WP_DEBUG')) {
-        define('WP_DEBUG', true);
-    }
-    if (!defined('WP_DEBUG_LOG')) {
-        define('WP_DEBUG_LOG', true);
-    }
+defined( 'ABSPATH' ) || exit;
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    return;
 }
 
 class FPOverrideRowsDiagnostic {
@@ -243,14 +238,6 @@ class FPOverrideRowsDiagnostic {
         }
     }
 }
-
-// Run the diagnostic if accessed directly
-if (basename($_SERVER['SCRIPT_NAME']) === 'override-rows-diagnostic.php') {
-    echo "<!DOCTYPE html><html><head><title>Override Rows Fix Diagnostic</title></head><body>";
-    FPOverrideRowsDiagnostic::run();
-    echo "</body></html>";
-}
-
 // WordPress action hook for admin access
 if (function_exists('add_action')) {
     add_action('wp_loaded', function() {

--- a/performance-test.php
+++ b/performance-test.php
@@ -1,16 +1,17 @@
 <?php
 /**
  * Performance Measurement Script
- * 
+ *
  * Run this script to measure the performance improvements
  * Usage: php performance-test.php
  */
 
-// WordPress bootstrap (adjust path as needed)
 require_once __DIR__ . '/../../wp-load.php';
 
-if (!defined('ABSPATH')) {
-    die('WordPress not loaded properly');
+defined( 'ABSPATH' ) || exit;
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    return;
 }
 
 class PerformanceTest {
@@ -283,9 +284,8 @@ class PerformanceTest {
         echo "Performance test completed successfully! 🚀\n";
     }
 }
-
 // Run the test if called directly
 if (php_sapi_name() === 'cli') {
-    $test = new PerformanceTest();
-    $test->runTests();
+$test = new PerformanceTest();
+$test->runTests();
 }

--- a/security-test.php
+++ b/security-test.php
@@ -1,14 +1,15 @@
 <?php
 /**
  * Security Test Script for FP Esperienze
- * 
+ *
  * Run this script to verify security implementation
  * Usage: wp eval-file security-test.php
  */
 
-if (!defined('ABSPATH')) {
-    echo "This script must be run within WordPress context.\n";
-    exit(1);
+defined( 'ABSPATH' ) || exit;
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    return;
 }
 
 echo "=== FP Esperienze Security Test ===\n\n";

--- a/setup-wizard-diagnostic.php
+++ b/setup-wizard-diagnostic.php
@@ -1,21 +1,15 @@
 <?php
 /**
  * Setup Wizard Diagnostic Script
- * 
+ *
  * This script helps diagnose setup wizard issues in FP Esperienze plugin.
  * Place this file in WordPress root directory and access via browser.
  */
 
-// Prevent direct access from web if not in WordPress context
-if (!defined('ABSPATH')) {
-    // Simple WordPress loading for diagnostic purposes
-    $wp_config_path = __DIR__ . '/wp-config.php';
-    if (file_exists($wp_config_path)) {
-        require_once $wp_config_path;
-        require_once ABSPATH . 'wp-settings.php';
-    } else {
-        die('WordPress not found. Place this file in WordPress root directory.');
-    }
+defined( 'ABSPATH' ) || exit;
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    return;
 }
 
 // Check if we're in admin context

--- a/verify-product-type-fix.php
+++ b/verify-product-type-fix.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Verification test for the Experience Product Type Fix
- * 
+ *
  * This simulates the WooCommerce product type registration to verify
  * that 'experience' is now properly recognized as a valid product type.
- * 
+ *
  * Run this in a WordPress environment with WooCommerce active to test.
  */
 
-// Ensure this is run in WordPress context
-if (!defined('ABSPATH')) {
-    echo "This test must be run within WordPress environment.\n";
-    exit;
+defined( 'ABSPATH' ) || exit;
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    return;
 }
 
 echo "<h1>Experience Product Type Fix - Verification Test</h1>\n";


### PR DESCRIPTION
## Summary
- guard diagnostic scripts with `ABSPATH` and admin capability checks
- exclude debug and test scripts from distributed plugin package

## Testing
- `php -l debug-product-type.php setup-wizard-diagnostic.php override-rows-diagnostic.php performance-test.php security-test.php verify-product-type-fix.php`
- `composer test` *(fails: Invalid configuration: Unexpected item 'parameters › bootstrap')*


------
https://chatgpt.com/codex/tasks/task_e_68bbf4fd93a8832f8aca4aced601a880