### PR TITLE
Add translation logging and settings

### DIFF
--- a/includes/Admin/Settings/AutoTranslateSettings.php
+++ b/includes/Admin/Settings/AutoTranslateSettings.php
@@ -22,6 +22,9 @@ class AutoTranslateSettings {
     /** Option name for cache TTL */
     public const OPTION_CACHE_TTL = 'fp_lt_cache_ttl';
 
+    /** Option name for translation logging */
+    public const OPTION_ENABLE_LOG = 'fp_lt_enable_log';
+
     /**
      * Constructor.
      */
@@ -70,6 +73,16 @@ class AutoTranslateSettings {
             ]
         );
 
+        register_setting(
+            'fp_lt_settings',
+            self::OPTION_ENABLE_LOG,
+            [
+                'type'              => 'integer',
+                'default'           => 0,
+                'sanitize_callback' => 'absint',
+            ]
+        );
+
         add_settings_section(
             'fp_lt_section',
             __('Auto Translation', 'fp-esperienze'),
@@ -97,6 +110,14 @@ class AutoTranslateSettings {
             self::OPTION_CACHE_TTL,
             __('Cache TTL', 'fp-esperienze'),
             [$this, 'cacheTtlField'],
+            'fp_lt_settings',
+            'fp_lt_section'
+        );
+
+        add_settings_field(
+            self::OPTION_ENABLE_LOG,
+            __('Enable logging', 'fp-esperienze'),
+            [$this, 'enableLogField'],
             'fp_lt_settings',
             'fp_lt_section'
         );
@@ -141,6 +162,14 @@ class AutoTranslateSettings {
         $value = (int) get_option(self::OPTION_CACHE_TTL, WEEK_IN_SECONDS);
         echo '<input type="number" id="' . esc_attr(self::OPTION_CACHE_TTL) . '" name="' . esc_attr(self::OPTION_CACHE_TTL) . '" value="' . esc_attr($value) . '" class="small-text" min="0" />';
         echo '<p class="description">' . esc_html__('Time in seconds to cache translations.', 'fp-esperienze') . '</p>';
+    }
+
+    /**
+     * Enable logging field callback.
+     */
+    public function enableLogField(): void {
+        $value = (int) get_option(self::OPTION_ENABLE_LOG, 0);
+        echo '<label><input type="checkbox" id="' . esc_attr(self::OPTION_ENABLE_LOG) . '" name="' . esc_attr(self::OPTION_ENABLE_LOG) . '" value="1" ' . checked(1, $value, false) . ' /> ' . esc_html__('Enable translation logging', 'fp-esperienze') . '</label>';
     }
 
     /**

--- a/includes/Core/I18nManager.php
+++ b/includes/Core/I18nManager.php
@@ -101,8 +101,16 @@ class I18nManager {
         if (false === $cached) {
             if ($queue) {
                 TranslationQueue::addString($key, $original, $lang);
+                $translated = $original;
+            } else {
+                $translated = AutoTranslator::translate($original, $lang);
+                $ttl        = (int) get_option('fp_lt_cache_ttl', WEEK_IN_SECONDS);
+                set_transient($cache_key, $translated, $ttl);
+
+                if ($translated === $original) {
+                    TranslationLogger::log('I18nManager translation unchanged for key ' . $key);
+                }
             }
-            $translated = $original;
         } else {
             $translated = (string) $cached;
         }

--- a/includes/Core/TranslationLogger.php
+++ b/includes/Core/TranslationLogger.php
@@ -23,6 +23,10 @@ class TranslationLogger {
             return;
         }
 
+        if (!get_option('fp_lt_enable_log')) {
+            return;
+        }
+
         $uploads = wp_upload_dir();
         if (empty($uploads['basedir'])) {
             return;

--- a/includes/Core/TranslationQueue.php
+++ b/includes/Core/TranslationQueue.php
@@ -161,7 +161,10 @@ class TranslationQueue {
         }
 
         // Call I18nManager to handle translation/registration.
-        I18nManager::translateString($text, $key, false);
+        $translated = I18nManager::translateString($text, $key, false);
+        if ($translated === $text) {
+            TranslationLogger::log('TranslationQueue string job untranslated for key ' . $key);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Gate translation logger by option and create setting to enable logging
- Log translation issues in I18nManager and TranslationQueue
- Cache translations after automatic translation and allow enabling logs via admin settings

## Testing
- `composer test` *(fails: Unexpected item 'parameters › bootstrap')*
- `vendor/bin/phpcs includes/Core/TranslationLogger.php includes/Core/I18nManager.php includes/Core/TranslationQueue.php includes/Admin/Settings/AutoTranslateSettings.php` *(fails: Referenced sniff "WordPress" does not exist)*
- `php -l includes/Core/TranslationLogger.php includes/Core/I18nManager.php includes/Core/TranslationQueue.php includes/Admin/Settings/AutoTranslateSettings.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdda451d6c832f8c58558d00ac17ee