### PR TITLE
Unsash GET parameters in archive filters

### DIFF
--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -171,7 +171,7 @@ class Shortcodes {
 
         // Language filter
         if (in_array('lang', $enabled_filters) && !empty($_GET['fp_lang'])) {
-            $language = sanitize_text_field($_GET['fp_lang']);
+            $language = sanitize_text_field(wp_unslash($_GET['fp_lang']));
             $args['meta_query'][] = [
                 'key'     => '_fp_exp_langs',
                 'value'   => $language,
@@ -181,7 +181,7 @@ class Shortcodes {
 
         // Meeting point filter
         if (in_array('mp', $enabled_filters) && !empty($_GET['fp_mp'])) {
-            $meeting_point_id = absint($_GET['fp_mp']);
+            $meeting_point_id = absint(wp_unslash($_GET['fp_mp']));
             $args['meta_query'][] = [
                 'key'     => '_fp_exp_meeting_point_id',
                 'value'   => $meeting_point_id,
@@ -191,7 +191,7 @@ class Shortcodes {
 
         // Duration filter
         if (in_array('duration', $enabled_filters) && !empty($_GET['fp_duration'])) {
-            $duration_range = sanitize_text_field($_GET['fp_duration']);
+            $duration_range = sanitize_text_field(wp_unslash($_GET['fp_duration']));
             switch ($duration_range) {
                 case '<=90':
                     $args['meta_query'][] = [
@@ -222,7 +222,7 @@ class Shortcodes {
 
         // Date availability filter
         if (in_array('date', $enabled_filters) && !empty($_GET['fp_date'])) {
-            $date = sanitize_text_field($_GET['fp_date']);
+            $date = sanitize_text_field(wp_unslash($_GET['fp_date']));
             if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
                 // Get products with availability on this date
                 $available_products = $this->getAvailableProductsForDate($date);


### PR DESCRIPTION
## Summary
- unslash `$_GET` parameters before sanitizing in archive shortcode filters

## Testing
- `composer install`
- `vendor/bin/phpstan analyse -c /tmp/phpstan-empty.neon --level=1 --memory-limit=1G includes/` *(fails: many undefined WordPress symbols)*
- `vendor/bin/phpcs --standard=WordPress includes/` *(fails: WordPress coding standard not installed)*
- `php test-filters.php`

------
https://chatgpt.com/codex/tasks/task_e_68bdc0fb4840832f8627d1714a7e7ce9