### PR TITLE
Sanitize cache invalidation patterns with esc_like

### DIFF
--- a/includes/Core/CacheManager.php
+++ b/includes/Core/CacheManager.php
@@ -101,18 +101,22 @@ class CacheManager {
         global $wpdb;
         
         // Delete all transients with this product pattern
-        $pattern = '_transient_fp_availability_' . $product_id . '_%';
-        $wpdb->query($wpdb->prepare(
-            "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-            $pattern
-        ));
-        
+        $pattern = $wpdb->esc_like('_transient_fp_availability_' . $product_id) . '%';
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+                $pattern
+            )
+        );
+
         // Also delete timeout transients
-        $timeout_pattern = '_transient_timeout_fp_availability_' . $product_id . '_%';
-        $wpdb->query($wpdb->prepare(
-            "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-            $timeout_pattern
-        ));
+        $timeout_pattern = $wpdb->esc_like('_transient_timeout_fp_availability_' . $product_id) . '%';
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+                $timeout_pattern
+            )
+        );
     }
     
     /**


### PR DESCRIPTION
## Summary
- escape transient deletion patterns in `invalidateProductCache`
- ensure timeout transient patterns are escaped the same way

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/Core/CacheManager.php` *(fails: WordPress standard not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bc16827ce4832fbea761aeaca0f862