### PR TITLE
Validate Google Places API URLs and use safe requests

### DIFF
--- a/includes/Integrations/GooglePlacesManager.php
+++ b/includes/Integrations/GooglePlacesManager.php
@@ -262,8 +262,22 @@ class GooglePlacesManager {
         } elseif ($method === 'GET' && !empty($params)) {
             $url = add_query_arg($params, $url);
         }
-        
-        return wp_remote_request($url, $args);
+
+        $url = wp_http_validate_url($url);
+        if (!$url || !str_starts_with($url, 'https://places.googleapis.com/')) {
+            $this->logError('Invalid Places API URL', ['url' => $url]);
+            return new \WP_Error('invalid_url', __('Invalid API URL', 'fp-esperienze'));
+        }
+
+        if ($method === 'POST') {
+            return wp_safe_remote_post($url, $args);
+        }
+
+        if ($method === 'GET') {
+            return wp_safe_remote_get($url, $args);
+        }
+
+        return wp_safe_remote_request($url, $args);
     }
     
     /**


### PR DESCRIPTION
## Summary
- validate Google Places API URLs before making requests
- switch to `wp_safe_remote_*` functions for safer HTTP calls

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: WordPress coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc12d0ecd4832f9617f5b9efd1b5ca