### PR TITLE
Add hyphenation and word-breaking for long experience titles

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -295,6 +295,8 @@
     margin: 0 0 10px 0;
     font-size: 18px;
     line-height: 1.3;
+    word-break: break-word;
+    hyphens: auto;
 }
 
 .fp-experience-title a {


### PR DESCRIPTION
## Summary
- ensure `.fp-experience-title` wraps long words with `word-break: break-word` and `hyphens: auto`

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*
- Manual verification of a card with a very long title to confirm text stays within the card


------
https://chatgpt.com/codex/tasks/task_e_68bc03fa44a4832f807dc2e11af4c203