### PR TITLE
Validate extras JSON payload before sanitizing

### DIFF
--- a/includes/Booking/Cart_Hooks.php
+++ b/includes/Booking/Cart_Hooks.php
@@ -67,7 +67,10 @@ class Cart_Hooks {
         $qty_adult = absint(wp_unslash($_POST['fp_qty_adult'] ?? 0));
         $qty_child = absint(wp_unslash($_POST['fp_qty_child'] ?? 0));
         $extras_data = json_decode(wp_unslash($_POST['fp_extras'] ?? ''), true);
-        
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            wp_send_json_error(['message' => __('Invalid extras payload', 'fp-esperienze')]);
+        }
+
         // Get gift data from POST
         $is_gift = !empty($_POST['fp_is_gift']);
         $gift_sender_name = sanitize_text_field(wp_unslash($_POST['fp_gift_sender_name'] ?? ''));


### PR DESCRIPTION
## Summary
- Validate extras payload decoding when adding experience to cart
- Abort cart addition with error message if extras JSON is invalid

## Testing
- `composer install`
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/Booking/Cart_Hooks.php` *(fails: coding standard "WordPress" not installed)*
- `php -l includes/Booking/Cart_Hooks.php`

------
https://chatgpt.com/codex/tasks/task_e_68bdb5ccdd74832fbed31ec0a70c06ff