### PR TITLE
Allow additional characters in mobile push token

### DIFF
--- a/MANUAL_TESTS_PUSH_TOKEN_SANITIZATION.md
+++ b/MANUAL_TESTS_PUSH_TOKEN_SANITIZATION.md
@@ -1,0 +1,21 @@
+# Manual Test: Push Token Sanitization
+
+## Allowed Characters
+- Letters A-Z, a-z
+- Numbers 0-9
+- Colon (:)
+- Dash (-)
+- Period (.)
+- Underscore (_)
+
+## Test Steps
+1. Obtain a valid authentication token for a mobile user.
+2. Acquire a real iOS push notification token from a device.
+3. Send a `POST` request to `/wp-json/fp-esperienze/v2/mobile/notifications/register` with:
+   - `token` set to the iOS token
+   - `platform` set to `ios`
+   - Authorization header set to `Bearer YOUR_AUTH_TOKEN`
+4. Confirm the response is `{"success": true, "message": "Push token registered successfully"}`.
+5. Verify the token is stored in user meta (`_push_notification_token`).
+6. Repeat steps 2-5 using an Android device and `platform` set to `android`.
+7. Optionally send a token containing disallowed characters and confirm they are stripped in storage.

--- a/includes/REST/MobileAPIManager.php
+++ b/includes/REST/MobileAPIManager.php
@@ -676,29 +676,34 @@ class MobileAPIManager {
     }
 
     /**
-     * Register push notification token
+     * Register push notification token.
      *
-     * @param WP_REST_Request $request Request object
-     * @return WP_REST_Response Response
+     * Allowed token characters: letters, numbers, colon (:), dash (-), period (.), underscore (_).
+     *
+     * @param WP_REST_Request $request Request object.
+     * @return WP_REST_Response Response.
      */
-    public function registerPushToken(WP_REST_Request $request): WP_REST_Response {
-        $user_id = $this->getCurrentMobileUserId($request);
-        $token = sanitize_text_field($request->get_param('token'));
-        $platform = sanitize_text_field($request->get_param('platform')); // ios, android
+    public function registerPushToken( WP_REST_Request $request ): WP_REST_Response {
+        $user_id = $this->getCurrentMobileUserId( $request );
+        // Allow letters, numbers, colon, dash, dot and underscore in token.
+        $token    = preg_replace( '/[^A-Za-z0-9:\-._]/', '', wp_unslash( $request->get_param( 'token' ) ) );
+        $platform = sanitize_text_field( $request->get_param( 'platform' ) ); // ios, android
 
-        if (empty($token)) {
-            return new WP_REST_Response(['error' => 'Token is required'], 400);
+        if ( empty( $token ) ) {
+            return new WP_REST_Response( [ 'error' => 'Token is required' ], 400 );
         }
 
-        // Store push token
-        update_user_meta($user_id, '_push_notification_token', $token);
-        update_user_meta($user_id, '_push_platform', $platform);
-        update_user_meta($user_id, '_push_registered_at', current_time('mysql'));
+        // Store push token.
+        update_user_meta( $user_id, '_push_notification_token', $token );
+        update_user_meta( $user_id, '_push_platform', $platform );
+        update_user_meta( $user_id, '_push_registered_at', current_time( 'mysql' ) );
 
-        return new WP_REST_Response([
-            'success' => true,
-            'message' => __('Push token registered successfully', 'fp-esperienze')
-        ]);
+        return new WP_REST_Response(
+            [
+                'success' => true,
+                'message' => __( 'Push token registered successfully', 'fp-esperienze' ),
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Allow colon, dash, dot and underscore when sanitizing push notification tokens
- Document permitted characters and manual test steps for iOS and Android tokens

## Testing
- `php -l includes/REST/MobileAPIManager.php`
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `./vendor/bin/phpcs --standard=WordPress includes/REST/MobileAPIManager.php` *(fails: WordPress standard not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc145088d0832fad718d7e61155d4e