### PR TITLE
Validate Meta dataset ID and use safe remote post

### DIFF
--- a/includes/Integrations/MetaCAPIManager.php
+++ b/includes/Integrations/MetaCAPIManager.php
@@ -146,10 +146,16 @@ class MetaCAPIManager {
             'access_token' => $this->settings['meta_access_token'],
         ];
         
+        // Validate dataset ID
+        if (!ctype_digit((string) $this->settings['meta_dataset_id'])) {
+            error_log('FP Esperienze Meta CAPI Error: Invalid dataset ID');
+            return false;
+        }
+
         // Send to Meta Conversions API
         $endpoint = self::API_ENDPOINT . $this->settings['meta_dataset_id'] . '/events';
-        
-        $response = wp_remote_post($endpoint, [
+
+        $response = wp_safe_remote_post($endpoint, [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
@@ -213,9 +219,17 @@ class MetaCAPIManager {
             'access_token' => $this->settings['meta_access_token'],
         ];
         
+        if (!ctype_digit((string) $this->settings['meta_dataset_id'])) {
+            error_log('FP Esperienze Meta CAPI Error: Invalid dataset ID');
+            return [
+                'success' => false,
+                'message' => __('Invalid Meta dataset ID.', 'fp-esperienze'),
+            ];
+        }
+
         $endpoint = self::API_ENDPOINT . $this->settings['meta_dataset_id'] . '/events';
-        
-        $response = wp_remote_post($endpoint, [
+
+        $response = wp_safe_remote_post($endpoint, [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],


### PR DESCRIPTION
## Summary
- ensure Meta dataset ID contains only digits before sending events
- switch Meta CAPI calls to wp_safe_remote_post
- log and abort when dataset ID validation fails

## Testing
- `bash dev-tools.sh test` *(fails: PHPStan analysis failed and PHPCS missing WordPress sniffs)*
- `vendor/bin/phpstan analyse --no-progress` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --report=summary` *(fails: Referenced sniff "WordPress" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0d751344832f88d865669435bf5d