### PR TITLE
Add customizable admin bar offset for plugin banners

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -3597,7 +3597,7 @@ body.fp-reduced-animations .fp-loading::after {
 /* Enhanced Notifications */
 .fp-notification {
     position: fixed;
-    top: 20px;
+    top: var(--fp-banner-offset, 20px);
     right: 20px;
     padding: 15px 20px;
     border-radius: 8px;
@@ -3608,6 +3608,10 @@ body.fp-reduced-animations .fp-loading::after {
     max-width: 400px;
     font-size: 14px;
     line-height: 1.4;
+}
+
+body.admin-bar .fp-notification {
+    top: calc(32px + var(--fp-banner-offset, 20px));
 }
 
 .fp-notification.show {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -809,8 +809,12 @@
     border-radius: 12px;
     padding: 24px;
     position: sticky;
-    top: 20px;
+    top: var(--fp-banner-offset, 20px);
     box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+}
+
+body.admin-bar .fp-booking-widget {
+    top: calc(32px + var(--fp-banner-offset, 20px));
 }
 
 .fp-booking-header {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,6 +5,10 @@
 (function($) {
     'use strict';
 
+    if (typeof fp_esperienze_admin !== 'undefined' && typeof fp_esperienze_admin.banner_offset !== 'undefined') {
+        document.documentElement.style.setProperty('--fp-banner-offset', fp_esperienze_admin.banner_offset + 'px');
+    }
+
     // Prevent multiple script execution
     if (window.FPEsperienzeAdmin && window.FPEsperienzeAdmin.initialized) {
         return;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -5,6 +5,10 @@
 (function($) {
     'use strict';
 
+    if (typeof fp_esperienze_params !== 'undefined' && typeof fp_esperienze_params.banner_offset !== 'undefined') {
+        document.documentElement.style.setProperty('--fp-banner-offset', fp_esperienze_params.banner_offset + 'px');
+    }
+
     $(document).ready(function() {
         // Initialize frontend functionality
         FPEsperienze.init();

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -328,6 +328,7 @@ class Plugin {
                 'rest_url' => get_rest_url(),
                 'nonce' => wp_create_nonce('fp_esperienze_nonce'),
                 'voucher_nonce' => wp_create_nonce('fp_voucher_nonce'),
+                'banner_offset' => apply_filters('fp_esperienze_banner_offset', 20),
             ]);
         }
     }
@@ -368,6 +369,7 @@ class Plugin {
             'ajax_url' => admin_url('admin-ajax.php'),
             'rest_url' => get_rest_url(),
             'nonce' => wp_create_nonce('fp_esperienze_admin_nonce'),
+            'banner_offset' => apply_filters('fp_esperienze_banner_offset', 20),
         ]);
 
         // Enqueue reports script only on reports page


### PR DESCRIPTION
## Summary
- handle WordPress admin bar by calculating top offset via `calc()` in frontend and admin banners
- expose `fp_esperienze_banner_offset` filter and localized JS variable to customize banner offset
- set CSS variable from JS for dynamic offset adjustments

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc02350eac832fae34ae2321afeae2