### PR TITLE
Respect reduced motion preference

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1365,6 +1365,16 @@ body.admin-bar .fp-booking-widget {
     100% { transform: rotate(360deg); }
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .fp-experience-card.fp-skeleton,
+    .fp-experience-image img,
+    .fp-btn-primary,
+    .fp-btn-secondary {
+        animation: none;
+        transition: none;
+    }
+}
+
 /* Error Messages */
 .fp-error-messages {
     margin-top: 16px;


### PR DESCRIPTION
## Summary
- Add `prefers-reduced-motion` media query to disable animations and transitions for key elements

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: WordPress coding standard not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bda290532c832f8f458f673ba084f3