### PR TITLE
Add translation queue cron processor

### DIFF
--- a/includes/Core/I18nManager.php
+++ b/includes/Core/I18nManager.php
@@ -88,7 +88,7 @@ class I18nManager {
      *
      * @return string Translated text.
      */
-    public static function translateString(string $original, string $key): string {
+    public static function translateString(string $original, string $key, bool $queue = true): string {
         $lang = self::getCurrentLanguage();
 
         if (empty($lang)) {
@@ -99,7 +99,9 @@ class I18nManager {
         $cached    = get_transient($cache_key);
 
         if (false === $cached) {
-            AutoTranslationQueue::addString($key, $original, $lang);
+            if ($queue) {
+                TranslationQueue::addString($key, $original, $lang);
+            }
             $translated = $original;
         } else {
             $translated = (string) $cached;

--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -8,6 +8,7 @@
 namespace FP\Esperienze\Core;
 
 use FP\Esperienze\Core\CapabilityManager;
+use FP\Esperienze\Core\TranslationQueue;
 
 defined('ABSPATH') || exit;
 
@@ -34,6 +35,11 @@ class Installer {
         
         // Update version option
         update_option('fp_esperienze_version', FP_ESPERIENZE_VERSION);
+
+        // Schedule translation queue processing
+        if (!wp_next_scheduled(TranslationQueue::CRON_HOOK)) {
+            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'hourly', TranslationQueue::CRON_HOOK);
+        }
         
         // Set activation redirect transient (only if not already complete)
         if (!get_option('fp_esperienze_setup_complete', false)) {
@@ -52,6 +58,7 @@ class Installer {
             'fp_daily_ai_analysis',
             'fp_esperienze_prebuild_availability',
             'fp_esperienze_retry_webhook',
+            'fp_es_process_translation_queue',
         ];
 
         // Clear all scheduled events for the plugin

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -35,7 +35,7 @@ use FP\Esperienze\Core\I18nManager;
 use FP\Esperienze\Core\CacheManager;
 use FP\Esperienze\Core\AssetOptimizer;
 use FP\Esperienze\Core\QueryMonitor;
-use FP\Esperienze\Core\AutoTranslationQueue;
+use FP\Esperienze\Core\TranslationQueue;
 
 defined('ABSPATH') || exit;
 
@@ -77,8 +77,8 @@ class Plugin {
         // Initialize the Experience product type EARLY to ensure it's registered before WooCommerce loads product types
         add_action('init', [$this, 'initExperienceProductType'], 5);
 
-        // Initialize auto translation queue
-        AutoTranslationQueue::init();
+        // Initialize translation queue
+        TranslationQueue::init();
         
         // Initialize other components later
         add_action('init', [$this, 'initComponents'], 20);

--- a/includes/Core/TranslationQueue.php
+++ b/includes/Core/TranslationQueue.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Translation Queue
+ *
+ * Manages queued translation jobs for strings and posts.
+ *
+ * @package FP\Esperienze\Core
+ */
+
+namespace FP\Esperienze\Core;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Handles queueing of translation jobs and cron processing.
+ */
+class TranslationQueue {
+    /**
+     * Custom post type used to store queued jobs.
+     */
+    private const POST_TYPE = 'fp_es_translation_job';
+
+    /**
+     * Meta keys for job data.
+     */
+    private const META_TYPE    = '_fp_es_job_type';
+    private const META_KEY     = '_fp_es_string_key';
+    private const META_TEXT    = '_fp_es_string_text';
+    private const META_POST_ID = '_fp_es_post_id';
+    private const META_LANG    = '_fp_es_lang';
+
+    /**
+     * Cron hook name.
+     */
+    public const CRON_HOOK = 'fp_es_process_translation_queue';
+
+    /**
+     * Initialize hooks.
+     */
+    public static function init(): void {
+        add_action('init', [self::class, 'registerPostType']);
+        add_action(self::CRON_HOOK, [self::class, 'processQueue']);
+        add_action('save_post', [self::class, 'queuePost'], 10, 2);
+    }
+
+    /**
+     * Register internal post type for queued jobs.
+     */
+    public static function registerPostType(): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        register_post_type(
+            self::POST_TYPE,
+            [
+                'public'              => false,
+                'show_ui'             => false,
+                'rewrite'             => false,
+                'supports'            => ['custom-fields'],
+                'label'               => 'FP Translation Job',
+                'capability_type'     => 'post',
+            ]
+        );
+    }
+
+    /**
+     * Queue a string for translation.
+     *
+     * @param string $key   Unique string key.
+     * @param string $text  Text to translate.
+     * @param string $lang  Target language.
+     */
+    public static function addString(string $key, string $text, string $lang): void {
+        wp_insert_post(
+            [
+                'post_type'   => self::POST_TYPE,
+                'post_status' => 'draft',
+                'post_title'  => 'String: ' . $key,
+                'meta_input'  => [
+                    self::META_TYPE => 'string',
+                    self::META_KEY  => $key,
+                    self::META_TEXT => $text,
+                    self::META_LANG => $lang,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Queue a post for translation.
+     *
+     * @param int $post_id Post ID.
+     */
+    public static function addPost(int $post_id): void {
+        wp_insert_post(
+            [
+                'post_type'   => self::POST_TYPE,
+                'post_status' => 'draft',
+                'post_title'  => 'Post: ' . $post_id,
+                'meta_input'  => [
+                    self::META_TYPE    => 'post',
+                    self::META_POST_ID => $post_id,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Handle post save action to queue for translation.
+     *
+     * @param int      $post_id Post ID.
+     * @param \WP_Post $post    Post object.
+     */
+    public static function queuePost(int $post_id, $post): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        if ($post->post_status === 'auto-draft' || $post->post_type === 'revision') {
+            return;
+        }
+
+        self::addPost($post_id);
+    }
+
+    /**
+     * Process queued translation jobs.
+     */
+    public static function processQueue(): void {
+        $jobs = get_posts(
+            [
+                'post_type'      => self::POST_TYPE,
+                'post_status'    => 'draft',
+                'posts_per_page' => 5,
+                'fields'         => 'ids',
+            ]
+        );
+
+        if (empty($jobs)) {
+            return;
+        }
+
+        foreach ($jobs as $job_id) {
+            $type = get_post_meta($job_id, self::META_TYPE, true);
+
+            if ($type === 'string') {
+                self::processStringJob($job_id);
+            } elseif ($type === 'post') {
+                self::processPostJob($job_id);
+            }
+
+            // Remove job from queue.
+            wp_delete_post($job_id, true);
+        }
+    }
+
+    /**
+     * Process a queued string translation job.
+     *
+     * @param int $job_id Job post ID.
+     */
+    private static function processStringJob(int $job_id): void {
+        $key  = get_post_meta($job_id, self::META_KEY, true);
+        $text = get_post_meta($job_id, self::META_TEXT, true);
+
+        if ($key === '' || $text === '') {
+            return;
+        }
+
+        // Call I18nManager to handle translation/registration.
+        I18nManager::translateString($text, $key, false);
+    }
+
+    /**
+     * Process a queued post translation job.
+     *
+     * @param int $job_id Job post ID.
+     */
+    private static function processPostJob(int $job_id): void {
+        $post_id = (int) get_post_meta($job_id, self::META_POST_ID, true);
+        if ($post_id <= 0) {
+            return;
+        }
+
+        $languages = I18nManager::getAvailableLanguages();
+        foreach ($languages as $lang) {
+            if (function_exists('wpml_tm_create_post_job')) {
+                wpml_tm_create_post_job($post_id, $lang);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add TranslationQueue using custom post meta posts for deferred translations
- schedule fp_es_process_translation_queue on activation and clear on deactivate
- wire I18nManager and plugin bootstrap to use the new queue

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8f2ee28832fa7fe9a651e26e2a9