### PR TITLE
Store multiple push tokens per user

### DIFF
--- a/MANUAL_TESTS_PUSH_TOKEN_SANITIZATION.md
+++ b/MANUAL_TESTS_PUSH_TOKEN_SANITIZATION.md
@@ -16,6 +16,6 @@
    - `platform` set to `ios`
    - Authorization header set to `Bearer YOUR_AUTH_TOKEN`
 4. Confirm the response is `{"success": true, "message": "Push token registered successfully"}`.
-5. Verify the token is stored in user meta (`_push_notification_token`).
+5. Verify the token is stored in user meta (`_push_notification_tokens`).
 6. Repeat steps 2-5 using an Android device and `platform` set to `android`.
 7. Optionally send a token containing disallowed characters and confirm they are stripped in storage.


### PR DESCRIPTION
## Summary
- Support registering multiple push notification tokens per user
- Send push notifications to all saved tokens and prune invalid ones
- Update manual test to reference new `_push_notification_tokens` meta key

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/REST/MobileAPIManager.php` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb93cfdd8832f9f00894cc79d4491