### PR TITLE
Sanitize export CSV link in bookings page

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -460,7 +460,7 @@ class MenuManager {
                         
                         <input type="submit" class="button" value="<?php _e('Filter', 'fp-esperienze'); ?>">
                         <a href="<?php echo admin_url('admin.php?page=fp-esperienze-bookings'); ?>" class="button"><?php _e('Clear', 'fp-esperienze'); ?></a>
-                        <a href="<?php echo add_query_arg(array_merge($_GET, ['action' => 'export_csv', '_wpnonce' => $export_nonce]), admin_url('admin.php')); ?>" class="button button-secondary"><?php _e('Export CSV', 'fp-esperienze'); ?></a>
+                        <a href="<?php echo esc_url(add_query_arg(array_merge(array_map('sanitize_text_field', $_GET), ['action' => 'export_csv', '_wpnonce' => $export_nonce]), admin_url('admin.php'))); ?>" class="button button-secondary"><?php _e('Export CSV', 'fp-esperienze'); ?></a>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- Sanitize and escape the export CSV link on the bookings management page

## Testing
- `composer test` *(fails: Invalid configuration: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: ERROR: the "WordPress" coding standard is not installed)*
- `vendor/bin/phpcs --standard=PSR12 includes/Admin/MenuManager.php`
- `php -l includes/Admin/MenuManager.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbfa31c154832fae1304e80b43aa89