### PR TITLE
Use plugin-specific container class

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1408,7 +1408,7 @@
 }
 
 /* Utility */
-.container {
+.fp-container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 20px;

--- a/templates/single-experience.php
+++ b/templates/single-experience.php
@@ -116,7 +116,7 @@ jQuery(document).ready(function($) {
             <?php endif; ?>
             
             <div class="fp-hero-info">
-                <div class="container">
+                <div class="fp-container">
                     <h1 class="fp-experience-title"><?php echo esc_html($product->get_name()); ?></h1>
                     
                     <?php if ($product->get_short_description()) : ?>
@@ -137,7 +137,7 @@ jQuery(document).ready(function($) {
 
     <!-- Trust/USP Bar -->
     <section class="fp-trust-bar">
-        <div class="container">
+        <div class="fp-container">
             <div class="fp-trust-items">
                 <?php if ($duration) : ?>
                     <div class="fp-trust-item">
@@ -205,7 +205,7 @@ jQuery(document).ready(function($) {
         </div>
     </section>
 
-    <div class="container fp-experience-content">
+    <div class="fp-container fp-experience-content">
         <div class="fp-content-layout">
             <!-- Main Content -->
             <div class="fp-main-content">


### PR DESCRIPTION
## Summary
- Avoid clash with theme styles by renaming `.container` utility to `.fp-container`
- Update single experience template to use new `.fp-container` wrapper classes

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: coding standards issues in includes/)*

------
https://chatgpt.com/codex/tasks/task_e_68bbffee7b24832fb8aa1e730081aa63