### PR TITLE
Ensure experience images keep 16:9 ratio

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -263,11 +263,13 @@
 .fp-experience-image {
     position: relative;
     overflow: hidden;
+    aspect-ratio: 16 / 9;
+    height: auto;
 }
 
 .fp-experience-image img {
     width: 100%;
-    height: 200px;
+    height: 100%;
     object-fit: cover;
     transition: transform 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- Maintain 16:9 aspect ratio and auto height for `.fp-experience-image`
- Let experience images fill their container without distortion

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress includes/` *(fails: multiple style violations)*
- `node test_image.js` *(fails: cannot load libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1ea05cf4832f9a0a7e3ded669340