### PR TITLE
Fix brand orange CSS variable definition

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -2,7 +2,7 @@
 
 /* CSS Custom Properties for consistent colors and accessibility */
 :root {
-    --fp-brand-orange: var(--fp-brand-orange); /* Original for backgrounds and borders */
+    --fp-brand-orange: #ff6b35; /* Brand primary orange for backgrounds and borders */
     --fp-brand-orange-text: #b24a25; /* Darker variant for text - meets AA contrast */
     --fp-text-gray: #555; /* Improved from #666 for better contrast */
     --fp-text-light-gray: #666; /* Improved from #999 for better contrast */


### PR DESCRIPTION
## Summary
- define `--fp-brand-orange` to `#ff6b35` in frontend stylesheet

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: WordPress coding standard not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1d816168832fb65d75bdaaa999ce