### PR TITLE
Hide gallery thumbnails on mobile

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -382,6 +382,12 @@
     transform: scale(1.05);
 }
 
+@media (max-width: 768px) {
+    .fp-gallery-thumbs {
+        display: none;
+    }
+}
+
 .fp-hero-info {
     padding: 40px;
     background: white;

--- a/templates/single-experience.php
+++ b/templates/single-experience.php
@@ -103,11 +103,11 @@ jQuery(document).ready(function($) {
                              alt="<?php echo esc_attr($product->get_name()); ?>" 
                              loading="lazy" />
                     </div>
-                    <?php if ($gallery_ids) : ?>
+                    <?php if ( $gallery_ids && ! wp_is_mobile() ) : ?>
                         <div class="fp-gallery-thumbs">
-                            <?php foreach (array_slice($gallery_ids, 0, 4) as $gallery_id) : ?>
-                                <img src="<?php echo esc_url(wp_get_attachment_image_url($gallery_id, 'thumbnail')); ?>" 
-                                     alt="<?php echo esc_attr($product->get_name()); ?>" 
+                            <?php foreach ( array_slice( $gallery_ids, 0, 4 ) as $gallery_id ) : ?>
+                                <img src="<?php echo esc_url( wp_get_attachment_image_url( $gallery_id, 'thumbnail' ) ); ?>"
+                                     alt="<?php echo esc_attr( $product->get_name() ); ?>"
                                      loading="lazy" />
                             <?php endforeach; ?>
                         </div>


### PR DESCRIPTION
## Summary
- hide gallery thumbnail strip on screens up to 768px
- skip rendering gallery thumbnails on mobile devices in single experience template

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0172f0fc832f815046f447824ba6