### PR TITLE
Sanitize voucher output filenames

### DIFF
--- a/includes/PDF/Qr.php
+++ b/includes/PDF/Qr.php
@@ -51,21 +51,31 @@ class Qr {
         
         // Save QR code image
         $upload_dir = wp_upload_dir();
-        $qr_dir = $upload_dir['basedir'] . '/fp-esperienze/voucher/qr/';
-        
+        $base_dir   = trailingslashit(wp_normalize_path($upload_dir['basedir']));
+        $qr_dir     = $base_dir . 'fp-esperienze/voucher/qr/';
+
         if (!file_exists($qr_dir)) {
             wp_mkdir_p($qr_dir);
         }
-        
-        $filename = 'qr-' . $voucher_data['code'] . '-' . time() . '.png';
-        $file_path = $qr_dir . $filename;
-        
+
+        $sanitized_code = sanitize_file_name($voucher_data['code']);
+        if ($sanitized_code === '') {
+            throw new \Exception('Invalid voucher code.');
+        }
+
+        $filename  = 'qr-' . $sanitized_code . '-' . time() . '.png';
+        $file_path = wp_normalize_path($qr_dir . $filename);
+
+        if (strpos($file_path, $base_dir) !== 0) {
+            throw new \Exception('Invalid file path for QR code.');
+        }
+
         $result = file_put_contents($file_path, $qr_image);
-        
+
         if ($result === false) {
             throw new \Exception('Failed to save QR code image to: ' . $file_path);
         }
-        
+
         return $file_path;
     }
     

--- a/includes/PDF/Voucher_Pdf.php
+++ b/includes/PDF/Voucher_Pdf.php
@@ -55,23 +55,33 @@ class Voucher_Pdf {
         
         // Save PDF file
         $upload_dir = wp_upload_dir();
-        $voucher_dir = $upload_dir['basedir'] . '/fp-esperienze/voucher/';
-        
+        $base_dir   = trailingslashit(wp_normalize_path($upload_dir['basedir']));
+        $voucher_dir = $base_dir . 'fp-esperienze/voucher/';
+
         if (!file_exists($voucher_dir)) {
             wp_mkdir_p($voucher_dir);
             // Create .htaccess for security
             self::createSecurityHtaccess($voucher_dir);
         }
-        
-        $filename = 'voucher-' . $voucher_data['code'] . '-' . time() . '.pdf';
-        $file_path = $voucher_dir . $filename;
-        
+
+        $sanitized_code = sanitize_file_name($voucher_data['code']);
+        if ($sanitized_code === '') {
+            throw new \Exception('Invalid voucher code.');
+        }
+
+        $filename  = 'voucher-' . $sanitized_code . '-' . time() . '.pdf';
+        $file_path = wp_normalize_path($voucher_dir . $filename);
+
+        if (strpos($file_path, $base_dir) !== 0) {
+            throw new \Exception('Invalid file path for PDF voucher.');
+        }
+
         $result = file_put_contents($file_path, $dompdf->output());
-        
+
         if ($result === false) {
             throw new \Exception('Failed to save PDF voucher to: ' . $file_path);
         }
-        
+
         return $file_path;
     }
     
@@ -90,22 +100,32 @@ class Voucher_Pdf {
         
         // Save HTML file
         $upload_dir = wp_upload_dir();
-        $voucher_dir = $upload_dir['basedir'] . '/fp-esperienze/voucher/';
-        
+        $base_dir   = trailingslashit(wp_normalize_path($upload_dir['basedir']));
+        $voucher_dir = $base_dir . 'fp-esperienze/voucher/';
+
         if (!file_exists($voucher_dir)) {
             wp_mkdir_p($voucher_dir);
             self::createSecurityHtaccess($voucher_dir);
         }
-        
-        $filename = 'voucher-' . $voucher_data['code'] . '-' . time() . '.html';
-        $file_path = $voucher_dir . $filename;
-        
+
+        $sanitized_code = sanitize_file_name($voucher_data['code']);
+        if ($sanitized_code === '') {
+            throw new \Exception('Invalid voucher code.');
+        }
+
+        $filename  = 'voucher-' . $sanitized_code . '-' . time() . '.html';
+        $file_path = wp_normalize_path($voucher_dir . $filename);
+
+        if (strpos($file_path, $base_dir) !== 0) {
+            throw new \Exception('Invalid file path for HTML voucher.');
+        }
+
         $result = file_put_contents($file_path, $html);
-        
+
         if ($result === false) {
             throw new \Exception('Failed to save HTML voucher to: ' . $file_path);
         }
-        
+
         return $file_path;
     }
     


### PR DESCRIPTION
## Summary
- Sanitize voucher QR and PDF filenames with `sanitize_file_name`
- Ensure files are written within the uploads directory and handle write failures

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1ed432bc832f9d94ddaa5471461b