### PR TITLE
Unslash nonce before verification

### DIFF
--- a/includes/Core/CapabilityManager.php
+++ b/includes/Core/CapabilityManager.php
@@ -150,7 +150,8 @@ class CapabilityManager {
         }
 
         // Check nonce
-        if (!isset($_POST[$nonce_name]) || !wp_verify_nonce($_POST[$nonce_name], $nonce_action)) {
+        // wp_unslash removes slashes added by WordPress before verifying the nonce.
+        if (!isset($_POST[$nonce_name]) || !wp_verify_nonce(wp_unslash($_POST[$nonce_name]), $nonce_action)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- sanitize nonce value for admin actions by unslashing before verification

## Testing
- `composer test` (fails: Unexpected item 'parameters › bootstrap')
- `vendor/bin/phpcs --standard=WordPress includes/Core/CapabilityManager.php` (fails: numerous coding standard errors)


------
https://chatgpt.com/codex/tasks/task_e_68bdbe73cf90832f95cf20249fb59535