### PR TITLE
Add auto translation settings

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -21,6 +21,7 @@ use FP\Esperienze\Core\I18nManager;
 use FP\Esperienze\Core\WebhookManager;
 use FP\Esperienze\Core\Log;
 use FP\Esperienze\Admin\DependencyChecker;
+use FP\Esperienze\Admin\Settings\AutoTranslateSettings;
 
 defined('ABSPATH') || exit;
 
@@ -42,6 +43,7 @@ class MenuManager {
         new PerformanceSettings();
         new ReportsManager();
         new SEOSettings();
+        new AutoTranslateSettings();
         
         // Handle setup wizard redirect
         add_action('admin_init', [$this, 'handleSetupWizardRedirect']);
@@ -2648,12 +2650,19 @@ class MenuManager {
                 <a href="<?php echo admin_url('admin.php?page=fp-esperienze-settings&tab=notifications'); ?>" class="nav-tab <?php echo $current_tab === 'notifications' ? 'nav-tab-active' : ''; ?>"><?php _e('Notifications', 'fp-esperienze'); ?></a>
                 <a href="<?php echo admin_url('admin.php?page=fp-esperienze-settings&tab=integrations'); ?>" class="nav-tab <?php echo $current_tab === 'integrations' ? 'nav-tab-active' : ''; ?>"><?php _e('Integrations', 'fp-esperienze'); ?></a>
                 <a href="<?php echo admin_url('admin.php?page=fp-esperienze-settings&tab=webhooks'); ?>" class="nav-tab <?php echo $current_tab === 'webhooks' ? 'nav-tab-active' : ''; ?>"><?php _e('Webhooks', 'fp-esperienze'); ?></a>
+                <a href="<?php echo admin_url('admin.php?page=fp-esperienze-settings&tab=autotranslate'); ?>" class="nav-tab <?php echo $current_tab === 'autotranslate' ? 'nav-tab-active' : ''; ?>"><?php _e('Auto Translate', 'fp-esperienze'); ?></a>
             </h2>
-            
-            <form method="post" action="">
-                <?php wp_nonce_field('fp_settings_nonce', 'fp_settings_nonce'); ?>
-                <input type="hidden" name="settings_tab" value="<?php echo esc_attr($current_tab); ?>" />
-                
+
+            <form method="post" action="<?php echo $current_tab === 'autotranslate' ? 'options.php' : ''; ?>">
+                <?php
+                if ($current_tab === 'autotranslate') {
+                    settings_fields('fp_lt_settings');
+                } else {
+                    wp_nonce_field('fp_settings_nonce', 'fp_settings_nonce');
+                    echo '<input type="hidden" name="settings_tab" value="' . esc_attr($current_tab) . '" />';
+                }
+                ?>
+
                 <?php if ($current_tab === 'general') : ?>
                 <div class="tab-content">
                     <table class="form-table">
@@ -3644,6 +3653,15 @@ class MenuManager {
                     <?php submit_button(__('Save Webhook Settings', 'fp-esperienze')); ?>
                 </div>
                 
+                <?php endif; ?>
+
+                <?php if ($current_tab === 'autotranslate') : ?>
+                <div class="tab-content">
+                    <?php
+                    do_settings_sections('fp_lt_settings');
+                    submit_button(__('Save Settings', 'fp-esperienze'));
+                    ?>
+                </div>
                 <?php endif; ?>
             </form>
         </div>

--- a/includes/Admin/Settings/AutoTranslateSettings.php
+++ b/includes/Admin/Settings/AutoTranslateSettings.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Auto Translation Settings.
+ *
+ * @package FP\Esperienze\Admin\Settings
+ */
+
+namespace FP\Esperienze\Admin\Settings;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Auto translation settings page.
+ */
+class AutoTranslateSettings {
+    /** Option name for endpoint */
+    public const OPTION_ENDPOINT = 'fp_lt_endpoint';
+
+    /** Option name for API key */
+    public const OPTION_API_KEY = 'fp_lt_api_key';
+
+    /** Option name for cache TTL */
+    public const OPTION_CACHE_TTL = 'fp_lt_cache_ttl';
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action('admin_init', [$this, 'registerSettings']);
+    }
+
+    /**
+     * Register settings and fields.
+     */
+    public function registerSettings(): void {
+        register_setting(
+            'fp_lt_settings',
+            self::OPTION_ENDPOINT,
+            [
+                'type'              => 'string',
+                'default'           => 'https://libretranslate.de/translate',
+                'sanitize_callback' => 'esc_url_raw',
+            ]
+        );
+
+        register_setting(
+            'fp_lt_settings',
+            self::OPTION_API_KEY,
+            [
+                'type'              => 'string',
+                'sanitize_callback' => 'sanitize_text_field',
+            ]
+        );
+
+        register_setting(
+            'fp_lt_settings',
+            self::OPTION_CACHE_TTL,
+            [
+                'type'              => 'integer',
+                'default'           => WEEK_IN_SECONDS,
+                'sanitize_callback' => 'absint',
+            ]
+        );
+
+        add_settings_section(
+            'fp_lt_section',
+            __('Auto Translation', 'fp-esperienze'),
+            [$this, 'sectionCallback'],
+            'fp_lt_settings'
+        );
+
+        add_settings_field(
+            self::OPTION_ENDPOINT,
+            __('API Endpoint', 'fp-esperienze'),
+            [$this, 'endpointField'],
+            'fp_lt_settings',
+            'fp_lt_section'
+        );
+
+        add_settings_field(
+            self::OPTION_API_KEY,
+            __('API Key', 'fp-esperienze'),
+            [$this, 'apiKeyField'],
+            'fp_lt_settings',
+            'fp_lt_section'
+        );
+
+        add_settings_field(
+            self::OPTION_CACHE_TTL,
+            __('Cache TTL', 'fp-esperienze'),
+            [$this, 'cacheTtlField'],
+            'fp_lt_settings',
+            'fp_lt_section'
+        );
+    }
+
+    /**
+     * Section description.
+     */
+    public function sectionCallback(): void {
+        echo '<p>' . esc_html__('Configure automatic translation service.', 'fp-esperienze') . '</p>';
+    }
+
+    /**
+     * Endpoint field callback.
+     */
+    public function endpointField(): void {
+        $value = get_option(self::OPTION_ENDPOINT, 'https://libretranslate.de/translate');
+        echo '<input type="url" id="' . esc_attr(self::OPTION_ENDPOINT) . '" name="' . esc_attr(self::OPTION_ENDPOINT) . '" value="' . esc_attr($value) . '" class="regular-text" />';
+    }
+
+    /**
+     * API key field callback.
+     */
+    public function apiKeyField(): void {
+        $value = get_option(self::OPTION_API_KEY, '');
+        echo '<input type="text" id="' . esc_attr(self::OPTION_API_KEY) . '" name="' . esc_attr(self::OPTION_API_KEY) . '" value="' . esc_attr($value) . '" class="regular-text" />';
+        echo '<p class="description">' . esc_html__('Optional API key for the translation service.', 'fp-esperienze') . '</p>';
+    }
+
+    /**
+     * Cache TTL field callback.
+     */
+    public function cacheTtlField(): void {
+        $value = (int) get_option(self::OPTION_CACHE_TTL, WEEK_IN_SECONDS);
+        echo '<input type="number" id="' . esc_attr(self::OPTION_CACHE_TTL) . '" name="' . esc_attr(self::OPTION_CACHE_TTL) . '" value="' . esc_attr($value) . '" class="small-text" min="0" />';
+        echo '<p class="description">' . esc_html__('Time in seconds to cache translations.', 'fp-esperienze') . '</p>';
+    }
+}
+

--- a/includes/Core/AutoTranslator.php
+++ b/includes/Core/AutoTranslator.php
@@ -30,7 +30,8 @@ class AutoTranslator {
             return (string) $cached;
         }
 
-        $endpoint = apply_filters('fp_es_auto_translator_endpoint', 'https://libretranslate.de/translate');
+        $endpoint = get_option('fp_lt_endpoint', 'https://libretranslate.de/translate');
+        $endpoint = apply_filters('fp_es_auto_translator_endpoint', $endpoint);
 
         $body = [
             'q'      => $text,
@@ -66,7 +67,8 @@ class AutoTranslator {
         }
 
         $translated = (string) $data['translatedText'];
-        set_transient($cache_key, $translated, WEEK_IN_SECONDS);
+        $cache_ttl = (int) get_option('fp_lt_cache_ttl', WEEK_IN_SECONDS);
+        set_transient($cache_key, $translated, $cache_ttl);
 
         return $translated;
     }


### PR DESCRIPTION
## Summary
- add AutoTranslateSettings admin class to register LibreTranslate endpoint, API key, and cache TTL options
- wire AutoTranslate settings tab into plugin settings menu
- load endpoint and cache TTL from options in AutoTranslator

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/Admin/Settings/AutoTranslateSettings.php includes/Core/AutoTranslator.php includes/Admin/MenuManager.php` *(fails: the "WordPress" coding standard is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bdca79c8d8832f831a018a4bd7c453