### PR TITLE
Persist purchase event id for Meta CAPI

### DIFF
--- a/includes/Integrations/MetaCAPIManager.php
+++ b/includes/Integrations/MetaCAPIManager.php
@@ -84,9 +84,9 @@ class MetaCAPIManager {
             'num_items' => count($content_ids),
         ];
         
-        // Generate event ID for deduplication with frontend tracking
-        $event_id = 'purchase_' . $order_id . '_' . time();
-        
+        // Retrieve event ID for deduplication with frontend tracking
+        $event_id = $order->get_meta('_meta_event_id');
+
         // Send to Meta Conversions API
         $this->sendEvent('Purchase', $event_data, $order, $event_id);
     }

--- a/includes/Integrations/TrackingManager.php
+++ b/includes/Integrations/TrackingManager.php
@@ -353,13 +353,17 @@ class TrackingManager {
         }
         
         if (!empty($items)) {
+            $event_id = $this->generateEventId('purchase', $order_id);
+            $order->update_meta_data('_meta_event_id', $event_id);
+            $order->save();
+
             $tracking_data = [
                 'event' => 'purchase',
                 'transaction_id' => $order->get_order_number(),
                 'currency' => $order->get_currency(),
                 'value' => $total_value,
                 'items' => $items,
-                'event_id' => $this->generateEventId('purchase', $order_id),
+                'event_id' => $event_id,
             ];
             
             // Add UTM attribution data if available


### PR DESCRIPTION
## Summary
- save purchase event ID as order meta for frontend tracking
- reuse stored event ID in Meta CAPI integration for deduplication

## Testing
- `composer test` *(fails: Unexpected item 'parameters > bootstrap')*
- `php -l includes/Integrations/TrackingManager.php`
- `php -l includes/Integrations/MetaCAPIManager.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc2dab823c832fa9dbe1262c0d196b