### PR TITLE
Improve focus styles for pagination and secondary buttons

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -170,6 +170,12 @@
     text-decoration: none;
 }
 
+.fp-pagination-link:focus-visible,
+.fp-btn-secondary:focus-visible {
+    outline: 2px solid var(--fp-brand-orange);
+    outline-offset: 2px;
+}
+
 .fp-pagination-current .fp-pagination-link {
     background: var(--fp-brand-orange);
     color: white;


### PR DESCRIPTION
## Summary
- add `:focus-visible` outline to `.fp-pagination-link` and `.fp-btn-secondary`

## Testing
- `composer test` (fails: Unexpected item 'parameters › bootstrap')
- `composer phpcs` (fails: the "WordPress" coding standard is not installed)
- `python3 accessibility-test.py`
- `NODE_PATH=$(npm root -g) node - <<'NODE' ... NODE`


------
https://chatgpt.com/codex/tasks/task_e_68bd20aa5bfc832f923330341c97cb2b