### PR TITLE
Sanitize AJAX filters with wp_unslash

### DIFF
--- a/MANUAL_TESTS_REPORTS.md
+++ b/MANUAL_TESTS_REPORTS.md
@@ -258,6 +258,18 @@
 - [ ] JavaScript errors don't break the page
 - [ ] Fallback content shows when API fails
 
+### 16. Special Character Filters
+
+**Objective**: Ensure filters handle special characters without double escaping
+
+**Steps**:
+1. Enter values containing characters like `O'Reilly` or `café` in filter fields
+2. Apply the filters and observe the results
+
+**Expected Results**:
+- [ ] Submitted values appear without extra backslashes
+- [ ] Filtered data matches the entered special characters
+
 ## Test Results Summary
 
 **Date Tested**: ________________

--- a/includes/Admin/ReportsManager.php
+++ b/includes/Admin/ReportsManager.php
@@ -469,11 +469,11 @@ class ReportsManager {
         }
 
         $filters = [
-            'date_from' => sanitize_text_field($_POST['date_from'] ?? ''),
-            'date_to' => sanitize_text_field($_POST['date_to'] ?? ''),
-            'product_id' => absint($_POST['product_id'] ?? 0),
-            'meeting_point_id' => absint($_POST['meeting_point_id'] ?? 0),
-            'language' => sanitize_text_field($_POST['language'] ?? '')
+            'date_from' => sanitize_text_field(wp_unslash($_POST['date_from'] ?? '')),
+            'date_to' => sanitize_text_field(wp_unslash($_POST['date_to'] ?? '')),
+            'product_id' => absint(wp_unslash($_POST['product_id'] ?? 0)),
+            'meeting_point_id' => absint(wp_unslash($_POST['meeting_point_id'] ?? 0)),
+            'language' => sanitize_text_field(wp_unslash($_POST['language'] ?? ''))
         ];
 
         $kpi_data = $this->getKpiData(array_filter($filters));
@@ -490,10 +490,10 @@ class ReportsManager {
             wp_die(__('Insufficient permissions.', 'fp-esperienze'));
         }
 
-        $period = sanitize_text_field($_POST['period'] ?? 'day');
+        $period = sanitize_text_field(wp_unslash($_POST['period'] ?? 'day'));
         $filters = [
-            'date_from' => sanitize_text_field($_POST['date_from'] ?? ''),
-            'date_to' => sanitize_text_field($_POST['date_to'] ?? ''),
+            'date_from' => sanitize_text_field(wp_unslash($_POST['date_from'] ?? '')),
+            'date_to' => sanitize_text_field(wp_unslash($_POST['date_to'] ?? '')),
         ];
 
         $chart_data = $this->getChartData($period, array_filter($filters));
@@ -510,13 +510,13 @@ class ReportsManager {
             wp_die(__('Insufficient permissions.', 'fp-esperienze'));
         }
         
-        $format = sanitize_text_field($_POST['format'] ?? 'csv');
+        $format = sanitize_text_field(wp_unslash($_POST['format'] ?? 'csv'));
         $filters = [
-            'date_from' => sanitize_text_field($_POST['date_from'] ?? ''),
-            'date_to' => sanitize_text_field($_POST['date_to'] ?? ''),
-            'product_id' => absint($_POST['product_id'] ?? 0),
-            'meeting_point_id' => absint($_POST['meeting_point_id'] ?? 0),
-            'language' => sanitize_text_field($_POST['language'] ?? '')
+            'date_from' => sanitize_text_field(wp_unslash($_POST['date_from'] ?? '')),
+            'date_to' => sanitize_text_field(wp_unslash($_POST['date_to'] ?? '')),
+            'product_id' => absint(wp_unslash($_POST['product_id'] ?? 0)),
+            'meeting_point_id' => absint(wp_unslash($_POST['meeting_point_id'] ?? 0)),
+            'language' => sanitize_text_field(wp_unslash($_POST['language'] ?? ''))
         ];
 
         $this->exportReportData($format, array_filter($filters));


### PR DESCRIPTION
## Summary
- Ensure all Reports AJAX handlers unslash `$_POST` data before sanitizing to prevent double escaping.
- Document manual test scenario for submitting filters with special characters.

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*
- `php -r "$value=addslashes('O\'Reilly & café'); ..."`

------
https://chatgpt.com/codex/tasks/task_e_68bc10cebbc8832f85528bd0be6a377e