### PR TITLE
Add translation cache clearing and logging

### DIFF
--- a/includes/Core/AutoTranslator.php
+++ b/includes/Core/AutoTranslator.php
@@ -53,16 +53,19 @@ class AutoTranslator {
         ]);
 
         if (is_wp_error($response)) {
+            TranslationLogger::log('AutoTranslator request error: ' . $response->get_error_message());
             return $text;
         }
 
         $code = wp_remote_retrieve_response_code($response);
         if (200 !== $code) {
+            TranslationLogger::log('AutoTranslator HTTP status ' . $code);
             return $text;
         }
 
         $data = json_decode(wp_remote_retrieve_body($response), true);
         if (!is_array($data) || empty($data['translatedText'])) {
+            TranslationLogger::log('AutoTranslator invalid response: ' . wp_remote_retrieve_body($response));
             return $text;
         }
 

--- a/includes/Core/TranslationLogger.php
+++ b/includes/Core/TranslationLogger.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Translation Logger.
+ *
+ * @package FP\Esperienze\Core
+ */
+
+namespace FP\Esperienze\Core;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Logs translation errors to a file in uploads directory.
+ */
+class TranslationLogger {
+    /**
+     * Log a message to the translation log file.
+     *
+     * @param string $message Message to log.
+     */
+    public static function log(string $message): void {
+        if ('' === $message) {
+            return;
+        }
+
+        $uploads = wp_upload_dir();
+        if (empty($uploads['basedir'])) {
+            return;
+        }
+
+        $file = trailingslashit($uploads['basedir']) . 'fp-esperienze-translation.log';
+        $entry = sprintf('[%s] %s%s', current_time('mysql'), $message, PHP_EOL);
+
+        // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+        file_put_contents($file, $entry, FILE_APPEND | LOCK_EX);
+    }
+}


### PR DESCRIPTION
## Summary
- add “Svuota cache” field to auto translation settings to delete cached translations
- log translation errors to `wp-content/uploads/fp-esperienze-translation.log`
- record `wp_remote_post()` issues in `AutoTranslator`

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `phpcs --standard=WordPress includes/` *(fails: many coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd048492c832f9ec2920e842c442c