### PR TITLE
Add Translation Help admin page

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -22,6 +22,7 @@ use FP\Esperienze\Core\WebhookManager;
 use FP\Esperienze\Core\Log;
 use FP\Esperienze\Admin\DependencyChecker;
 use FP\Esperienze\Admin\Settings\AutoTranslateSettings;
+use FP\Esperienze\Admin\Settings\TranslationHelp;
 
 defined('ABSPATH') || exit;
 
@@ -44,6 +45,7 @@ class MenuManager {
         new ReportsManager();
         new SEOSettings();
         new AutoTranslateSettings();
+        new TranslationHelp();
         
         // Handle setup wizard redirect
         add_action('admin_init', [$this, 'handleSetupWizardRedirect']);

--- a/includes/Admin/Settings/TranslationHelp.php
+++ b/includes/Admin/Settings/TranslationHelp.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Translation Help page.
+ *
+ * @package FP\Esperienze\Admin\Settings
+ */
+
+namespace FP\Esperienze\Admin\Settings;
+
+use FP\Esperienze\Core\CapabilityManager;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Displays instructions for translating the plugin.
+ */
+class TranslationHelp {
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action('admin_menu', [$this, 'registerPage']);
+    }
+
+    /**
+     * Register the submenu page.
+     */
+    public function registerPage(): void {
+        add_submenu_page(
+            'fp-esperienze',
+            __('Translation Help', 'fp-esperienze'),
+            __('Translation Help', 'fp-esperienze'),
+            CapabilityManager::MANAGE_FP_ESPERIENZE,
+            'fp-esperienze-translation-help',
+            [$this, 'renderPage']
+        );
+    }
+
+    /**
+     * Render the help page content.
+     */
+    public function renderPage(): void {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Translation Help', 'fp-esperienze'); ?></h1>
+            <ol>
+                <li>
+                    <?php
+                    echo wp_kses_post(
+                        sprintf(
+                            /* translators: %s: WPML translation modes documentation URL */
+                            __('Enable WPML and select the <strong>Translate Everything</strong> mode in <a href="%s" target="_blank">WPML → Settings</a>.', 'fp-esperienze'),
+                            'https://wpml.org/documentation/getting-started-guide/translation-modes/'
+                        )
+                    );
+                    ?>
+                </li>
+                <li>
+                    <?php esc_html_e('Register dynamic strings with I18nManager::translateString:', 'fp-esperienze'); ?>
+                    <pre><code><?php echo esc_html("\\FP\\Esperienze\\Core\\I18nManager::translateString('your-string', 'fp-esperienze');"); ?></code></pre>
+                </li>
+                <li>
+                    <?php
+                    echo wp_kses_post(
+                        sprintf(
+                            /* translators: %s: LibreTranslate URL */
+                            __('Configure the automatic translator endpoint (e.g., %1$sLibreTranslate%2$s) in the Auto Translation settings page.', 'fp-esperienze'),
+                            '<a href="https://libretranslate.com/" target="_blank">',
+                            '</a>'
+                        )
+                    );
+                    ?>
+                </li>
+            </ol>
+            <p>
+                <?php
+                echo wp_kses_post(
+                    sprintf(
+                        /* translators: %s: WPML docs URL */
+                        __('See the %1$sWPML documentation%2$s for further details.', 'fp-esperienze'),
+                        '<a href="https://wpml.org/documentation/" target="_blank">',
+                        '</a>'
+                    )
+                );
+                ?>
+            </p>
+            <p><img src="https://wpml.org/wp-content/uploads/2020/08/wpml-translate-everything.png" alt="<?php esc_attr_e('WPML Translate Everything screenshot', 'fp-esperienze'); ?>" style="max-width:100%;height:auto;" /></p>
+            <p><a href="https://www.youtube.com/watch?v=6HuLlHotE5w" target="_blank"><?php esc_html_e('Video: WPML Translate Everything overview', 'fp-esperienze'); ?></a></p>
+        </div>
+        <?php
+    }
+}


### PR DESCRIPTION
## Summary
- add Translation Help admin page with WPML guidance and automatic translation resources
- initialize Translation Help page from MenuManager

## Testing
- `php -l includes/Admin/Settings/TranslationHelp.php`
- `php -l includes/Admin/MenuManager.php`
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcbd79e30832fa0159b8042bbb6d5