### PR TITLE
Add AutoTranslator helper

### DIFF
--- a/includes/Core/AutoTranslator.php
+++ b/includes/Core/AutoTranslator.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Auto Translator using LibreTranslate
+ *
+ * @package FP\Esperienze\Core
+ */
+
+namespace FP\Esperienze\Core;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Provides automatic translation with caching
+ */
+class AutoTranslator {
+
+    /**
+     * Translate text using LibreTranslate with caching
+     *
+     * @param string $text   Text to translate
+     * @param string $target Target language code
+     * @param string $source Source language code, defaults to 'auto'
+     *
+     * @return string Translated text or original text on failure
+     */
+    public static function translate(string $text, string $target, string $source = 'auto'): string {
+        $cache_key = 'fp_tr_' . md5($text . '|' . $target);
+        $cached    = get_transient($cache_key);
+        if (false !== $cached) {
+            return (string) $cached;
+        }
+
+        $endpoint = apply_filters('fp_es_auto_translator_endpoint', 'https://libretranslate.de/translate');
+
+        $body = [
+            'q'      => $text,
+            'source' => $source,
+            'target' => $target,
+            'format' => 'text',
+        ];
+
+        $api_key = get_option('fp_lt_api_key');
+        if (!empty($api_key)) {
+            $body['api_key'] = $api_key;
+        }
+
+        $response = wp_remote_post($endpoint, [
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body' => wp_json_encode($body),
+        ]);
+
+        if (is_wp_error($response)) {
+            return $text;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if (200 !== $code) {
+            return $text;
+        }
+
+        $data = json_decode(wp_remote_retrieve_body($response), true);
+        if (!is_array($data) || empty($data['translatedText'])) {
+            return $text;
+        }
+
+        $translated = (string) $data['translatedText'];
+        set_transient($cache_key, $translated, WEEK_IN_SECONDS);
+
+        return $translated;
+    }
+}


### PR DESCRIPTION
## Summary
- add AutoTranslator class to handle LibreTranslate requests

## Testing
- `composer test` (fails: Unexpected item 'parameters › bootstrap')
- `composer phpcs` (fails: code style violations)

------
https://chatgpt.com/codex/tasks/task_e_68bdc8c1cd98832fa70d380292a3dde0