### PR TITLE
Add automatic translation helper and localize language options

### DIFF
--- a/includes/Core/I18nManager.php
+++ b/includes/Core/I18nManager.php
@@ -80,6 +80,37 @@ class I18nManager {
     }
 
     /**
+     * Translate a string using automatic translation with caching
+     * and register it for manual review in WPML.
+     *
+     * @param string $original Original text.
+     * @param string $key      Unique string key.
+     *
+     * @return string Translated text.
+     */
+    public static function translateString(string $original, string $key): string {
+        $lang = self::getCurrentLanguage();
+
+        if (empty($lang)) {
+            return $original;
+        }
+
+        $cache_key = 'fp_i18n_' . md5($key . $lang);
+        $cached    = get_transient($cache_key);
+
+        if (false !== $cached) {
+            $translated = (string) $cached;
+        } else {
+            $translated = AutoTranslator::translate($original, $lang);
+            set_transient($cache_key, $translated, WEEK_IN_SECONDS);
+        }
+
+        do_action('wpml_register_single_string', 'fp-esperienze', $key, $original);
+
+        return $translated;
+    }
+
+    /**
      * Get available languages
      *
      * @return array

--- a/templates/admin/reports.php
+++ b/templates/admin/reports.php
@@ -58,10 +58,10 @@ defined('ABSPATH') || exit;
                         <td>
                             <select name="language" id="fp-language-filter">
                                 <option value=""><?php _e('All Languages', 'fp-esperienze'); ?></option>
-                                <option value="en">English</option>
-                                <option value="it">Italiano</option>
-                                <option value="es">Español</option>
-                                <option value="fr">Français</option>
+                                <option value="en"><?php echo esc_html( \FP\Esperienze\Core\I18nManager::translateString('English', 'language_english') ); ?></option>
+                                <option value="it"><?php echo esc_html( \FP\Esperienze\Core\I18nManager::translateString('Italiano', 'language_italian') ); ?></option>
+                                <option value="es"><?php echo esc_html( \FP\Esperienze\Core\I18nManager::translateString('Español', 'language_spanish') ); ?></option>
+                                <option value="fr"><?php echo esc_html( \FP\Esperienze\Core\I18nManager::translateString('Français', 'language_french') ); ?></option>
                             </select>
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary
- add translateString utility with caching and WPML registration
- localize report language filter options using translateString

## Testing
- `composer install --no-interaction`
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: WordPress coding standard not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc9946944832fbfdaec9b49e9d1e1