### PR TITLE
Validate Brevo API URLs before requests

### DIFF
--- a/includes/Integrations/BrevoManager.php
+++ b/includes/Integrations/BrevoManager.php
@@ -239,12 +239,18 @@ class BrevoManager {
             ],
             'timeout' => 30,
         ];
-        
+
         if (!empty($body)) {
             $args['body'] = wp_json_encode($body);
         }
-        
-        return wp_remote_request($url, $args);
+
+        $url = wp_http_validate_url($url);
+        if (!$url || !str_starts_with($url, 'https://api.brevo.com/')) {
+            $this->logError('Invalid Brevo API URL', ['url' => $url]);
+            return new \WP_Error('invalid_url', __('Invalid API URL', 'fp-esperienze'));
+        }
+
+        return wp_safe_remote_request($url, $args);
     }
     
     /**


### PR DESCRIPTION
## Summary
- ensure Brevo API calls use wp_safe_remote_* with URL validation
- add logging for invalid Brevo URLs

## Testing
- `composer test` *(fails: Invalid configuration: Unexpected item 'parameters › bootstrap')*


------
https://chatgpt.com/codex/tasks/task_e_68bc2802641c832f870fc2a32ebb3b6a