### PR TITLE
Prefer gtag for GA4 tracking

### DIFF
--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -276,12 +276,14 @@
                 return;
             }
             
-            if (typeof window.dataLayer !== 'undefined') {
+            if (typeof window.gtag === 'function') {
+                window.gtag('event', eventName, eventData);
+            } else if (typeof window.dataLayer !== 'undefined') {
                 window.dataLayer.push({
                     event: eventName,
                     ecommerce: eventData
                 });
-                
+
                 // Debug logging removed for production
             }
         },


### PR DESCRIPTION
## Summary
- Use `gtag('event')` when GA4 gtag is available
- Fall back to `dataLayer.push` for GTM if gtag is absent

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: "WordPress" coding standard not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2a9894e0832f8427bde414302d16