### PR TITLE
Prevent variable overwriting when rendering email templates

### DIFF
--- a/includes/Integrations/EmailMarketingManager.php
+++ b/includes/Integrations/EmailMarketingManager.php
@@ -537,7 +537,7 @@ class EmailMarketingManager {
         }
 
         ob_start();
-        extract($data);
+        extract($data, EXTR_SKIP);
         include $template_path;
         return ob_get_clean();
     }


### PR DESCRIPTION
## Summary
- avoid overwriting pre-existing template variables by using `extract($data, EXTR_SKIP)`

## Testing
- `php /tmp/test_render.php | head -n 20`
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/Integrations/EmailMarketingManager.php` *(fails: WordPress coding standard not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfe03c3e8832fac2c94889a88dbfe