### PR TITLE
Add data cleanup on uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ add_filter( 'fp_trusted_proxies', function() {
 
 Only requests that originate from a trusted proxy will have their `X-Forwarded-*` headers processed. Otherwise the plugin falls back to `$_SERVER['REMOTE_ADDR']`.
 
+## Uninstall
+
+Removing the plugin via WordPress will drop all custom database tables beginning with `fp_` and delete any options or transients with the `fp_esperienze_` prefix. To preserve this data during uninstall, define the following constant in your `wp-config.php` before removing the plugin:
+
+```php
+define('FP_ESPERIENZE_PRESERVE_DATA', true);
+```
+
 ## Features
 
 - **Experience Product Type**: Custom WooCommerce product type for bookable experiences

--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -69,10 +69,51 @@ class Installer {
     }
 
     /**
-     * Plugin uninstall - remove capabilities
+     * Plugin uninstall - remove capabilities and plugin data
      */
     public static function uninstall(): void {
         CapabilityManager::removeCapabilitiesFromRoles();
+
+        if (defined('FP_ESPERIENZE_PRESERVE_DATA') && FP_ESPERIENZE_PRESERVE_DATA) {
+            return;
+        }
+
+        global $wpdb;
+
+        $tables = [
+            $wpdb->prefix . 'fp_meeting_points',
+            $wpdb->prefix . 'fp_extras',
+            $wpdb->prefix . 'fp_product_extras',
+            $wpdb->prefix . 'fp_schedules',
+            $wpdb->prefix . 'fp_overrides',
+            $wpdb->prefix . 'fp_bookings',
+            $wpdb->prefix . 'fp_exp_vouchers',
+            $wpdb->prefix . 'fp_vouchers',
+            $wpdb->prefix . 'fp_dynamic_pricing_rules',
+            $wpdb->prefix . 'fp_exp_holds',
+        ];
+
+        foreach ($tables as $table) {
+            $wpdb->query("DROP TABLE IF EXISTS $table");
+        }
+
+        $option_like = $wpdb->esc_like('fp_esperienze_') . '%';
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+                $option_like
+            )
+        );
+
+        $transient_like = $wpdb->esc_like('_transient_fp_esperienze_') . '%';
+        $timeout_like   = $wpdb->esc_like('_transient_timeout_fp_esperienze_') . '%';
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+                $transient_like,
+                $timeout_like
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Drop all plugin tables and options during uninstall, with optional constant to preserve data
- Document uninstall behavior and preservation option in README

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc29cce288832f9f696e1f5068b11c