### PR TITLE
Add WPML auto translation hooks and settings

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -2580,7 +2580,8 @@ class MenuManager {
         $current_tab = sanitize_text_field(wp_unslash($_GET['tab'] ?? 'general'));
         
         // Get general settings
-        $archive_page_id = get_option('fp_esperienze_archive_page_id', 0);
+        $archive_page_id    = get_option('fp_esperienze_archive_page_id', 0);
+        $wpml_auto_send     = (bool) get_option('fp_esperienze_wpml_auto_send', false);
         
         // Get current settings
         $gift_exp_months = get_option('fp_esperienze_gift_default_exp_months', 12);
@@ -2711,8 +2712,20 @@ class MenuManager {
                             </td>
                         </tr>
                         <?php endif; ?>
+
+                        <?php if (I18nManager::getActivePlugin() === 'wpml') : ?>
+                        <tr>
+                            <th scope="row">
+                                <label for="wpml_auto_send"><?php _e('Auto-send to WPML', 'fp-esperienze'); ?></label>
+                            </th>
+                            <td>
+                                <input type="checkbox" id="wpml_auto_send" name="wpml_auto_send" value="1" <?php checked($wpml_auto_send); ?> />
+                                <p class="description"><?php _e('Automatically create WPML translation jobs when saving experiences or meeting points.', 'fp-esperienze'); ?></p>
+                            </td>
+                        </tr>
+                        <?php endif; ?>
                     </table>
-                    
+
                     <?php submit_button(__('Save Settings', 'fp-esperienze')); ?>
                 </div>
                 <?php endif; ?>
@@ -3868,7 +3881,8 @@ class MenuManager {
         if ($tab === 'general') {
             // Update general settings
             update_option('fp_esperienze_archive_page_id', absint(wp_unslash($_POST['archive_page_id'] ?? 0)));
-            
+            update_option('fp_esperienze_wpml_auto_send', !empty($_POST['wpml_auto_send']));
+
         } elseif ($tab === 'branding') {
             // Update branding settings
             $branding_settings = [

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -24,6 +24,7 @@ use FP\Esperienze\Data\VoucherManager;
 use FP\Esperienze\Data\NotificationManager;
 use FP\Esperienze\Data\DynamicPricingHooks;
 use FP\Esperienze\Data\HoldManager;
+use FP\Esperienze\Data\WPMLHooks;
 use FP\Esperienze\Integrations\TrackingManager;
 use FP\Esperienze\Integrations\BrevoManager;
 use FP\Esperienze\Integrations\GooglePlacesManager;
@@ -186,12 +187,15 @@ class Plugin {
         
         // Initialize Google Places manager for meeting point reviews
         new GooglePlacesManager();
-        
+
         // Initialize enhanced email marketing manager
         new \FP\Esperienze\Integrations\EmailMarketingManager();
-        
+
         // Initialize AI features manager
         new \FP\Esperienze\AI\AIFeaturesManager();
+
+        // Initialize WPML hooks for automatic translation jobs
+        new WPMLHooks();
     }
 
     /**

--- a/includes/Data/WPMLHooks.php
+++ b/includes/Data/WPMLHooks.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WPML Hooks for automatic translation job creation.
+ *
+ * @package FP\Esperienze\Data
+ */
+
+namespace FP\Esperienze\Data;
+
+use FP\Esperienze\Core\I18nManager;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Handles sending posts to WPML on save.
+ */
+class WPMLHooks {
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action('save_post_experience', [$this, 'sendToWpml'], 10, 3);
+        add_action('save_post_meeting_point', [$this, 'sendToWpml'], 10, 3);
+    }
+
+    /**
+     * Send post to WPML translation management.
+     *
+     * @param int      $post_id Post ID.
+     * @param \WP_Post $post    Post object.
+     * @param bool     $update  Whether this is an existing post being updated.
+     */
+    public function sendToWpml(int $post_id, \WP_Post $post, bool $update): void {
+        // Check if automatic sending is enabled.
+        $enabled = (bool) get_option('fp_esperienze_wpml_auto_send', false);
+        if (!$enabled) {
+            return;
+        }
+
+        // Ignore autosaves and revisions.
+        if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        // Determine available languages.
+        $languages = I18nManager::getAvailableLanguages();
+        if (empty($languages)) {
+            return;
+        }
+
+        $source_lang = I18nManager::getPostLanguage($post_id);
+
+        foreach ($languages as $lang) {
+            if ($lang === $source_lang) {
+                continue;
+            }
+
+            do_action('wpml_tm_create_post_job', $post_id, $lang);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `WPMLHooks` to dispatch WPML translation jobs on experience/meeting point save
- wire hooks into core plugin initialization
- add admin setting to toggle automatic WPML sending

## Testing
- `composer test` *(fails: Invalid configuration: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs --standard=WordPress includes/Data/WPMLHooks.php includes/Core/Plugin.php includes/Admin/MenuManager.php` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcec76338832f8512ec5154f4bbbd