### PR TITLE
Use wp_safe_remote_get in SystemStatus remote request check

### DIFF
--- a/includes/Admin/SystemStatus.php
+++ b/includes/Admin/SystemStatus.php
@@ -382,17 +382,23 @@ class SystemStatus {
      */
     private function checkRemoteRequests(): array {
         $test_url = 'https://httpbin.org/get';
-        $response = wp_remote_get($test_url, [
+        $response = wp_safe_remote_get($test_url, [
             'timeout' => 10,
-            'sslverify' => false
         ]);
 
         if (is_wp_error($response)) {
+            $error_message = $response->get_error_message();
+            $description   = $error_message;
+
+            if (false !== strpos(strtolower($error_message), 'ssl') || false !== strpos(strtolower($error_message), 'certificate')) {
+                $description = __('SSL certificate validation failed. Please verify your server configuration.', 'fp-esperienze');
+            }
+
             return [
                 'title' => __('Remote Requests', 'fp-esperienze'),
                 'status' => 'error',
                 'message' => __('Failed', 'fp-esperienze'),
-                'description' => $response->get_error_message()
+                'description' => $description
             ];
         }
 


### PR DESCRIPTION
## Summary
- use `wp_safe_remote_get` instead of `wp_remote_get` for remote request health check
- remove disabled SSL verification and show helpful message when certificate validation fails

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc11e39998832f9b004eed480decf7