### PR TITLE
Add script translation handling and JS string localization

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,6 +5,8 @@
 (function($) {
     'use strict';
 
+    const { __, sprintf } = wp.i18n;
+
     if (typeof fp_esperienze_admin !== 'undefined' && typeof fp_esperienze_admin.banner_offset !== 'undefined') {
         document.documentElement.style.setProperty('--fp-banner-offset', fp_esperienze_admin.banner_offset + 'px');
     }
@@ -521,7 +523,7 @@
             
             if (hasErrors) {
                 var uniqueMessages = [...new Set(errorMessages)];
-                alert('Please fix the following errors:\n\n' + uniqueMessages.join('\n'));
+                alert(__('Please fix the following errors:', 'fp-esperienze') + '\n\n' + uniqueMessages.join('\n'));
                 return false;
             }
             
@@ -561,7 +563,7 @@
             window.addEventListener('beforeunload', function(e) {
                 if (FPEsperienzeAdmin.hasUnsavedChanges) {
                     e.preventDefault();
-                    e.returnValue = 'You have unsaved changes. Are you sure you want to leave?';
+                    e.returnValue = __('You have unsaved changes. Are you sure you want to leave?', 'fp-esperienze');
                     return e.returnValue;
                 }
             });
@@ -813,7 +815,7 @@
                     }, 300);
                 } catch (error) {
                     console.error('FP Esperienze: Error adding time slot:', error);
-                    alert('Error adding time slot. Please try again.');
+                    alert(__('Error adding time slot. Please try again.', 'fp-esperienze'));
                     $button.prop('disabled', false).removeClass('fp-loading');
                 }
             });
@@ -827,14 +829,14 @@
                 var $card = $button.closest('.fp-time-slot-card-clean');
                 
                 // Add confirmation for destructive action
-                if (confirm('Are you sure you want to remove this time slot?')) {
+                if (confirm(__('Are you sure you want to remove this time slot?', 'fp-esperienze'))) {
                     $button.prop('disabled', true).addClass('fp-loading');
                     
                     try {
                         self.removeTimeSlotCardClean($button);
                     } catch (error) {
                         console.error('FP Esperienze: Error removing time slot:', error);
-                        alert('Error removing time slot. Please try again.');
+                        alert(__('Error removing time slot. Please try again.', 'fp-esperienze'));
                         $button.prop('disabled', false).removeClass('fp-loading');
                     }
                 }
@@ -1078,7 +1080,7 @@
             
             // Confirm removal if there's a date value
             if (dateValue) {
-                if (!confirm(fp_esperienze_admin.strings.confirm_remove_override || 'Are you sure you want to remove this date override?')) {
+                if (!confirm(fp_esperienze_admin.strings.confirm_remove_override || __('Are you sure you want to remove this date override?', 'fp-esperienze'))) {
                     return;
                 }
             }
@@ -1331,7 +1333,7 @@
                 
                 // Confirm removal if there's a date value
                 if (dateValue) {
-                    if (!confirm(fp_esperienze_admin.strings.confirm_remove_override || 'Are you sure you want to remove this date override?')) {
+                    if (!confirm(fp_esperienze_admin.strings.confirm_remove_override || __('Are you sure you want to remove this date override?', 'fp-esperienze'))) {
                         return;
                     }
                 }
@@ -1576,7 +1578,7 @@
                 var container = $('#fp-time-slots-container');
                 if (!container.length) {
                     console.error('FP Esperienze: Time slots container not found');
-                    this.showUserFeedback('Error: Unable to find time slots container. Please refresh the page.', 'error');
+                    this.showUserFeedback(__('Error: Unable to find time slots container. Please refresh the page.', 'fp-esperienze'), 'error');
                     return;
                 }
                 
@@ -1592,7 +1594,7 @@
                 var cardHtml = this.createTimeSlotCardHTMLClean(index);
                 if (!cardHtml) {
                     console.error('FP Esperienze: Failed to create card HTML');
-                    this.showUserFeedback('Error creating time slot card. Please try again.', 'error');
+                    this.showUserFeedback(__('Error creating time slot card. Please try again.', 'fp-esperienze'), 'error');
                     return;
                 }
                 
@@ -1839,7 +1841,7 @@
             var container = $('#fp-overrides-container .fp-overrides-container-clean');
             if (!container.length) {
                 console.error('FP Esperienze: Override container not found');
-                alert('Error: Override container not found. Please refresh the page.');
+                alert(__('Error: Override container not found. Please refresh the page.', 'fp-esperienze'));
                 return;
             }
             
@@ -1876,7 +1878,7 @@
                 
             } catch (error) {
                 console.error('FP Esperienze: Error in addOverrideCardClean:', error);
-                alert('Error adding override. Please try again.');
+                alert(__('Error adding override. Please try again.', 'fp-esperienze'));
             }
         },
 
@@ -1900,16 +1902,16 @@
             // Validate at least one day selected
             var checkedDays = $card.find('.fp-day-pill-clean input:checked').length;
             if (checkedDays === 0) {
-                errors.push('Select at least one day of the week');
+                errors.push(__('Select at least one day of the week', 'fp-esperienze'));
                 $card.find('.fp-days-selection-clean').addClass('fp-error-field');
                 isValid = false;
             } else {
                 $card.find('.fp-days-selection-clean').removeClass('fp-error-field');
             }
-            
+
             // Show errors if any
             if (!isValid) {
-                var errorMsg = 'Please fix the following errors:\n' + errors.join('\n');
+                var errorMsg = __('Please fix the following errors:', 'fp-esperienze') + '\n' + errors.join('\n');
                 alert(errorMsg);
             }
             
@@ -2157,24 +2159,24 @@
                 // Validate time input
                 var $timeInput = $card.find('input[type="time"]');
                 if ($timeInput.length && !$timeInput.val()) {
-                    errors.push('Start time is required');
+                    errors.push(__('Start time is required', 'fp-esperienze'));
                     $timeInput.addClass('fp-error-field');
-                    this.showFieldError($timeInput, 'Please select a start time');
+                    this.showFieldError($timeInput, __('Please select a start time', 'fp-esperienze'));
                     isValid = false;
                 }
                 
                 // Validate at least one day selected
                 var checkedDays = $card.find('.fp-day-pill-clean input:checked').length;
                 if (checkedDays === 0) {
-                    errors.push('Select at least one day of the week');
+                    errors.push(__('Select at least one day of the week', 'fp-esperienze'));
                     $card.find('.fp-days-pills-clean').addClass('fp-error-field');
-                    this.showFieldError($card.find('.fp-days-pills-clean'), 'Please select at least one day');
+                    this.showFieldError($card.find('.fp-days-pills-clean'), __('Please select at least one day', 'fp-esperienze'));
                     isValid = false;
                 }
                 
                 // Show consolidated error feedback
                 if (!isValid) {
-                    this.showUserFeedback('Please fix the validation errors in the time slot configuration', 'error');
+                    this.showUserFeedback(__('Please fix the validation errors in the time slot configuration', 'fp-esperienze'), 'error');
                     $card.addClass('fp-error-shake');
                     setTimeout(function() {
                         $card.removeClass('fp-error-shake');
@@ -2361,14 +2363,14 @@
                 window.addEventListener('error', (event) => {
                     if (event.filename && event.filename.includes('admin.js')) {
                         console.error('FP Esperienze: Uncaught error:', event.error);
-                        this.handleCriticalError('Unexpected error occurred', event.error);
+                        this.handleCriticalError(__('Unexpected error occurred', 'fp-esperienze'), event.error);
                     }
                 });
                 
                 // Promise rejection handler
                 window.addEventListener('unhandledrejection', (event) => {
                     console.error('FP Esperienze: Unhandled promise rejection:', event.reason);
-                    this.handleCriticalError('Promise rejection', event.reason);
+                    this.handleCriticalError(__('Promise rejection', 'fp-esperienze'), event.reason);
                 });
                 
                 // Set up periodic health checks
@@ -2518,7 +2520,7 @@
                 } else {
                     $card.removeClass('is-closed');
                     $fields.removeClass('is-closed');
-                    this.announceToScreenReader('Date reopened for bookings');
+                    this.announceToScreenReader(__('Date reopened for bookings', 'fp-esperienze'));
                 }
                 
                 // Track the interaction
@@ -2528,7 +2530,7 @@
                 
             } catch (error) {
                 console.error('FP Esperienze: Error handling override closed:', error);
-                this.showUserFeedback('Error updating closed status. Please try again.', 'error');
+                this.showUserFeedback(__('Error updating closed status. Please try again.', 'fp-esperienze'), 'error');
             }
         },
 
@@ -2579,7 +2581,7 @@
             var self = this;
             
             // Add loading overlay functionality
-            $('body').append('<div id="fp-loading-overlay" class="fp-loading-overlay" style="display: none;"><div class="fp-spinner"></div><div class="fp-loading-text">Loading...</div></div>');
+            $('body').append('<div id="fp-loading-overlay" class="fp-loading-overlay" style="display: none;"><div class="fp-spinner"></div><div class="fp-loading-text">' + __('Loading...', 'fp-esperienze') + '</div></div>');
             
             // Enhance AJAX requests with loading states
             $(document).on('click', '.fp-async-button', function(e) {
@@ -2588,7 +2590,7 @@
                 
                 $button.prop('disabled', true)
                        .addClass('loading')
-                       .html('<span class="fp-spinner-small"></span> ' + ($button.data('loading-text') || 'Loading...'));
+                       .html('<span class="fp-spinner-small"></span> ' + ($button.data('loading-text') || __('Loading...', 'fp-esperienze')));
                 
                 // Restore button after timeout if no other action
                 setTimeout(function() {
@@ -2610,7 +2612,7 @@
                 
                 // Show loading overlay for complex forms
                 if ($form.hasClass('fp-complex-form')) {
-                    self.showLoadingOverlay($form.data('loading-message') || 'Processing...');
+                    self.showLoadingOverlay($form.data('loading-message') || __('Processing...', 'fp-esperienze'));
                 }
             });
         },

--- a/assets/js/booking-widget.js
+++ b/assets/js/booking-widget.js
@@ -6,6 +6,8 @@
 (function($) {
     'use strict';
 
+    const { __, sprintf } = wp.i18n;
+
     $(document).ready(function() {
         // Initialize booking widget functionality
         FPBookingWidget.init();
@@ -260,7 +262,7 @@
             var productId = $('#fp-product-id').val();
             
             $('#fp-loading').show();
-            $('#fp-time-slots').html('<p class="fp-slots-placeholder">' + 'Loading available times...' + '</p>');
+            $('#fp-time-slots').html('<p class="fp-slots-placeholder">' + __('Loading available times...', 'fp-esperienze') + '</p>');
             $('#fp-error-messages').empty();
             
             var restUrl = (typeof fp_esperienze_params !== 'undefined' && fp_esperienze_params.rest_url) 
@@ -297,13 +299,16 @@
             var html = '';
             
             if (!slots || slots.length === 0) {
-                html = '<p class="fp-no-slots">No availability for this date.</p>';
+                html = '<p class="fp-no-slots">' + __('No availability for this date.', 'fp-esperienze') + '</p>';
             } else {
                 slots.forEach(function(slot) {
                     var availableClass = slot.is_available ? 'available' : 'unavailable';
-                    var availableText = slot.is_available ? 
-                        slot.available + ' spots left' : 
-                        'Sold out';
+                    var availableText = slot.is_available ?
+                        slot.available + ' ' + __('spots left', 'fp-esperienze') :
+                        __('Sold out', 'fp-esperienze');
+                    var availableLabel = slot.is_available ?
+                        sprintf(__('%d spots available', 'fp-esperienze'), slot.available) :
+                        __('sold out', 'fp-esperienze');
                     var availableColorClass = slot.is_available ? 'fp-slot-available' : 'fp-slot-unavailable';
                     
                     html += '<div class="fp-time-slot ' + availableClass + '" ' +
@@ -314,9 +319,7 @@
                            'role="radio" ' +
                            'tabindex="0" ' +
                            'aria-checked="false" ' +
-                           'aria-label="Time slot ' + slot.start_time + ' to ' + slot.end_time + ', ' + 
-                           (slot.is_available ? slot.available + ' spots available' : 'sold out') + 
-                           ', price from €' + slot.adult_price + '">' +
+                           'aria-label="' + sprintf(__('Time slot %1$s to %2$s, %3$s, price from €%4$s', 'fp-esperienze'), slot.start_time, slot.end_time, availableLabel, slot.adult_price) + '">' +
                            '<div class="fp-slot-time">' + slot.start_time + ' - ' + slot.end_time + '</div>' +
                            '<div class="fp-slot-info">' +
                            '<div class="fp-slot-price">From €' + slot.adult_price + '</div>' +
@@ -339,9 +342,9 @@
             var $socialProof = $('#fp-social-proof');
             
             if (this.selectedSlot && this.selectedSlot.available <= 5 && this.selectedSlot.available > 0) {
-                var message = this.selectedSlot.available === 1 ? 
-                    'Only 1 spot left!' : 
-                    'Only ' + this.selectedSlot.available + ' spots left!';
+                var message = this.selectedSlot.available === 1 ?
+                    __('Only 1 spot left!', 'fp-esperienze') :
+                    sprintf(__('Only %d spots left!', 'fp-esperienze'), this.selectedSlot.available);
                 
                 $socialProof.find('.fp-urgency-text').text(message);
                 $socialProof.show();
@@ -519,7 +522,7 @@
                 window.FPEsperienze.addToCart();
             } else {
                 // Fallback: redirect to shop with error
-                self.showError(fp_booking_widget_i18n.error_booking_unavailable || 'Booking system temporarily unavailable. Please try again.');
+                self.showError(fp_booking_widget_i18n.error_booking_unavailable || __('Booking system temporarily unavailable. Please try again.', 'fp-esperienze'));
                 $('#fp-add-to-cart').prop('disabled', false).text('Add to Cart');
             }
         },

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -5,6 +5,8 @@
 (function($) {
     'use strict';
 
+    const { __, sprintf } = wp.i18n;
+
     if (typeof fp_esperienze_params !== 'undefined' && typeof fp_esperienze_params.banner_offset !== 'undefined') {
         document.documentElement.style.setProperty('--fp-banner-offset', fp_esperienze_params.banner_offset + 'px');
     }
@@ -91,7 +93,7 @@
                 var cartItemKey = $form.data('cart-item-key');
                 
                 if (!voucherCode) {
-                    self.showVoucherMessage($form, 'error', 'Please enter a voucher code.');
+                    self.showVoucherMessage($form, 'error', __('Please enter a voucher code.', 'fp-esperienze'));
                     return;
                 }
                 
@@ -126,7 +128,7 @@
             var $btn = $form.find('.fp-apply-voucher-btn');
             var originalText = $btn.text();
             
-            $btn.prop('disabled', true).text('Applying...');
+            $btn.prop('disabled', true).text(__('Applying...', 'fp-esperienze'));
             self.clearVoucherMessage($form);
             
             $.ajax({
@@ -156,7 +158,7 @@
                     }
                 },
                 error: function() {
-                    self.showVoucherMessage($form, 'error', 'Something went wrong. Please try again.');
+                    self.showVoucherMessage($form, 'error', __('Something went wrong. Please try again.', 'fp-esperienze'));
                 },
                 complete: function() {
                     $btn.prop('disabled', false).text(originalText);
@@ -172,7 +174,7 @@
             var $btn = $form.find('.fp-remove-voucher-btn');
             var originalText = $btn.text();
             
-            $btn.prop('disabled', true).text('Removing...');
+            $btn.prop('disabled', true).text(__('Removing...', 'fp-esperienze'));
             self.clearVoucherMessage($form);
             
             $.ajax({
@@ -197,7 +199,7 @@
                     }
                 },
                 error: function() {
-                    self.showVoucherMessage($form, 'error', 'Something went wrong. Please try again.');
+                    self.showVoucherMessage($form, 'error', __('Something went wrong. Please try again.', 'fp-esperienze'));
                 },
                 complete: function() {
                     $btn.prop('disabled', false).text(originalText);
@@ -222,7 +224,7 @@
                 $status.html(
                     '<span class="fp-voucher-applied">' +
                     '<i class="dashicons dashicons-yes-alt"></i> ' +
-                    'Voucher applied: ' + data.discount_info.description +
+                    sprintf(__('Voucher applied: %s', 'fp-esperienze'), data.discount_info.description) +
                     '</span>'
                 ).addClass('success').show();
                 
@@ -435,13 +437,13 @@
                     self.displayTimeSlots(response.slots);
                 },
                 error: function(xhr, status, error) {
-                    var errorMsg = 'Failed to load availability.';
+                    var errorMsg = __('Failed to load availability.', 'fp-esperienze');
                     if (xhr.responseJSON && xhr.responseJSON.message) {
                         errorMsg = xhr.responseJSON.message;
                     } else if (status === 'timeout') {
-                        errorMsg = 'Request timed out. Please try again.';
+                        errorMsg = __('Request timed out. Please try again.', 'fp-esperienze');
                     } else if (status === 'error') {
-                        errorMsg = 'Network error. Please check your connection.';
+                        errorMsg = __('Network error. Please check your connection.', 'fp-esperienze');
                     }
                     self.showError(errorMsg);
                     $('#fp-time-slots').html('<p class="fp-slots-placeholder">' + errorMsg + '</p>');

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -302,6 +302,12 @@ class Plugin {
             );
         }
 
+        wp_set_script_translations(
+            'fp-esperienze-frontend',
+            'fp-esperienze',
+            FP_ESPERIENZE_PLUGIN_DIR . 'languages'
+        );
+
         // Enqueue booking widget JS only on single experience pages
         if (is_singular('product')) {
             $booking_widget_url = AssetOptimizer::getMinifiedAssetUrl('js', 'booking-widget');
@@ -315,6 +321,12 @@ class Plugin {
                 ['jquery', 'fp-esperienze-frontend'],
                 FP_ESPERIENZE_VERSION,
                 true
+            );
+
+            wp_set_script_translations(
+                'fp-esperienze-booking-widget',
+                'fp-esperienze',
+                FP_ESPERIENZE_PLUGIN_DIR . 'languages'
             );
             
             // Localize booking widget with translated strings
@@ -372,6 +384,12 @@ class Plugin {
                 FP_ESPERIENZE_VERSION,
                 true
             );
+
+            wp_set_script_translations(
+                'fp-esperienze-admin-modular',
+                'fp-esperienze',
+                FP_ESPERIENZE_PLUGIN_DIR . 'languages'
+            );
             
             // Localize the modular script
             wp_localize_script('fp-esperienze-admin-modular', 'fp_esperienze_admin', [
@@ -393,6 +411,12 @@ class Plugin {
                 ['jquery'],
                 FP_ESPERIENZE_VERSION,
                 true
+            );
+
+            wp_set_script_translations(
+                'fp-esperienze-admin',
+                'fp-esperienze',
+                FP_ESPERIENZE_PLUGIN_DIR . 'languages'
             );
             
             // Localize script with admin data

--- a/languages/fp-esperienze.pot
+++ b/languages/fp-esperienze.pot
@@ -2441,3 +2441,124 @@ msgstr ""
 #: fp-esperienze.php:86
 msgid "FP Esperienze requires WooCommerce 8.0 or higher."
 msgstr ""
+
+#: assets/js/frontend.js:129
+msgid "Applying..."
+msgstr ""
+
+#: assets/js/frontend.js:159 assets/js/frontend.js:200
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#: assets/js/frontend.js:175
+msgid "Removing..."
+msgstr ""
+
+#: assets/js/frontend.js:440
+msgid "Request timed out. Please try again."
+msgstr ""
+
+#: assets/js/frontend.js:442
+msgid "Network error. Please check your connection."
+msgstr ""
+
+#: assets/js/booking-widget.js:305
+msgid "%d spots available"
+msgstr ""
+
+#: assets/js/booking-widget.js:346
+msgid "Only 1 spot left!"
+msgstr ""
+
+#: assets/js/booking-widget.js:347
+msgid "Only %d spots left!"
+msgstr ""
+
+#: assets/js/booking-widget.js:319
+#, php-format
+msgid "Time slot %1$s to %2$s, %3$s, price from €%4$s"
+msgstr ""
+
+#: assets/js/admin.js:2584 assets/js/admin.js:2593
+msgid "Loading..."
+msgstr ""
+
+#: assets/js/admin.js:2615
+msgid "Processing..."
+msgstr ""
+
+#: assets/js/admin.js:818
+msgid "Error adding time slot. Please try again."
+msgstr ""
+
+#: assets/js/admin.js:839
+msgid "Error removing time slot. Please try again."
+msgstr ""
+
+#: assets/js/admin.js:1844
+msgid "Error: Override container not found. Please refresh the page."
+msgstr ""
+
+#: assets/js/admin.js:1881
+msgid "Error adding override. Please try again."
+msgstr ""
+
+#: assets/js/admin.js:1581
+msgid "Error: Unable to find time slots container. Please refresh the page."
+msgstr ""
+
+#: assets/js/admin.js:1597
+msgid "Error creating time slot card. Please try again."
+msgstr ""
+
+#: assets/js/admin.js:2533
+msgid "Error updating closed status. Please try again."
+msgstr ""
+
+#: assets/js/admin.js:2164
+msgid "Please select a start time"
+msgstr ""
+
+#: assets/js/admin.js:2173
+msgid "Please select at least one day"
+msgstr ""
+
+#: assets/js/admin.js:2158
+msgid "Start time is required"
+msgstr ""
+
+#: assets/js/admin.js:2170 assets/js/admin.js:1904
+msgid "Select at least one day of the week"
+msgstr ""
+
+#: assets/js/admin.js:2179
+msgid "Please fix the validation errors in the time slot configuration"
+msgstr ""
+
+#: assets/js/admin.js:526 assets/js/admin.js:1914
+msgid "Please fix the following errors:"
+msgstr ""
+
+#: assets/js/admin.js:2523
+msgid "Date reopened for bookings"
+msgstr ""
+
+#: assets/js/admin.js:2366
+msgid "Unexpected error occurred"
+msgstr ""
+
+#: assets/js/admin.js:2373
+msgid "Promise rejection"
+msgstr ""
+
+#: assets/js/admin.js:566
+msgid "You have unsaved changes. Are you sure you want to leave?"
+msgstr ""
+
+#: assets/js/admin.js:832
+msgid "Are you sure you want to remove this time slot?"
+msgstr ""
+
+#: assets/js/admin.js:1083 assets/js/admin.js:1333
+msgid "Are you sure you want to remove this date override?"
+msgstr ""


### PR DESCRIPTION
## Summary
- Load translations for frontend, booking widget, and admin scripts via `wp_set_script_translations`
- Localize numerous user-facing strings in `frontend.js`, `booking-widget.js`, and `admin.js`
- Extend `fp-esperienze.pot` with new JavaScript strings

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: code style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd1615e98832f8ba35847a42d3eb0