### PR TITLE
Add async/defer to gtag enqueue

### DIFF
--- a/includes/Integrations/TrackingManager.php
+++ b/includes/Integrations/TrackingManager.php
@@ -128,6 +128,8 @@ class TrackingManager {
                 null,
                 true
             );
+            wp_script_add_data('google-analytics-gtag', 'async', true);
+            wp_script_add_data('google-analytics-gtag', 'defer', true);
             
             // Add inline script for GA4 initialization
             $ga4_init_script = "
@@ -151,6 +153,8 @@ class TrackingManager {
                     null,
                     true
                 );
+                wp_script_add_data('google-analytics-gtag', 'async', true);
+                wp_script_add_data('google-analytics-gtag', 'defer', true);
                 
                 $gads_init_script = "
                     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary
- ensure gtag script for Google Analytics 4 loads asynchronously and deferred
- apply same async/defer flags when loading gtag only for Google Ads

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*
- `php -l includes/Integrations/TrackingManager.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc2b6dd690832f8d3af4378885307f