### PR TITLE
Add JS translation support and regenerate POT file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules/
 vendor/
 
+# Translation binaries
+languages/*.mo
+
 # Build artifacts
 /build/
 /dist/

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -221,38 +221,38 @@
                         };
                     },
                     failure: function() {
-                        alert('There was an error while fetching events!');
+                        alert(__('There was an error while fetching events!', 'fp-esperienze'));
                     }
                 },
                 eventClick: function(info) {
                     var booking = info.event.extendedProps;
                     var content = '<div class="fp-booking-popup">' +
                         '<h3>' + info.event.title + '</h3>' +
-                        '<p><strong>Order:</strong> #' + booking.order_id + '</p>' +
-                        '<p><strong>Customer:</strong> ' + booking.customer_name + '</p>' +
-                        '<p><strong>Status:</strong> ' + booking.status + '</p>' +
-                        '<p><strong>Participants:</strong> ' + booking.adults + ' adults, ' + booking.children + ' children</p>' +
-                        '<p><strong>Date:</strong> ' + info.event.start.toLocaleDateString() + '</p>' +
-                        '<p><strong>Time:</strong> ' + info.event.start.toLocaleTimeString() + '</p>' +
+                        '<p><strong>' + __('Order', 'fp-esperienze') + ':</strong> #' + booking.order_id + '</p>' +
+                        '<p><strong>' + __('Customer', 'fp-esperienze') + ':</strong> ' + booking.customer_name + '</p>' +
+                        '<p><strong>' + __('Status', 'fp-esperienze') + ':</strong> ' + booking.status + '</p>' +
+                        '<p><strong>' + __('Participants', 'fp-esperienze') + ':</strong> ' + booking.adults + ' ' + __('adults', 'fp-esperienze') + ', ' + booking.children + ' ' + __('children', 'fp-esperienze') + '</p>' +
+                        '<p><strong>' + __('Date', 'fp-esperienze') + ':</strong> ' + info.event.start.toLocaleDateString() + '</p>' +
+                        '<p><strong>' + __('Time', 'fp-esperienze') + ':</strong> ' + info.event.start.toLocaleTimeString() + '</p>' +
                         '</div>';
                     
                     // Show popup (using WordPress admin modal or simple alert)
                     if (typeof tb_show !== 'undefined') {
                         $('body').append('<div id="fp-booking-details" style="display:none">' + content + '</div>');
-                        tb_show('Booking Details', '#TB_inline?inlineId=fp-booking-details&width=400&height=300');
+                        tb_show(__('Booking Details', 'fp-esperienze'), '#TB_inline?inlineId=fp-booking-details&width=400&height=300');
                     } else {
-                        alert(info.event.title + '\n' + 
-                              'Order: #' + booking.order_id + '\n' +
-                              'Status: ' + booking.status + '\n' +
-                              'Participants: ' + (booking.adults + booking.children));
+                        alert(info.event.title + '\n' +
+                              __('Order', 'fp-esperienze') + ': #' + booking.order_id + '\n' +
+                              __('Status', 'fp-esperienze') + ': ' + booking.status + '\n' +
+                              __('Participants', 'fp-esperienze') + ': ' + (booking.adults + booking.children));
                     }
                 },
                 eventDidMount: function(info) {
                     // Add tooltip
-                    info.el.setAttribute('title', 
+                    info.el.setAttribute('title',
                         info.event.title + '\n' +
-                        'Order: #' + info.event.extendedProps.order_id + '\n' +
-                        'Status: ' + info.event.extendedProps.status
+                        __('Order', 'fp-esperienze') + ': #' + info.event.extendedProps.order_id + '\n' +
+                        __('Status', 'fp-esperienze') + ': ' + info.event.extendedProps.status
                     );
                 }
             });
@@ -630,15 +630,17 @@
             // Build new summary HTML
             var summaryHtml;
             if (slots.length === 0) {
-                summaryHtml = '<div class="fp-summary-table"><div class="fp-empty-state">No time slots configured yet. Click "Add Time Slot" below to get started.</div></div>';
+                summaryHtml = '<div class="fp-summary-table"><div class="fp-empty-state">' +
+                    sprintf(__('No time slots configured yet. Click "%s" below to get started.', 'fp-esperienze'), __('Add Time Slot', 'fp-esperienze')) +
+                    '</div></div>';
             } else {
                 summaryHtml = '<table class="fp-summary-table">' +
                     '<thead><tr>' +
-                        '<th>Time</th>' +
-                        '<th>Days</th>' +
-                        '<th>Duration</th>' +
-                        '<th>Capacity</th>' +
-                        '<th>Customized</th>' +
+                        '<th>' + __('Time', 'fp-esperienze') + '</th>' +
+                        '<th>' + __('Days', 'fp-esperienze') + '</th>' +
+                        '<th>' + __('Duration', 'fp-esperienze') + '</th>' +
+                        '<th>' + __('Capacity', 'fp-esperienze') + '</th>' +
+                        '<th>' + __('Customized', 'fp-esperienze') + '</th>' +
                     '</tr></thead><tbody>';
                 
                 slots.forEach(function(slot) {
@@ -656,9 +658,9 @@
                     });
                     
                     summaryHtml += '</div></td>' +
-                        '<td>' + (slot.duration ? slot.duration + ' min' : '<em>Default</em>') + '</td>' +
-                        '<td>' + (slot.capacity ? slot.capacity : '<em>Default</em>') + '</td>' +
-                        '<td>' + (slot.customCount > 0 ? slot.customCount + ' setting' + (slot.customCount > 1 ? 's' : '') : '<em>None</em>') + '</td>' +
+                        '<td>' + (slot.duration ? slot.duration + ' ' + __('min', 'fp-esperienze') : '<em>' + __('Default', 'fp-esperienze') + '</em>') + '</td>' +
+                        '<td>' + (slot.capacity ? slot.capacity : '<em>' + __('Default', 'fp-esperienze') + '</em>') + '</td>' +
+                        '<td>' + (slot.customCount > 0 ? slot.customCount + ' ' + (slot.customCount === 1 ? __('setting', 'fp-esperienze') : __('settings', 'fp-esperienze')) : '<em>' + __('None', 'fp-esperienze') + '</em>') + '</td>' +
                         '</tr>';
                 });
                 
@@ -1785,7 +1787,7 @@
                 // Show empty state if no cards left
                 if (container.find('.fp-time-slot-card-clean').length === 0) {
                     var emptyMessage = '<div class="fp-empty-slots-message" style="opacity: 0;">' +
-                        '<p>No time slots configured yet. Add your first time slot below.</p>' +
+                        '<p>' + __('No time slots configured yet. Add your first time slot below.', 'fp-esperienze') + '</p>' +
                     '</div>';
                     var $emptyMsg = $(emptyMessage);
                     container.prepend($emptyMsg);
@@ -1795,9 +1797,9 @@
                     var button = $('#fp-add-time-slot');
                     var $buttonText = button.find('span:not(.dashicons)');
                     if ($buttonText.length) {
-                        $buttonText.text('Add Time Slot');
+                        $buttonText.text(__('Add Time Slot', 'fp-esperienze'));
                     } else {
-                        button.text('Add Time Slot');
+                        button.text(__('Add Time Slot', 'fp-esperienze'));
                     }
                 } else {
                     // Update button text if cards remain
@@ -1966,7 +1968,7 @@
                     // Announce state change
                     var dayName = $(this).text().trim();
                     var isChecked = $(this).closest('.fp-day-pill-clean').find('input').is(':checked');
-                    this.announceToScreenReader(dayName + ' ' + (isChecked ? 'selected' : 'deselected'));
+                    this.announceToScreenReader(dayName + ' ' + (isChecked ? __('selected', 'fp-esperienze') : __('deselected', 'fp-esperienze')));
                 }
             });
             
@@ -2090,13 +2092,10 @@
                 var button = $('#fp-add-time-slot');
                 
                 if (count > 0) {
-                    var currentText = button.find('span:not(.dashicons)').text() || button.text();
-                    if (currentText.indexOf('Another') === -1) {
-                        button.find('span:not(.dashicons)').text('Add Another Time Slot');
-                    }
+                    button.find('span:not(.dashicons)').text(__('Add Another Time Slot', 'fp-esperienze'));
                     button.attr('aria-expanded', 'true');
                 } else {
-                    button.find('span:not(.dashicons)').text('Add Time Slot');
+                    button.find('span:not(.dashicons)').text(__('Add Time Slot', 'fp-esperienze'));
                     button.attr('aria-expanded', 'false');
                 }
                 
@@ -2105,7 +2104,8 @@
                 
                 // Announce change to screen readers
                 if (count > 0) {
-                    this.announceToScreenReader(count + ' time slot' + (count === 1 ? '' : 's') + ' configured');
+                    var slotMsg = count === 1 ? __('1 time slot configured', 'fp-esperienze') : sprintf(__('%d time slots configured', 'fp-esperienze'), count);
+                    this.announceToScreenReader(slotMsg);
                 }
             } catch (error) {
                 console.warn('FP Esperienze: Error updating slot count feedback:', error);
@@ -2122,13 +2122,10 @@
                 var button = $('#fp-add-override');
                 
                 if (count > 0) {
-                    var currentText = button.find('span:not(.dashicons)').text() || button.text();
-                    if (currentText.indexOf('Another') === -1) {
-                        button.find('span:not(.dashicons)').text('Add Another Date Override');
-                    }
+                    button.find('span:not(.dashicons)').text(__('Add Another Date Override', 'fp-esperienze'));
                     button.attr('aria-expanded', 'true');
                 } else {
-                    button.find('span:not(.dashicons)').text('Add Date Override');
+                    button.find('span:not(.dashicons)').text(__('Add Date Override', 'fp-esperienze'));
                     button.attr('aria-expanded', 'false');
                 }
                 
@@ -2137,7 +2134,8 @@
                 
                 // Announce change to screen readers
                 if (count > 0) {
-                    this.announceToScreenReader(count + ' date override' + (count === 1 ? '' : 's') + ' configured');
+                    var overrideMsg = count === 1 ? __('1 date override configured', 'fp-esperienze') : sprintf(__('%d date overrides configured', 'fp-esperienze'), count);
+                    this.announceToScreenReader(overrideMsg);
                 }
             } catch (error) {
                 console.warn('FP Esperienze: Error updating override count feedback:', error);
@@ -2282,13 +2280,13 @@
                 // Show empty state if no cards left
                 if (container.find('.fp-override-card-clean').length === 0) {
                     var emptyMessage = '<div class="fp-overrides-empty-clean">' +
-                        '<p>No date overrides configured. Add exceptions below for specific dates when you need to close, change capacity, or modify pricing.</p>' +
+                        '<p>' + __('No date overrides configured. Add exceptions below for specific dates when you need to close, change capacity, or modify pricing.', 'fp-esperienze') + '</p>' +
                     '</div>';
                     container.prepend(emptyMessage);
-                    
+
                     // Reset button text
                     var button = $('#fp-add-override');
-                    button.find('span:not(.dashicons)').text('Add Date Override');
+                    button.find('span:not(.dashicons)').text(__('Add Date Override', 'fp-esperienze'));
                 } else {
                     // Update button text if only one left
                     self.updateOverrideCountFeedback();
@@ -2413,7 +2411,7 @@
             } catch (recoveryError) {
                 console.error('FP Esperienze: Error recovery failed:', recoveryError);
                 // Fallback: show basic alert
-                alert('A critical error occurred. Please refresh the page.');
+                alert(__('A critical error occurred. Please refresh the page.', 'fp-esperienze'));
             }
         },
 
@@ -2516,7 +2514,7 @@
                 if (isChecked) {
                     $card.addClass('is-closed');
                     $fields.addClass('is-closed');
-                    this.announceToScreenReader('Date marked as closed');
+                    this.announceToScreenReader(__('Date marked as closed', 'fp-esperienze'));
                 } else {
                     $card.removeClass('is-closed');
                     $fields.removeClass('is-closed');

--- a/assets/js/booking-widget.js
+++ b/assets/js/booking-widget.js
@@ -1,3 +1,4 @@
+
 /**
  * FP Esperienze Booking Widget
  * GetYourGuide-style functionality
@@ -322,7 +323,7 @@
                            'aria-label="' + sprintf(__('Time slot %1$s to %2$s, %3$s, price from €%4$s', 'fp-esperienze'), slot.start_time, slot.end_time, availableLabel, slot.adult_price) + '">' +
                            '<div class="fp-slot-time">' + slot.start_time + ' - ' + slot.end_time + '</div>' +
                            '<div class="fp-slot-info">' +
-                           '<div class="fp-slot-price">From €' + slot.adult_price + '</div>' +
+                           '<div class="fp-slot-price">' + sprintf(__('From €%s', 'fp-esperienze'), slot.adult_price) + '</div>' +
                            '<div class="' + availableColorClass + '">' + availableText + '</div>' +
                            '</div>' +
                            '</div>';
@@ -383,10 +384,12 @@
             
             var detailsHtml = '';
             if (adultQty > 0) {
-                detailsHtml += '<div>' + adultQty + ' Adult' + (adultQty > 1 ? 's' : '') + ': €' + adultTotal.toFixed(2) + '</div>';
+                var adultLabel = adultQty === 1 ? __('Adult', 'fp-esperienze') : __('Adults', 'fp-esperienze');
+                detailsHtml += '<div>' + adultQty + ' ' + adultLabel + ': €' + adultTotal.toFixed(2) + '</div>';
             }
             if (childQty > 0) {
-                detailsHtml += '<div>' + childQty + ' Child' + (childQty > 1 ? 'ren' : '') + ': €' + childTotal.toFixed(2) + '</div>';
+                var childLabel = childQty === 1 ? __('Child', 'fp-esperienze') : __('Children', 'fp-esperienze');
+                detailsHtml += '<div>' + childQty + ' ' + childLabel + ': €' + childTotal.toFixed(2) + '</div>';
             }
             
             // Calculate extras
@@ -403,7 +406,7 @@
                     var extraItemTotal = 0;
                     if (billingType === 'per_person') {
                         extraItemTotal = extraPrice * extraQty * totalParticipants;
-                        detailsHtml += '<div>' + extraName + ' (' + extraQty + ' × ' + totalParticipants + ' people): €' + extraItemTotal.toFixed(2) + '</div>';
+                        detailsHtml += '<div>' + extraName + ' (' + extraQty + ' × ' + totalParticipants + ' ' + __('people', 'fp-esperienze') + '): €' + extraItemTotal.toFixed(2) + '</div>';
                     } else {
                         extraItemTotal = extraPrice * extraQty;
                         detailsHtml += '<div>' + extraName + ' (' + extraQty + '): €' + extraItemTotal.toFixed(2) + '</div>';
@@ -476,15 +479,15 @@
             
             // Update button text and help text
             if (isValid) {
-                $('#fp-cart-help').text('Ready to book this experience');
+                $('#fp-cart-help').text(__('Ready to book this experience', 'fp-esperienze'));
             } else if (!this.selectedDate) {
-                $('#fp-cart-help').text('Select a date to continue');
+                $('#fp-cart-help').text(__('Select a date to continue', 'fp-esperienze'));
             } else if (!this.selectedSlot) {
-                $('#fp-cart-help').text('Select a time slot to continue');
+                $('#fp-cart-help').text(__('Select a time slot to continue', 'fp-esperienze'));
             } else if (adultQty === 0 && childQty === 0) {
-                $('#fp-cart-help').text('Select at least one participant');
+                $('#fp-cart-help').text(__('Select at least one participant', 'fp-esperienze'));
             } else {
-                $('#fp-cart-help').text('Complete all required fields');
+                $('#fp-cart-help').text(__('Complete all required fields', 'fp-esperienze'));
             }
         },
 
@@ -500,7 +503,7 @@
             var childQty = parseInt($('#fp-qty-child').val()) || 0;
             var meetingPointId = $('#fp-meeting-point-id').val() || 1;
             
-            $('#fp-add-to-cart').prop('disabled', true).text('Adding...');
+            $('#fp-add-to-cart').prop('disabled', true).text(__('Adding...', 'fp-esperienze'));
             
             // Collect extras data
             var extras = {};
@@ -523,7 +526,7 @@
             } else {
                 // Fallback: redirect to shop with error
                 self.showError(fp_booking_widget_i18n.error_booking_unavailable || __('Booking system temporarily unavailable. Please try again.', 'fp-esperienze'));
-                $('#fp-add-to-cart').prop('disabled', false).text('Add to Cart');
+                $('#fp-add-to-cart').prop('disabled', false).text(__('Add to Cart', 'fp-esperienze'));
             }
         },
 

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -605,7 +605,7 @@
             var childQty = parseInt($('#fp-qty-child').val()) || 0;
             var meetingPointId = $('#fp-meeting-point-id').val() || 1;
             
-            $('#fp-add-to-cart').prop('disabled', true).text('Adding...');
+            $('#fp-add-to-cart').prop('disabled', true).text(__('Adding...', 'fp-esperienze'));
             
             // Collect extras data
             var extras = {};
@@ -655,12 +655,12 @@
                         : '/cart';
                     window.location.href = cartUrl;
                 } else {
-                    throw new Error('Failed to add to cart');
+                    throw new Error(__('Failed to add to cart', 'fp-esperienze'));
                 }
             })
             .catch(function(error) {
-                self.showError('Failed to add to cart. Please try again.');
-                $('#fp-add-to-cart').prop('disabled', false).text('Add to Cart');
+                self.showError(__('Failed to add to cart. Please try again.', 'fp-esperienze'));
+                $('#fp-add-to-cart').prop('disabled', false).text(__('Add to Cart', 'fp-esperienze'));
             });
         },
 

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -344,17 +344,20 @@ class Plugin {
             ]);
         }
 
-        // Localize script with WooCommerce data
+        // Localize frontend script with dynamic data
+        $frontend_params = [
+            'ajax_url' => admin_url('admin-ajax.php'),
+            'rest_url' => get_rest_url(),
+            'nonce' => wp_create_nonce('fp_esperienze_nonce'),
+            'voucher_nonce' => wp_create_nonce('fp_voucher_nonce'),
+            'banner_offset' => apply_filters('fp_esperienze_banner_offset', 20),
+        ];
+
         if (function_exists('wc_get_cart_url')) {
-            wp_localize_script('fp-esperienze-frontend', 'fp_esperienze_params', [
-                'cart_url' => wc_get_cart_url(),
-                'ajax_url' => admin_url('admin-ajax.php'),
-                'rest_url' => get_rest_url(),
-                'nonce' => wp_create_nonce('fp_esperienze_nonce'),
-                'voucher_nonce' => wp_create_nonce('fp_voucher_nonce'),
-                'banner_offset' => apply_filters('fp_esperienze_banner_offset', 20),
-            ]);
+            $frontend_params['cart_url'] = wc_get_cart_url();
         }
+
+        wp_localize_script('fp-esperienze-frontend', 'fp_esperienze_params', $frontend_params);
     }
 
     /**

--- a/languages/fp-esperienze-en_US.po
+++ b/languages/fp-esperienze-en_US.po
@@ -4,3669 +4,3704 @@ msgid ""
 msgstr ""
 "Project-Id-Version: FP Esperienze 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fp-esperienze\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "POT-Creation-Date: 2025-09-07T19:30:25+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2025-09-07T19:30:25+00:00\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fp-esperienze\n"
+"Language: en_US\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Plugin Name of the plugin
-#: fp-esperienze.php
-#: includes/Admin/MenuManager.php:69
+#: fp-esperienze.php includes/Admin/MenuManager.php:69
 #: includes/Admin/MenuManager.php:70
 msgid "FP Esperienze"
-msgstr ""
+msgstr "FP Esperienze"
 
 #. Plugin URI of the plugin
 #: fp-esperienze.php
 msgid "https://github.com/franpass87/FP-Esperienze"
-msgstr ""
+msgstr "https://github.com/franpass87/FP-Esperienze"
 
 #. Description of the plugin
 #: fp-esperienze.php
 msgid "Experience booking management plugin for WordPress and WooCommerce"
-msgstr ""
+msgstr "Experience booking management plugin for WordPress and WooCommerce"
 
 #. Author of the plugin
 #: fp-esperienze.php
 msgid "Francesco Passeri"
-msgstr ""
+msgstr "Francesco Passeri"
 
 #. Author URI of the plugin
 #: fp-esperienze.php
 msgid "https://francescopasseri.com"
-msgstr ""
+msgstr "https://francescopasseri.com"
 
 #: fp-esperienze.php:41
 msgid "FP Esperienze requires WordPress 6.5 or higher."
-msgstr ""
+msgstr "FP Esperienze requires WordPress 6.5 or higher."
 
 #: fp-esperienze.php:51
 msgid "FP Esperienze requires PHP 8.1 or higher."
-msgstr ""
+msgstr "FP Esperienze requires PHP 8.1 or higher."
 
 #: fp-esperienze.php:68
 #, php-format
-msgid "FP Esperienze: Some advanced features (PDF generation, QR codes) require composer dependencies. Run %s in the plugin directory to enable all features."
+msgid ""
+"FP Esperienze: Some advanced features (PDF generation, QR codes) require "
+"composer dependencies. Run %s in the plugin directory to enable all features."
 msgstr ""
+"FP Esperienze: Some advanced features (PDF generation, QR codes) require "
+"composer dependencies. Run %s in the plugin directory to enable all features."
 
-#: fp-esperienze.php:86
-#: fp-esperienze.php:128
+#: fp-esperienze.php:86 fp-esperienze.php:128
 msgid "FP Esperienze requires WooCommerce to be installed and activated."
-msgstr ""
+msgstr "FP Esperienze requires WooCommerce to be installed and activated."
 
-#: fp-esperienze.php:96
-#: fp-esperienze.php:133
+#: fp-esperienze.php:96 fp-esperienze.php:133
 msgid "FP Esperienze requires WooCommerce 8.0 or higher."
-msgstr ""
+msgstr "FP Esperienze requires WooCommerce 8.0 or higher."
 
 #: includes/Admin/DependencyChecker.php:40
 msgid "Required for PDF voucher generation"
-msgstr ""
+msgstr "Required for PDF voucher generation"
 
 #: includes/Admin/DependencyChecker.php:41
 msgid "Vouchers will be generated as HTML instead of PDF"
-msgstr ""
+msgstr "Vouchers will be generated as HTML instead of PDF"
 
 #: includes/Admin/DependencyChecker.php:56
 msgid "Required for QR code generation on vouchers"
-msgstr ""
+msgstr "Required for QR code generation on vouchers"
 
 #: includes/Admin/DependencyChecker.php:57
 msgid "Vouchers will not include QR codes for scanning"
-msgstr ""
+msgstr "Vouchers will not include QR codes for scanning"
 
 #: includes/Admin/DependencyChecker.php:73
 msgid "External libraries for enhanced functionality"
-msgstr ""
+msgstr "External libraries for enhanced functionality"
 
 #: includes/Admin/DependencyChecker.php:74
 msgid "Run \"composer install --no-dev\" to enable all features"
-msgstr ""
+msgstr "Run \"composer install --no-dev\" to enable all features"
 
 #: includes/Admin/DependencyChecker.php:86
 msgid "To enable all features:"
-msgstr ""
+msgstr "To enable all features:"
 
 #: includes/Admin/DependencyChecker.php:88
 msgid "Navigate to the plugin directory in terminal:"
-msgstr ""
+msgstr "Navigate to the plugin directory in terminal:"
 
 #: includes/Admin/DependencyChecker.php:90
 msgid "Install dependencies:"
-msgstr ""
+msgstr "Install dependencies:"
 
 #: includes/Admin/DependencyChecker.php:93
-msgid "Note: The plugin works without these dependencies, but some features will have fallback behavior."
+msgid ""
+"Note: The plugin works without these dependencies, but some features will "
+"have fallback behavior."
 msgstr ""
+"Note: The plugin works without these dependencies, but some features will "
+"have fallback behavior."
 
 #: includes/Admin/DependencyChecker.php:108
 msgid "Optional Dependencies Status"
-msgstr ""
+msgstr "Optional Dependencies Status"
 
-#: includes/Admin/MenuManager.php:81
-#: includes/Admin/MenuManager.php:82
+#: includes/Admin/MenuManager.php:81 includes/Admin/MenuManager.php:82
 msgid "Dashboard"
-msgstr ""
+msgstr "Dashboard"
 
-#: includes/Admin/MenuManager.php:91
-#: includes/Admin/MenuManager.php:92
+#: includes/Admin/MenuManager.php:91 includes/Admin/MenuManager.php:92
 msgid "Bookings"
-msgstr ""
+msgstr "Bookings"
 
-#: includes/Admin/MenuManager.php:101
-#: includes/Admin/MenuManager.php:102
+#: includes/Admin/MenuManager.php:101 includes/Admin/MenuManager.php:102
 #: includes/Admin/MenuManager.php:844
 msgid "Meeting Points"
-msgstr ""
+msgstr "Meeting Points"
 
-#: includes/Admin/MenuManager.php:111
-#: includes/Admin/MenuManager.php:112
+#: includes/Admin/MenuManager.php:111 includes/Admin/MenuManager.php:112
 #: includes/ProductType/Experience.php:399
 msgid "Extras"
-msgstr ""
+msgstr "Extras"
 
-#: includes/Admin/MenuManager.php:121
-#: includes/Admin/MenuManager.php:122
+#: includes/Admin/MenuManager.php:121 includes/Admin/MenuManager.php:122
 msgid "Vouchers"
-msgstr ""
+msgstr "Vouchers"
 
-#: includes/Admin/MenuManager.php:131
-#: includes/Admin/MenuManager.php:132
+#: includes/Admin/MenuManager.php:131 includes/Admin/MenuManager.php:132
 msgid "Closures"
-msgstr ""
+msgstr "Closures"
 
-#: includes/Admin/MenuManager.php:141
-#: includes/Admin/MenuManager.php:142
+#: includes/Admin/MenuManager.php:141 includes/Admin/MenuManager.php:142
 msgid "Reports"
-msgstr ""
+msgstr "Reports"
 
-#: includes/Admin/MenuManager.php:151
-#: includes/Admin/MenuManager.php:152
+#: includes/Admin/MenuManager.php:151 includes/Admin/MenuManager.php:152
 #: includes/Admin/PerformanceSettings.php:48
 msgid "Performance"
-msgstr ""
+msgstr "Performance"
 
-#: includes/Admin/MenuManager.php:161
-#: includes/Admin/MenuManager.php:162
+#: includes/Admin/MenuManager.php:161 includes/Admin/MenuManager.php:162
 #: includes/Admin/MenuManager.php:391
 msgid "Settings"
-msgstr ""
+msgstr "Settings"
 
 #: includes/Admin/MenuManager.php:238
 msgid "Edit Extra"
-msgstr ""
+msgstr "Edit Extra"
 
 #: includes/Admin/MenuManager.php:239
 msgid "PDF link copied to clipboard!"
-msgstr ""
+msgstr "PDF link copied to clipboard!"
 
 #: includes/Admin/MenuManager.php:240
 msgid "Please select an action."
-msgstr ""
+msgstr "Please select an action."
 
 #: includes/Admin/MenuManager.php:241
 msgid "Please select at least one voucher."
-msgstr ""
+msgstr "Please select at least one voucher."
 
 #: includes/Admin/MenuManager.php:242
 msgid "Are you sure you want to void the selected vouchers?"
-msgstr ""
+msgstr "Are you sure you want to void the selected vouchers?"
 
 #: includes/Admin/MenuManager.php:243
 msgid "Are you sure you want to resend emails for the selected vouchers?"
-msgstr ""
+msgstr "Are you sure you want to resend emails for the selected vouchers?"
 
 #: includes/Admin/MenuManager.php:244
 msgid "Are you sure you want to extend the selected vouchers by"
-msgstr ""
+msgstr "Are you sure you want to extend the selected vouchers by"
 
 #: includes/Admin/MenuManager.php:245
 msgid "months?"
-msgstr ""
+msgstr "months?"
 
 #: includes/Admin/MenuManager.php:246
 msgid "Are you sure? This will invalidate all existing QR codes!"
-msgstr ""
+msgstr "Are you sure? This will invalidate all existing QR codes!"
 
 #: includes/Admin/MenuManager.php:247
 msgid "Select Logo"
-msgstr ""
+msgstr "Select Logo"
 
 #: includes/Admin/MenuManager.php:248
 msgid "Use This Image"
-msgstr ""
+msgstr "Use This Image"
 
 #: includes/Admin/MenuManager.php:249
 msgid "Please enter a webhook URL first."
-msgstr ""
+msgstr "Please enter a webhook URL first."
 
-#: includes/Admin/MenuManager.php:250
-#: includes/Admin/MenuManager.php:3403
+#: includes/Admin/MenuManager.php:250 includes/Admin/MenuManager.php:3403
 msgid "Testing..."
-msgstr ""
+msgstr "Testing..."
 
 #: includes/Admin/MenuManager.php:251
 msgid "Webhook test successful!"
-msgstr ""
+msgstr "Webhook test successful!"
 
 #: includes/Admin/MenuManager.php:252
 msgid "Status:"
-msgstr ""
+msgstr "Status:"
 
 #: includes/Admin/MenuManager.php:253
 msgid "Webhook test failed:"
-msgstr ""
+msgstr "Webhook test failed:"
 
 #: includes/Admin/MenuManager.php:254
 msgid "Request failed. Please try again."
-msgstr ""
+msgstr "Request failed. Please try again."
 
 #: includes/Admin/MenuManager.php:255
 msgid "Generate a new webhook secret? This will invalidate the current secret."
 msgstr ""
+"Generate a new webhook secret? This will invalidate the current secret."
 
 #: includes/Admin/MenuManager.php:256
 msgid "Clean up expired holds now?"
-msgstr ""
+msgstr "Clean up expired holds now?"
 
 #: includes/Admin/MenuManager.php:257
 msgid "Cleaning..."
-msgstr ""
+msgstr "Cleaning..."
 
 #: includes/Admin/MenuManager.php:258
 msgid "Cleanup completed!"
-msgstr ""
+msgstr "Cleanup completed!"
 
 #: includes/Admin/MenuManager.php:259
 msgid "Cleaned up:"
-msgstr ""
+msgstr "Cleaned up:"
 
 #: includes/Admin/MenuManager.php:260
 msgid "holds"
-msgstr ""
+msgstr "holds"
 
 #: includes/Admin/MenuManager.php:261
 msgid "Cleanup failed:"
-msgstr ""
+msgstr "Cleanup failed:"
 
 #: includes/Admin/MenuManager.php:262
 msgid "Resend voucher email?"
-msgstr ""
+msgstr "Resend voucher email?"
 
 #: includes/Admin/MenuManager.php:263
 msgid "Extend voucher expiration?"
-msgstr ""
+msgstr "Extend voucher expiration?"
 
 #: includes/Admin/MenuManager.php:264
 msgid "Are you sure you want to void this voucher?"
-msgstr ""
+msgstr "Are you sure you want to void this voucher?"
 
-#: includes/Admin/MenuManager.php:265
-#: includes/Admin/MenuManager.php:585
+#: includes/Admin/MenuManager.php:265 includes/Admin/MenuManager.php:585
 #: includes/Admin/MenuManager.php:665
 msgid "Select time slot"
-msgstr ""
+msgstr "Select time slot"
 
 #: includes/Admin/MenuManager.php:266
 msgid "Loading events..."
-msgstr ""
+msgstr "Loading events..."
 
 #: includes/Admin/MenuManager.php:267
 msgid "There was an error while fetching events. Please try again."
-msgstr ""
+msgstr "There was an error while fetching events. Please try again."
 
 #: includes/Admin/MenuManager.php:268
 msgid "Error loading time slots"
-msgstr ""
+msgstr "Error loading time slots"
 
 #: includes/Admin/MenuManager.php:269
 msgid "Error rescheduling booking"
-msgstr ""
+msgstr "Error rescheduling booking"
 
 #: includes/Admin/MenuManager.php:270
 msgid "Error checking cancellation rules"
-msgstr ""
+msgstr "Error checking cancellation rules"
 
 #: includes/Admin/MenuManager.php:271
 msgid "This booking cannot be cancelled."
-msgstr ""
+msgstr "This booking cannot be cancelled."
 
 #: includes/Admin/MenuManager.php:272
 msgid "Error cancelling booking"
-msgstr ""
+msgstr "Error cancelling booking"
 
 #: includes/Admin/MenuManager.php:273
 msgid "Are you sure you want to cancel this booking?"
-msgstr ""
+msgstr "Are you sure you want to cancel this booking?"
 
 #: includes/Admin/MenuManager.php:274
 msgid "spots available"
-msgstr ""
+msgstr "spots available"
 
 #: includes/Admin/MenuManager.php:275
 msgid "Are you sure you want to delete the meeting point"
-msgstr ""
+msgstr "Are you sure you want to delete the meeting point"
 
 #: includes/Admin/MenuManager.php:276
-msgid "This action cannot be undone and will fail if the meeting point is currently in use."
+msgid ""
+"This action cannot be undone and will fail if the meeting point is currently "
+"in use."
 msgstr ""
+"This action cannot be undone and will fail if the meeting point is currently "
+"in use."
 
 #: includes/Admin/MenuManager.php:298
 msgid "FP Esperienze Dashboard"
-msgstr ""
+msgstr "FP Esperienze Dashboard"
 
 #: includes/Admin/MenuManager.php:302
-msgid "Setup wizard completed successfully! Your experience booking system is ready to use."
+msgid ""
+"Setup wizard completed successfully! Your experience booking system is ready "
+"to use."
 msgstr ""
+"Setup wizard completed successfully! Your experience booking system is ready "
+"to use."
 
-#: includes/Admin/MenuManager.php:310
-#: templates/admin/reports.php:97
+#: includes/Admin/MenuManager.php:310 templates/admin/reports.php:97
 msgid "Total Bookings"
-msgstr ""
+msgstr "Total Bookings"
 
 #: includes/Admin/MenuManager.php:315
 msgid "This Month"
-msgstr ""
+msgstr "This Month"
 
 #: includes/Admin/MenuManager.php:320
 msgid "Upcoming"
-msgstr ""
+msgstr "Upcoming"
 
 #: includes/Admin/MenuManager.php:325
 msgid "Active Vouchers"
-msgstr ""
+msgstr "Active Vouchers"
 
 #: includes/Admin/MenuManager.php:333
 msgid "Recent Bookings"
-msgstr ""
+msgstr "Recent Bookings"
 
 #: includes/Admin/MenuManager.php:339
 msgid "Unknown Experience"
-msgstr ""
+msgstr "Unknown Experience"
 
 #: includes/Admin/MenuManager.php:360
 msgid "View All Bookings"
-msgstr ""
+msgstr "View All Bookings"
 
 #: includes/Admin/MenuManager.php:365
-msgid "No bookings yet. Create your first experience to start accepting bookings!"
+msgid ""
+"No bookings yet. Create your first experience to start accepting bookings!"
 msgstr ""
+"No bookings yet. Create your first experience to start accepting bookings!"
 
 #: includes/Admin/MenuManager.php:371
 msgid "Quick Actions"
-msgstr ""
+msgstr "Quick Actions"
 
 #: includes/Admin/MenuManager.php:375
 msgid "Add New Experience"
-msgstr ""
+msgstr "Add New Experience"
 
 #: includes/Admin/MenuManager.php:379
 msgid "Manage Bookings"
-msgstr ""
+msgstr "Manage Bookings"
 
 #: includes/Admin/MenuManager.php:383
 msgid "Create Voucher"
-msgstr ""
+msgstr "Create Voucher"
 
 #: includes/Admin/MenuManager.php:387
 msgid "View Reports"
-msgstr ""
+msgstr "View Reports"
 
 #: includes/Admin/MenuManager.php:438
 msgid "Bookings Management"
-msgstr ""
+msgstr "Bookings Management"
 
-#: includes/Admin/MenuManager.php:447
-#: includes/Admin/MenuManager.php:1542
+#: includes/Admin/MenuManager.php:447 includes/Admin/MenuManager.php:1542
 msgid "All Statuses"
-msgstr ""
+msgstr "All Statuses"
 
 #: includes/Admin/MenuManager.php:448
 msgid "Confirmed"
-msgstr ""
+msgstr "Confirmed"
 
 #: includes/Admin/MenuManager.php:449
 msgid "Cancelled"
-msgstr ""
+msgstr "Cancelled"
 
 #: includes/Admin/MenuManager.php:450
 msgid "Refunded"
-msgstr ""
+msgstr "Refunded"
 
-#: includes/Admin/MenuManager.php:454
-#: includes/Admin/MenuManager.php:1550
+#: includes/Admin/MenuManager.php:454 includes/Admin/MenuManager.php:1550
 msgid "All Products"
-msgstr ""
+msgstr "All Products"
 
 #: includes/Admin/MenuManager.php:462
 msgid "From Date"
-msgstr ""
+msgstr "From Date"
 
 #: includes/Admin/MenuManager.php:463
 msgid "To Date"
-msgstr ""
+msgstr "To Date"
 
-#: includes/Admin/MenuManager.php:465
-#: includes/Admin/MenuManager.php:1573
+#: includes/Admin/MenuManager.php:465 includes/Admin/MenuManager.php:1573
 msgid "Filter"
-msgstr ""
+msgstr "Filter"
 
-#: includes/Admin/MenuManager.php:466
-#: includes/Admin/MenuManager.php:1576
+#: includes/Admin/MenuManager.php:466 includes/Admin/MenuManager.php:1576
 #: includes/Frontend/Shortcodes.php:389
 msgid "Clear"
-msgstr ""
+msgstr "Clear"
 
 #: includes/Admin/MenuManager.php:467
 msgid "Export CSV"
-msgstr ""
+msgstr "Export CSV"
 
 #: includes/Admin/MenuManager.php:474
 msgid "List View"
-msgstr ""
+msgstr "List View"
 
 #: includes/Admin/MenuManager.php:475
 msgid "Calendar View"
-msgstr ""
+msgstr "Calendar View"
 
 #: includes/Admin/MenuManager.php:482
 msgid "No bookings found matching your criteria."
-msgstr ""
+msgstr "No bookings found matching your criteria."
 
 #: includes/Admin/MenuManager.php:488
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
-#: includes/Admin/MenuManager.php:489
-#: assets/js/admin.js:231
-#: assets/js/admin.js:245
-#: assets/js/admin.js:254
-#: assets/js/archive-block.js:120
+#: includes/Admin/MenuManager.php:489 assets/js/admin.js:231
+#: assets/js/admin.js:245 assets/js/admin.js:254 assets/js/archive-block.js:120
 msgid "Order"
-msgstr ""
+msgstr "Order"
 
-#: includes/Admin/MenuManager.php:490
-#: includes/Admin/MenuManager.php:1615
+#: includes/Admin/MenuManager.php:490 includes/Admin/MenuManager.php:1615
 #: includes/Admin/MenuManager.php:4145
 msgid "Product"
-msgstr ""
+msgstr "Product"
 
 #: includes/Admin/MenuManager.php:491
 msgid "Date & Time"
-msgstr ""
+msgstr "Date & Time"
 
-#: includes/Admin/MenuManager.php:492
-#: templates/single-experience.php:586
-#: assets/js/admin.js:234
-#: assets/js/admin.js:247
+#: includes/Admin/MenuManager.php:492 templates/single-experience.php:586
+#: assets/js/admin.js:234 assets/js/admin.js:247
 msgid "Participants"
-msgstr ""
+msgstr "Participants"
 
-#: includes/Admin/MenuManager.php:493
-#: includes/Admin/MenuManager.php:1618
-#: includes/Admin/MenuManager.php:4151
-#: assets/js/admin.js:233
-#: assets/js/admin.js:246
-#: assets/js/admin.js:255
+#: includes/Admin/MenuManager.php:493 includes/Admin/MenuManager.php:1618
+#: includes/Admin/MenuManager.php:4151 assets/js/admin.js:233
+#: assets/js/admin.js:246 assets/js/admin.js:255
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
-#: includes/Admin/MenuManager.php:494
-#: includes/Admin/MenuManager.php:4152
-#: includes/Frontend/Shortcodes.php:330
-#: includes/ProductType/Experience.php:527
+#: includes/Admin/MenuManager.php:494 includes/Admin/MenuManager.php:4152
+#: includes/Frontend/Shortcodes.php:330 includes/ProductType/Experience.php:527
 #: includes/ProductType/Experience.php:735
-#: includes/ProductType/Experience.php:886
-#: templates/admin/reports.php:44
-#: templates/single-experience.php:267
-#: assets/js/archive-block.js:88
+#: includes/ProductType/Experience.php:886 templates/admin/reports.php:44
+#: templates/single-experience.php:267 assets/js/archive-block.js:88
 msgid "Meeting Point"
-msgstr ""
+msgstr "Meeting Point"
 
-#: includes/Admin/MenuManager.php:495
-#: includes/Admin/MenuManager.php:1620
+#: includes/Admin/MenuManager.php:495 includes/Admin/MenuManager.php:1620
 #: includes/Admin/MenuManager.php:4155
 msgid "Created"
-msgstr ""
+msgstr "Created"
 
-#: includes/Admin/MenuManager.php:496
-#: includes/Admin/MenuManager.php:977
-#: includes/Admin/MenuManager.php:1299
-#: includes/Admin/MenuManager.php:1621
+#: includes/Admin/MenuManager.php:496 includes/Admin/MenuManager.php:977
+#: includes/Admin/MenuManager.php:1299 includes/Admin/MenuManager.php:1621
 #: includes/Admin/MenuManager.php:2326
 msgid "Actions"
-msgstr ""
+msgstr "Actions"
 
-#: includes/Admin/MenuManager.php:511
-#: includes/Admin/MenuManager.php:1635
+#: includes/Admin/MenuManager.php:511 includes/Admin/MenuManager.php:1635
 #: includes/Admin/MenuManager.php:4161
 msgid "Product not found"
-msgstr ""
+msgstr "Product not found"
 
 #: includes/Admin/MenuManager.php:524
 #, php-format
 msgid "%d total (%d adults, %d children)"
-msgstr ""
+msgstr "%d total (%d adults, %d children)"
 
-#: includes/Admin/MenuManager.php:536
-#: includes/Admin/MenuManager.php:4166
+#: includes/Admin/MenuManager.php:536 includes/Admin/MenuManager.php:4166
 msgid "Not found"
-msgstr ""
+msgstr "Not found"
 
-#: includes/Admin/MenuManager.php:538
-#: includes/Admin/MenuManager.php:1003
+#: includes/Admin/MenuManager.php:538 includes/Admin/MenuManager.php:1003
 msgid "Not set"
-msgstr ""
+msgstr "Not set"
 
 #: includes/Admin/MenuManager.php:546
 msgid "Reschedule"
-msgstr ""
+msgstr "Reschedule"
 
-#: includes/Admin/MenuManager.php:549
-#: includes/Admin/MenuManager.php:596
-#: includes/Admin/MenuManager.php:619
-#: includes/Admin/MenuManager.php:947
+#: includes/Admin/MenuManager.php:549 includes/Admin/MenuManager.php:596
+#: includes/Admin/MenuManager.php:619 includes/Admin/MenuManager.php:947
 msgid "Cancel"
-msgstr ""
+msgstr "Cancel"
 
 #: includes/Admin/MenuManager.php:552
 msgid "No actions available"
-msgstr ""
+msgstr "No actions available"
 
-#: includes/Admin/MenuManager.php:571
-#: includes/Admin/MenuManager.php:595
+#: includes/Admin/MenuManager.php:571 includes/Admin/MenuManager.php:595
 msgid "Reschedule Booking"
-msgstr ""
+msgstr "Reschedule Booking"
 
 #: includes/Admin/MenuManager.php:578
 msgid "New Date:"
-msgstr ""
+msgstr "New Date:"
 
 #: includes/Admin/MenuManager.php:583
 msgid "New Time Slot:"
-msgstr ""
+msgstr "New Time Slot:"
 
 #: includes/Admin/MenuManager.php:590
 msgid "Admin Notes:"
-msgstr ""
+msgstr "Admin Notes:"
 
 #: includes/Admin/MenuManager.php:591
 msgid "Optional notes about the reschedule..."
-msgstr ""
+msgstr "Optional notes about the reschedule..."
 
 #: includes/Admin/MenuManager.php:606
 msgid "Cancel Booking"
-msgstr ""
+msgstr "Cancel Booking"
 
 #: includes/Admin/MenuManager.php:613
 msgid "Cancellation Reason:"
-msgstr ""
+msgstr "Cancellation Reason:"
 
 #: includes/Admin/MenuManager.php:614
 msgid "Reason for cancellation..."
-msgstr ""
+msgstr "Reason for cancellation..."
 
 #: includes/Admin/MenuManager.php:618
 msgid "Confirm Cancellation"
-msgstr ""
+msgstr "Confirm Cancellation"
 
-#: includes/Admin/MenuManager.php:825
-#: includes/Admin/MenuManager.php:1868
-#: includes/Admin/MenuManager.php:2361
-#: includes/Admin/MenuManager.php:2515
-#: includes/Admin/MenuManager.php:3876
-#: includes/Admin/MenuManager.php:4051
-#: includes/Admin/MenuManager.php:4232
-#: includes/Admin/MenuManager.php:4268
-#: includes/Admin/MenuManager.php:4296
-#: includes/Admin/MenuManager.php:4328
-#: includes/Admin/MenuManager.php:4351
-#: includes/Admin/MenuManager.php:4404
-#: includes/Admin/MenuManager.php:4432
-#: includes/Admin/MenuManager.php:4449
+#: includes/Admin/MenuManager.php:825 includes/Admin/MenuManager.php:1868
+#: includes/Admin/MenuManager.php:2361 includes/Admin/MenuManager.php:2515
+#: includes/Admin/MenuManager.php:3876 includes/Admin/MenuManager.php:4051
+#: includes/Admin/MenuManager.php:4232 includes/Admin/MenuManager.php:4268
+#: includes/Admin/MenuManager.php:4296 includes/Admin/MenuManager.php:4328
+#: includes/Admin/MenuManager.php:4351 includes/Admin/MenuManager.php:4404
+#: includes/Admin/MenuManager.php:4432 includes/Admin/MenuManager.php:4449
 #: includes/REST/SecurePDFAPI.php:72
 msgid "Security check failed."
-msgstr ""
+msgstr "Security check failed."
 
-#: includes/Admin/MenuManager.php:848
-#: includes/Admin/MenuManager.php:852
+#: includes/Admin/MenuManager.php:848 includes/Admin/MenuManager.php:852
 msgid "Add New"
-msgstr ""
+msgstr "Add New"
 
 #: includes/Admin/MenuManager.php:861
 msgid "Edit Meeting Point"
-msgstr ""
+msgstr "Edit Meeting Point"
 
 #: includes/Admin/MenuManager.php:861
 msgid "Add New Meeting Point"
-msgstr ""
+msgstr "Add New Meeting Point"
 
-#: includes/Admin/MenuManager.php:874
-#: includes/Admin/MenuManager.php:974
-#: includes/Admin/MenuManager.php:1210
-#: includes/Admin/MenuManager.php:1291
-#: includes/Admin/MenuManager.php:1355
-#: assets/js/archive-block.js:75
+#: includes/Admin/MenuManager.php:874 includes/Admin/MenuManager.php:974
+#: includes/Admin/MenuManager.php:1210 includes/Admin/MenuManager.php:1291
+#: includes/Admin/MenuManager.php:1355 assets/js/archive-block.js:75
 msgid "Name"
-msgstr ""
+msgstr "Name"
 
-#: includes/Admin/MenuManager.php:885
-#: includes/Admin/MenuManager.php:975
+#: includes/Admin/MenuManager.php:885 includes/Admin/MenuManager.php:975
 msgid "Address"
-msgstr ""
+msgstr "Address"
 
 #: includes/Admin/MenuManager.php:895
 msgid "Latitude"
-msgstr ""
+msgstr "Latitude"
 
 #: includes/Admin/MenuManager.php:901
 msgid "Decimal degrees format (e.g., 41.9028)"
-msgstr ""
+msgstr "Decimal degrees format (e.g., 41.9028)"
 
 #: includes/Admin/MenuManager.php:907
 msgid "Longitude"
-msgstr ""
+msgstr "Longitude"
 
 #: includes/Admin/MenuManager.php:913
 msgid "Decimal degrees format (e.g., 12.4964)"
-msgstr ""
+msgstr "Decimal degrees format (e.g., 12.4964)"
 
 #: includes/Admin/MenuManager.php:919
 msgid "Google Place ID"
-msgstr ""
+msgstr "Google Place ID"
 
 #: includes/Admin/MenuManager.php:925
 msgid "Google Places API Place ID for enhanced integration"
-msgstr ""
+msgstr "Google Places API Place ID for enhanced integration"
 
 #: includes/Admin/MenuManager.php:931
 msgid "Note"
-msgstr ""
+msgstr "Note"
 
 #: includes/Admin/MenuManager.php:936
 msgid "Additional instructions or notes for this meeting point"
-msgstr ""
+msgstr "Additional instructions or notes for this meeting point"
 
 #: includes/Admin/MenuManager.php:943
 msgid "Update Meeting Point"
-msgstr ""
+msgstr "Update Meeting Point"
 
 #: includes/Admin/MenuManager.php:943
 msgid "Add Meeting Point"
-msgstr ""
+msgstr "Add Meeting Point"
 
 #: includes/Admin/MenuManager.php:962
 msgid "Meeting Points List"
-msgstr ""
+msgstr "Meeting Points List"
 
 #: includes/Admin/MenuManager.php:969
 msgid "No meeting points found. Add your first meeting point above."
-msgstr ""
+msgstr "No meeting points found. Add your first meeting point above."
 
 #: includes/Admin/MenuManager.php:976
 msgid "Coordinates"
-msgstr ""
+msgstr "Coordinates"
 
-#: includes/Admin/MenuManager.php:988
-#: includes/Admin/MenuManager.php:1008
+#: includes/Admin/MenuManager.php:988 includes/Admin/MenuManager.php:1008
 #: includes/Admin/MenuManager.php:1329
 msgid "Edit"
-msgstr ""
+msgstr "Edit"
 
-#: includes/Admin/MenuManager.php:993
-#: includes/Admin/MenuManager.php:1335
+#: includes/Admin/MenuManager.php:993 includes/Admin/MenuManager.php:1335
 msgid "Delete"
-msgstr ""
+msgstr "Delete"
 
-#: includes/Admin/MenuManager.php:1076
-#: includes/Admin/MenuManager.php:1126
+#: includes/Admin/MenuManager.php:1076 includes/Admin/MenuManager.php:1126
 msgid "Name and address are required fields."
-msgstr ""
+msgstr "Name and address are required fields."
 
 #: includes/Admin/MenuManager.php:1087
 msgid "Meeting point created successfully."
-msgstr ""
+msgstr "Meeting point created successfully."
 
 #: includes/Admin/MenuManager.php:1093
 msgid "Failed to create meeting point."
-msgstr ""
+msgstr "Failed to create meeting point."
 
-#: includes/Admin/MenuManager.php:1108
-#: includes/Admin/MenuManager.php:1162
+#: includes/Admin/MenuManager.php:1108 includes/Admin/MenuManager.php:1162
 msgid "Invalid meeting point ID."
-msgstr ""
+msgstr "Invalid meeting point ID."
 
 #: includes/Admin/MenuManager.php:1137
 msgid "Meeting point updated successfully."
-msgstr ""
+msgstr "Meeting point updated successfully."
 
 #: includes/Admin/MenuManager.php:1147
 msgid "Failed to update meeting point."
-msgstr ""
+msgstr "Failed to update meeting point."
 
 #: includes/Admin/MenuManager.php:1173
 msgid "Meeting point deleted successfully."
-msgstr ""
+msgstr "Meeting point deleted successfully."
 
 #: includes/Admin/MenuManager.php:1179
-msgid "Cannot delete meeting point. It may be in use by schedules or set as default for products."
+msgid ""
+"Cannot delete meeting point. It may be in use by schedules or set as default "
+"for products."
 msgstr ""
+"Cannot delete meeting point. It may be in use by schedules or set as default "
+"for products."
 
 #: includes/Admin/MenuManager.php:1199
 msgid "Extras Management"
-msgstr ""
+msgstr "Extras Management"
 
 #: includes/Admin/MenuManager.php:1202
 msgid "Add New Extra"
-msgstr ""
+msgstr "Add New Extra"
 
-#: includes/Admin/MenuManager.php:1218
-#: includes/Admin/MenuManager.php:1292
+#: includes/Admin/MenuManager.php:1218 includes/Admin/MenuManager.php:1292
 #: includes/Admin/MenuManager.php:1363
 msgid "Description"
-msgstr ""
+msgstr "Description"
 
-#: includes/Admin/MenuManager.php:1226
-#: includes/Admin/MenuManager.php:1293
-#: includes/Admin/MenuManager.php:1371
-#: assets/js/archive-block.js:76
+#: includes/Admin/MenuManager.php:1226 includes/Admin/MenuManager.php:1293
+#: includes/Admin/MenuManager.php:1371 assets/js/archive-block.js:76
 msgid "Price"
-msgstr ""
+msgstr "Price"
 
-#: includes/Admin/MenuManager.php:1234
-#: includes/Admin/MenuManager.php:1294
+#: includes/Admin/MenuManager.php:1234 includes/Admin/MenuManager.php:1294
 #: includes/Admin/MenuManager.php:1379
 msgid "Billing Type"
-msgstr ""
+msgstr "Billing Type"
 
-#: includes/Admin/MenuManager.php:1238
-#: includes/Admin/MenuManager.php:1313
+#: includes/Admin/MenuManager.php:1238 includes/Admin/MenuManager.php:1313
 #: includes/Admin/MenuManager.php:1383
 msgid "Per Person"
-msgstr ""
+msgstr "Per Person"
 
-#: includes/Admin/MenuManager.php:1239
-#: includes/Admin/MenuManager.php:1313
+#: includes/Admin/MenuManager.php:1239 includes/Admin/MenuManager.php:1313
 #: includes/Admin/MenuManager.php:1384
 msgid "Per Booking"
-msgstr ""
+msgstr "Per Booking"
 
-#: includes/Admin/MenuManager.php:1245
-#: includes/Admin/MenuManager.php:1295
+#: includes/Admin/MenuManager.php:1245 includes/Admin/MenuManager.php:1295
 #: includes/Admin/MenuManager.php:1390
 msgid "Tax Class"
-msgstr ""
+msgstr "Tax Class"
 
-#: includes/Admin/MenuManager.php:1257
-#: includes/Admin/MenuManager.php:1402
+#: includes/Admin/MenuManager.php:1257 includes/Admin/MenuManager.php:1402
 msgid "Max Quantity"
-msgstr ""
+msgstr "Max Quantity"
 
-#: includes/Admin/MenuManager.php:1265
-#: includes/Admin/MenuManager.php:1297
-#: includes/Admin/MenuManager.php:1410
-#: templates/single-experience.php:682
+#: includes/Admin/MenuManager.php:1265 includes/Admin/MenuManager.php:1297
+#: includes/Admin/MenuManager.php:1410 templates/single-experience.php:682
 msgid "Required"
-msgstr ""
+msgstr "Required"
 
 #: includes/Admin/MenuManager.php:1269
 msgid "Check if this extra is required for booking"
-msgstr ""
+msgstr "Check if this extra is required for booking"
 
-#: includes/Admin/MenuManager.php:1274
-#: includes/Admin/MenuManager.php:1298
-#: includes/Admin/MenuManager.php:1418
-#: includes/Admin/MenuManager.php:1543
+#: includes/Admin/MenuManager.php:1274 includes/Admin/MenuManager.php:1298
+#: includes/Admin/MenuManager.php:1418 includes/Admin/MenuManager.php:1543
 #: includes/ProductType/Experience.php:2175
 #: includes/ProductType/Experience.php:2279
 msgid "Active"
-msgstr ""
+msgstr "Active"
 
 #: includes/Admin/MenuManager.php:1278
 msgid "Check to make this extra available for selection"
-msgstr ""
+msgstr "Check to make this extra available for selection"
 
 #: includes/Admin/MenuManager.php:1283
 msgid "Add Extra"
-msgstr ""
+msgstr "Add Extra"
 
 #: includes/Admin/MenuManager.php:1287
 msgid "Existing Extras"
-msgstr ""
+msgstr "Existing Extras"
 
 #: includes/Admin/MenuManager.php:1296
 msgid "Max Qty"
-msgstr ""
+msgstr "Max Qty"
 
 #: includes/Admin/MenuManager.php:1305
 msgid "No extras found."
-msgstr ""
+msgstr "No extras found."
 
-#: includes/Admin/MenuManager.php:1314
-#: includes/Data/ExtraManager.php:314
+#: includes/Admin/MenuManager.php:1314 includes/Data/ExtraManager.php:314
 msgid "Standard"
-msgstr ""
+msgstr "Standard"
 
 #: includes/Admin/MenuManager.php:1331
 msgid "Are you sure you want to delete this extra?"
-msgstr ""
+msgstr "Are you sure you want to delete this extra?"
 
-#: includes/Admin/MenuManager.php:1534
-#: includes/Admin/MenuManager.php:2652
+#: includes/Admin/MenuManager.php:1534 includes/Admin/MenuManager.php:2652
 msgid "Gift Vouchers"
-msgstr ""
+msgstr "Gift Vouchers"
 
 #: includes/Admin/MenuManager.php:1544
 msgid "Redeemed"
-msgstr ""
+msgstr "Redeemed"
 
-#: includes/Admin/MenuManager.php:1545
-#: includes/Admin/MenuManager.php:1688
+#: includes/Admin/MenuManager.php:1545 includes/Admin/MenuManager.php:1688
 msgid "Expired"
-msgstr ""
+msgstr "Expired"
 
-#: includes/Admin/MenuManager.php:1546
-#: includes/Admin/MenuManager.php:1593
+#: includes/Admin/MenuManager.php:1546 includes/Admin/MenuManager.php:1593
 #: includes/Admin/MenuManager.php:1739
 msgid "Void"
-msgstr ""
+msgstr "Void"
 
 #: includes/Admin/MenuManager.php:1561
 msgid "From date"
-msgstr ""
+msgstr "From date"
 
 #: includes/Admin/MenuManager.php:1566
 msgid "To date"
-msgstr ""
+msgstr "To date"
 
 #: includes/Admin/MenuManager.php:1571
 msgid "Search vouchers..."
-msgstr ""
+msgstr "Search vouchers..."
 
-#: includes/Admin/MenuManager.php:1581
-#: includes/Admin/MenuManager.php:1756
+#: includes/Admin/MenuManager.php:1581 includes/Admin/MenuManager.php:1756
 #, php-format
 msgid "%d items"
-msgstr ""
+msgstr "%d items"
 
 #: includes/Admin/MenuManager.php:1592
 msgid "Bulk actions"
-msgstr ""
+msgstr "Bulk actions"
 
 #: includes/Admin/MenuManager.php:1594
 msgid "Resend emails"
-msgstr ""
+msgstr "Resend emails"
 
 #: includes/Admin/MenuManager.php:1595
 msgid "Extend expiration"
-msgstr ""
+msgstr "Extend expiration"
 
 #: includes/Admin/MenuManager.php:1600
 msgid "months"
-msgstr ""
+msgstr "months"
 
-#: includes/Admin/MenuManager.php:1603
-#: templates/single-experience.php:823
+#: includes/Admin/MenuManager.php:1603 templates/single-experience.php:823
 #: templates/voucher-form.php:36
 msgid "Apply"
-msgstr ""
+msgstr "Apply"
 
 #: includes/Admin/MenuManager.php:1614
 msgid "Code"
-msgstr ""
+msgstr "Code"
 
-#: includes/Admin/MenuManager.php:1616
-#: includes/Booking/Cart_Hooks.php:302
+#: includes/Admin/MenuManager.php:1616 includes/Booking/Cart_Hooks.php:302
 msgid "Recipient"
-msgstr ""
+msgstr "Recipient"
 
 #: includes/Admin/MenuManager.php:1617
 msgid "Value"
-msgstr ""
+msgstr "Value"
 
 #: includes/Admin/MenuManager.php:1619
 msgid "Expires"
-msgstr ""
+msgstr "Expires"
 
 #: includes/Admin/MenuManager.php:1628
 msgid "No vouchers found."
-msgstr ""
+msgstr "No vouchers found."
 
 #: includes/Admin/MenuManager.php:1654
 msgid "Full Experience"
-msgstr ""
+msgstr "Full Experience"
 
 #: includes/Admin/MenuManager.php:1668
 #, php-format
 msgid "Order #%d"
-msgstr ""
+msgstr "Order #%d"
 
 #: includes/Admin/MenuManager.php:1676
 #, php-format
 msgid "From: %s"
-msgstr ""
+msgstr "From: %s"
 
 #: includes/Admin/MenuManager.php:1697
 msgid "Download PDF"
-msgstr ""
+msgstr "Download PDF"
 
 #: includes/Admin/MenuManager.php:1701
 msgid "Copy PDF link"
-msgstr ""
+msgstr "Copy PDF link"
 
 #: includes/Admin/MenuManager.php:1702
 msgid "Copy Link"
-msgstr ""
+msgstr "Copy Link"
 
 #: includes/Admin/MenuManager.php:1716
 msgid "Resend"
-msgstr ""
+msgstr "Resend"
 
 #: includes/Admin/MenuManager.php:1725
 msgid "Months to extend"
-msgstr ""
+msgstr "Months to extend"
 
 #: includes/Admin/MenuManager.php:1728
 msgid "Extend"
-msgstr ""
+msgstr "Extend"
 
-#: includes/Admin/MenuManager.php:1857
-#: includes/Admin/MenuManager.php:2365
-#: includes/Admin/MenuManager.php:2519
-#: includes/Admin/MenuManager.php:4047
+#: includes/Admin/MenuManager.php:1857 includes/Admin/MenuManager.php:2365
+#: includes/Admin/MenuManager.php:2519 includes/Admin/MenuManager.php:4047
 #: includes/Core/CapabilityManager.php:133
 msgid "You do not have permission to perform this action."
-msgstr ""
+msgstr "You do not have permission to perform this action."
 
 #: includes/Admin/MenuManager.php:1927
 msgid "Voucher voided successfully."
-msgstr ""
+msgstr "Voucher voided successfully."
 
 #: includes/Admin/MenuManager.php:1933
 msgid "Failed to void voucher."
-msgstr ""
+msgstr "Failed to void voucher."
 
-#: includes/Admin/MenuManager.php:1955
-#: includes/Admin/MenuManager.php:2047
-#: includes/REST/SecurePDFAPI.php:99
-#: includes/REST/SecurePDFAPI.php:130
+#: includes/Admin/MenuManager.php:1955 includes/Admin/MenuManager.php:2047
+#: includes/REST/SecurePDFAPI.php:99 includes/REST/SecurePDFAPI.php:130
 msgid "Voucher not found."
-msgstr ""
+msgstr "Voucher not found."
 
 #: includes/Admin/MenuManager.php:1966
 msgid "Associated order not found."
-msgstr ""
+msgstr "Associated order not found."
 
 #: includes/Admin/MenuManager.php:2005
 msgid "Voucher email resent successfully."
-msgstr ""
+msgstr "Voucher email resent successfully."
 
 #: includes/Admin/MenuManager.php:2015
 msgid "Failed to resend voucher email."
-msgstr ""
+msgstr "Failed to resend voucher email."
 
 #: includes/Admin/MenuManager.php:2030
 msgid "Invalid extension period."
-msgstr ""
+msgstr "Invalid extension period."
 
 #: includes/Admin/MenuManager.php:2070
 #, php-format
 msgid "Voucher expiration extended to %s."
-msgstr ""
+msgstr "Voucher expiration extended to %s."
 
 #: includes/Admin/MenuManager.php:2076
 msgid "Failed to extend voucher expiration."
-msgstr ""
+msgstr "Failed to extend voucher expiration."
 
 #: includes/Admin/MenuManager.php:2096
 msgid "No vouchers selected."
-msgstr ""
+msgstr "No vouchers selected."
 
 #: includes/Admin/MenuManager.php:2148
 #, php-format
 msgid "%d voucher voided."
 msgid_plural "%d vouchers voided."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d voucher voided."
+msgstr[1] "%d vouchers voided."
 
 #: includes/Admin/MenuManager.php:2151
 #, php-format
 msgid "%d voucher email resent."
 msgid_plural "%d voucher emails resent."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d voucher email resent."
+msgstr[1] "%d voucher emails resent."
 
 #: includes/Admin/MenuManager.php:2154
 #, php-format
 msgid "%d voucher extended."
 msgid_plural "%d vouchers extended."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d voucher extended."
+msgstr[1] "%d vouchers extended."
 
 #: includes/Admin/MenuManager.php:2164
 #, php-format
 msgid "%d vouchers failed to process."
-msgstr ""
+msgstr "%d vouchers failed to process."
 
-#: includes/Admin/MenuManager.php:2184
-#: includes/Admin/MenuManager.php:2247
+#: includes/Admin/MenuManager.php:2184 includes/Admin/MenuManager.php:2247
 #: includes/Admin/MenuManager.php:2255
 msgid "PDF not found."
-msgstr ""
+msgstr "PDF not found."
 
 #: includes/Admin/MenuManager.php:2224
 #, php-format
 msgid "Voucher %s: %s by %s"
-msgstr ""
+msgstr "Voucher %s: %s by %s"
 
 #: includes/Admin/MenuManager.php:2281
 msgid "Global Closures Management"
-msgstr ""
+msgstr "Global Closures Management"
 
-#: includes/Admin/MenuManager.php:2284
-#: includes/Admin/MenuManager.php:2310
+#: includes/Admin/MenuManager.php:2284 includes/Admin/MenuManager.php:2310
 msgid "Add Global Closure"
-msgstr ""
+msgstr "Add Global Closure"
 
-#: includes/Admin/MenuManager.php:2292
-#: includes/Admin/MenuManager.php:2323
-#: includes/Admin/MenuManager.php:4146
-#: includes/ProductType/Experience.php:1096
-#: assets/js/admin.js:235
-#: assets/js/archive-block.js:74
+#: includes/Admin/MenuManager.php:2292 includes/Admin/MenuManager.php:2323
+#: includes/Admin/MenuManager.php:4146 includes/ProductType/Experience.php:1096
+#: assets/js/admin.js:235 assets/js/archive-block.js:74
 #: assets/js/archive-block.js:90
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #: includes/Admin/MenuManager.php:2296
 msgid "Select the date to close for all experiences."
-msgstr ""
+msgstr "Select the date to close for all experiences."
 
-#: includes/Admin/MenuManager.php:2301
-#: includes/Admin/MenuManager.php:2325
+#: includes/Admin/MenuManager.php:2301 includes/Admin/MenuManager.php:2325
 msgid "Reason"
-msgstr ""
+msgstr "Reason"
 
 #: includes/Admin/MenuManager.php:2305
 msgid "Optional reason for the closure."
-msgstr ""
+msgstr "Optional reason for the closure."
 
 #: includes/Admin/MenuManager.php:2315
 msgid "Existing Closures"
-msgstr ""
+msgstr "Existing Closures"
 
 #: includes/Admin/MenuManager.php:2318
 msgid "No global closures found."
-msgstr ""
+msgstr "No global closures found."
 
-#: includes/Admin/MenuManager.php:2324
-#: includes/Data/ICSGenerator.php:54
-#: includes/Data/ICSGenerator.php:242
-#: includes/Data/VoucherManager.php:277
-#: includes/Data/VoucherManager.php:346
-#: includes/PDF/Voucher_Pdf.php:146
+#: includes/Admin/MenuManager.php:2324 includes/Data/ICSGenerator.php:54
+#: includes/Data/ICSGenerator.php:242 includes/Data/VoucherManager.php:277
+#: includes/Data/VoucherManager.php:346 includes/PDF/Voucher_Pdf.php:146
 #: includes/ProductType/Experience.php:78
 #: includes/ProductType/Experience.php:119
-#: includes/ProductType/Experience.php:2455
-#: templates/admin/reports.php:31
+#: includes/ProductType/Experience.php:2455 templates/admin/reports.php:31
 msgid "Experience"
-msgstr ""
+msgstr "Experience"
 
-#: includes/Admin/MenuManager.php:2333
-#: includes/Data/VoucherManager.php:666
+#: includes/Admin/MenuManager.php:2333 includes/Data/VoucherManager.php:666
 #: includes/REST/BookingsAPI.php:154
 msgid "Unknown Product"
-msgstr ""
+msgstr "Unknown Product"
 
 #: includes/Admin/MenuManager.php:2341
 msgid "Are you sure you want to remove this closure?"
-msgstr ""
+msgstr "Are you sure you want to remove this closure?"
 
-#: includes/Admin/MenuManager.php:2342
-#: includes/ProductType/Experience.php:688
+#: includes/Admin/MenuManager.php:2342 includes/ProductType/Experience.php:688
 #: includes/ProductType/Experience.php:832
 #: includes/ProductType/Experience.php:1117
 #: includes/ProductType/Experience.php:1218
 #: includes/ProductType/Experience.php:1382
 #: includes/ProductType/Experience.php:1476
 #: includes/ProductType/Experience.php:2178
-#: includes/ProductType/Experience.php:2283
-#: templates/single-experience.php:830
+#: includes/ProductType/Experience.php:2283 templates/single-experience.php:830
 #: templates/voucher-form.php:43
 msgid "Remove"
-msgstr ""
+msgstr "Remove"
 
-#: includes/Admin/MenuManager.php:2403
-#: includes/Admin/MenuManager.php:2455
+#: includes/Admin/MenuManager.php:2403 includes/Admin/MenuManager.php:2455
 msgid "Extra name is required."
-msgstr ""
+msgstr "Extra name is required."
 
 #: includes/Admin/MenuManager.php:2414
 msgid "Extra created successfully."
-msgstr ""
+msgstr "Extra created successfully."
 
 #: includes/Admin/MenuManager.php:2420
 msgid "Failed to create extra."
-msgstr ""
+msgstr "Failed to create extra."
 
-#: includes/Admin/MenuManager.php:2435
-#: includes/Admin/MenuManager.php:2487
+#: includes/Admin/MenuManager.php:2435 includes/Admin/MenuManager.php:2487
 msgid "Invalid extra ID."
-msgstr ""
+msgstr "Invalid extra ID."
 
 #: includes/Admin/MenuManager.php:2466
 msgid "Extra updated successfully."
-msgstr ""
+msgstr "Extra updated successfully."
 
 #: includes/Admin/MenuManager.php:2472
 msgid "Failed to update extra."
-msgstr ""
+msgstr "Failed to update extra."
 
 #: includes/Admin/MenuManager.php:2498
 msgid "Extra deleted successfully."
-msgstr ""
+msgstr "Extra deleted successfully."
 
 #: includes/Admin/MenuManager.php:2504
 msgid "Cannot delete extra. It may be in use by products."
-msgstr ""
+msgstr "Cannot delete extra. It may be in use by products."
 
 #: includes/Admin/MenuManager.php:2534
 msgid "Global closure added successfully."
-msgstr ""
+msgstr "Global closure added successfully."
 
 #: includes/Admin/MenuManager.php:2540
 msgid "Failed to add global closure."
-msgstr ""
+msgstr "Failed to add global closure."
 
 #: includes/Admin/MenuManager.php:2555
 msgid "Global closure removed successfully."
-msgstr ""
+msgstr "Global closure removed successfully."
 
 #: includes/Admin/MenuManager.php:2561
 msgid "Failed to remove global closure."
-msgstr ""
+msgstr "Failed to remove global closure."
 
-#: includes/Admin/MenuManager.php:2592
-#: includes/Admin/SetupWizard.php:676
+#: includes/Admin/MenuManager.php:2592 includes/Admin/SetupWizard.php:676
 #: includes/Core/Installer.php:478
-msgid "This voucher is valid for one experience booking. Please present the QR code when redeeming."
+msgid ""
+"This voucher is valid for one experience booking. Please present the QR code "
+"when redeeming."
 msgstr ""
+"This voucher is valid for one experience booking. Please present the QR code "
+"when redeeming."
 
 #: includes/Admin/MenuManager.php:2646
 msgid "FP Esperienze Settings"
-msgstr ""
+msgstr "FP Esperienze Settings"
 
 #: includes/Admin/MenuManager.php:2649
 msgid "General"
-msgstr ""
+msgstr "General"
 
-#: includes/Admin/MenuManager.php:2650
-#: templates/single-experience.php:200
+#: includes/Admin/MenuManager.php:2650 templates/single-experience.php:200
 msgid "Booking"
-msgstr ""
+msgstr "Booking"
 
 #: includes/Admin/MenuManager.php:2651
 msgid "Branding"
-msgstr ""
+msgstr "Branding"
 
 #: includes/Admin/MenuManager.php:2653
 msgid "Notifications"
-msgstr ""
+msgstr "Notifications"
 
-#: includes/Admin/MenuManager.php:2654
-#: includes/Admin/SetupWizard.php:301
+#: includes/Admin/MenuManager.php:2654 includes/Admin/SetupWizard.php:301
 msgid "Integrations"
-msgstr ""
+msgstr "Integrations"
 
 #: includes/Admin/MenuManager.php:2655
 msgid "Webhooks"
-msgstr ""
+msgstr "Webhooks"
 
 #: includes/Admin/MenuManager.php:2656
 msgid "Auto Translate"
-msgstr ""
+msgstr "Auto Translate"
 
 #: includes/Admin/MenuManager.php:2674
 msgid "Archive Page"
-msgstr ""
+msgstr "Archive Page"
 
 #: includes/Admin/MenuManager.php:2680
 msgid "Select a page"
-msgstr ""
+msgstr "Select a page"
 
 #: includes/Admin/MenuManager.php:2687
-msgid "Select the page to use as the experience archive. This is used for WPML/Polylang URL translation."
+msgid ""
+"Select the page to use as the experience archive. This is used for WPML/"
+"Polylang URL translation."
 msgstr ""
+"Select the page to use as the experience archive. This is used for WPML/"
+"Polylang URL translation."
 
 #: includes/Admin/MenuManager.php:2693
 msgid "Multilingual Plugin"
-msgstr ""
+msgstr "Multilingual Plugin"
 
 #: includes/Admin/MenuManager.php:2697
 msgid "detected and active"
-msgstr ""
+msgstr "detected and active"
 
 #: includes/Admin/MenuManager.php:2700
-msgid "The plugin will automatically filter experiences by language and provide translated meeting point data."
+msgid ""
+"The plugin will automatically filter experiences by language and provide "
+"translated meeting point data."
 msgstr ""
+"The plugin will automatically filter experiences by language and provide "
+"translated meeting point data."
 
 #: includes/Admin/MenuManager.php:2706
 msgid "Multilingual Support"
-msgstr ""
+msgstr "Multilingual Support"
 
 #: includes/Admin/MenuManager.php:2708
 msgid "No multilingual plugin detected."
-msgstr ""
+msgstr "No multilingual plugin detected."
 
 #: includes/Admin/MenuManager.php:2710
-msgid "Install WPML or Polylang to enable multilingual features including translated meeting points and language-filtered archives."
+msgid ""
+"Install WPML or Polylang to enable multilingual features including "
+"translated meeting points and language-filtered archives."
 msgstr ""
+"Install WPML or Polylang to enable multilingual features including "
+"translated meeting points and language-filtered archives."
 
 #: includes/Admin/MenuManager.php:2719
 msgid "Auto-send to WPML"
-msgstr ""
+msgstr "Auto-send to WPML"
 
 #: includes/Admin/MenuManager.php:2723
-msgid "Automatically create WPML translation jobs when saving experiences or meeting points."
+msgid ""
+"Automatically create WPML translation jobs when saving experiences or "
+"meeting points."
 msgstr ""
+"Automatically create WPML translation jobs when saving experiences or "
+"meeting points."
 
-#: includes/Admin/MenuManager.php:2729
-#: includes/Admin/MenuManager.php:2939
-#: includes/Admin/MenuManager.php:3016
-#: includes/Admin/MenuManager.php:3677
+#: includes/Admin/MenuManager.php:2729 includes/Admin/MenuManager.php:2939
+#: includes/Admin/MenuManager.php:3016 includes/Admin/MenuManager.php:3677
 msgid "Save Settings"
-msgstr ""
+msgstr "Save Settings"
 
 #: includes/Admin/MenuManager.php:2735
 msgid "Typography & Colors"
-msgstr ""
+msgstr "Typography & Colors"
 
 #: includes/Admin/MenuManager.php:2736
 msgid "Configure fonts and colors for your experience booking system."
-msgstr ""
+msgstr "Configure fonts and colors for your experience booking system."
 
 #: includes/Admin/MenuManager.php:2741
 msgid "Primary Font"
-msgstr ""
+msgstr "Primary Font"
 
-#: includes/Admin/MenuManager.php:2745
-#: includes/Admin/MenuManager.php:2769
+#: includes/Admin/MenuManager.php:2745 includes/Admin/MenuManager.php:2769
 msgid "Inherit from theme"
-msgstr ""
+msgstr "Inherit from theme"
 
 #: includes/Admin/MenuManager.php:2759
 msgid "Primary font used for body text in experience displays."
-msgstr ""
+msgstr "Primary font used for body text in experience displays."
 
 #: includes/Admin/MenuManager.php:2765
 msgid "Heading Font"
-msgstr ""
+msgstr "Heading Font"
 
 #: includes/Admin/MenuManager.php:2785
 msgid "Font used for headings and titles in experience displays."
-msgstr ""
+msgstr "Font used for headings and titles in experience displays."
 
 #: includes/Admin/MenuManager.php:2791
 msgid "Primary Color"
-msgstr ""
+msgstr "Primary Color"
 
 #: includes/Admin/MenuManager.php:2803
 msgid "Primary brand color used for buttons, highlights, and accents."
-msgstr ""
+msgstr "Primary brand color used for buttons, highlights, and accents."
 
 #: includes/Admin/MenuManager.php:2809
 msgid "Secondary Color"
-msgstr ""
+msgstr "Secondary Color"
 
 #: includes/Admin/MenuManager.php:2821
 msgid "Secondary color used for text elements and darker accents."
-msgstr ""
+msgstr "Secondary color used for text elements and darker accents."
 
 #: includes/Admin/MenuManager.php:2826
 msgid "Font Preview"
-msgstr ""
+msgstr "Font Preview"
 
 #: includes/Admin/MenuManager.php:2828
 msgid "Experience Title Preview"
-msgstr ""
+msgstr "Experience Title Preview"
 
 #: includes/Admin/MenuManager.php:2829
-msgid "This is how your body text will appear in experience descriptions and details."
+msgid ""
+"This is how your body text will appear in experience descriptions and "
+"details."
 msgstr ""
+"This is how your body text will appear in experience descriptions and "
+"details."
 
 #: includes/Admin/MenuManager.php:2832
 msgid "Save Branding Settings"
-msgstr ""
+msgstr "Save Branding Settings"
 
 #: includes/Admin/MenuManager.php:2841
 msgid "Default Expiration (months)"
-msgstr ""
+msgstr "Default Expiration (months)"
 
 #: includes/Admin/MenuManager.php:2851
 msgid "How many months gift vouchers should be valid for by default."
-msgstr ""
+msgstr "How many months gift vouchers should be valid for by default."
 
 #: includes/Admin/MenuManager.php:2857
 msgid "PDF Logo URL"
-msgstr ""
+msgstr "PDF Logo URL"
 
 #: includes/Admin/MenuManager.php:2865
 msgid "Select Image"
-msgstr ""
+msgstr "Select Image"
 
 #: includes/Admin/MenuManager.php:2866
 msgid "Logo to display on gift voucher PDFs."
-msgstr ""
+msgstr "Logo to display on gift voucher PDFs."
 
-#: includes/Admin/MenuManager.php:2872
-#: includes/Admin/SetupWizard.php:702
+#: includes/Admin/MenuManager.php:2872 includes/Admin/SetupWizard.php:702
 msgid "Brand Color"
-msgstr ""
+msgstr "Brand Color"
 
 #: includes/Admin/MenuManager.php:2879
 msgid "Primary color for gift voucher PDFs."
-msgstr ""
+msgstr "Primary color for gift voucher PDFs."
 
 #: includes/Admin/MenuManager.php:2885
 msgid "Email Sender Name"
-msgstr ""
+msgstr "Email Sender Name"
 
 #: includes/Admin/MenuManager.php:2893
 msgid "Name used in the \"From\" field of gift voucher emails."
-msgstr ""
+msgstr "Name used in the \"From\" field of gift voucher emails."
 
 #: includes/Admin/MenuManager.php:2899
 msgid "Email Sender Address"
-msgstr ""
+msgstr "Email Sender Address"
 
 #: includes/Admin/MenuManager.php:2907
 msgid "Email address used in the \"From\" field of gift voucher emails."
-msgstr ""
+msgstr "Email address used in the \"From\" field of gift voucher emails."
 
 #: includes/Admin/MenuManager.php:2913
 msgid "Terms & Conditions"
-msgstr ""
+msgstr "Terms & Conditions"
 
 #: includes/Admin/MenuManager.php:2920
 msgid "Terms and conditions text displayed on gift voucher PDFs."
-msgstr ""
+msgstr "Terms and conditions text displayed on gift voucher PDFs."
 
 #: includes/Admin/MenuManager.php:2926
 msgid "HMAC Secret Key"
-msgstr ""
+msgstr "HMAC Secret Key"
 
 #: includes/Admin/MenuManager.php:2932
 msgid "Regenerate Secret"
-msgstr ""
+msgstr "Regenerate Secret"
 
 #: includes/Admin/MenuManager.php:2934
-msgid "Secret key used to sign QR codes for security. Regenerating will invalidate existing QR codes!"
+msgid ""
+"Secret key used to sign QR codes for security. Regenerating will invalidate "
+"existing QR codes!"
 msgstr ""
+"Secret key used to sign QR codes for security. Regenerating will invalidate "
+"existing QR codes!"
 
 #: includes/Admin/MenuManager.php:2945
 msgid "Capacity Management"
-msgstr ""
+msgstr "Capacity Management"
 
 #: includes/Admin/MenuManager.php:2946
-msgid "Configure optimistic locking and capacity hold settings for better overbooking prevention."
+msgid ""
+"Configure optimistic locking and capacity hold settings for better "
+"overbooking prevention."
 msgstr ""
+"Configure optimistic locking and capacity hold settings for better "
+"overbooking prevention."
 
 #: includes/Admin/MenuManager.php:2951
 msgid "Enable Capacity Holds"
-msgstr ""
+msgstr "Enable Capacity Holds"
 
 #: includes/Admin/MenuManager.php:2959
-msgid "Enable optimistic locking system that temporarily reserves spots when users add experiences to cart. When disabled, atomic capacity checks are used instead."
+msgid ""
+"Enable optimistic locking system that temporarily reserves spots when users "
+"add experiences to cart. When disabled, atomic capacity checks are used "
+"instead."
 msgstr ""
+"Enable optimistic locking system that temporarily reserves spots when users "
+"add experiences to cart. When disabled, atomic capacity checks are used "
+"instead."
 
 #: includes/Admin/MenuManager.php:2965
 msgid "Hold Duration (minutes)"
-msgstr ""
+msgstr "Hold Duration (minutes)"
 
 #: includes/Admin/MenuManager.php:2975
-msgid "How long spots should be held in the cart before expiring. Recommended: 15 minutes."
+msgid ""
+"How long spots should be held in the cart before expiring. Recommended: 15 "
+"minutes."
 msgstr ""
+"How long spots should be held in the cart before expiring. Recommended: 15 "
+"minutes."
 
 #: includes/Admin/MenuManager.php:2980
 msgid "Hold Statistics"
-msgstr ""
+msgstr "Hold Statistics"
 
 #: includes/Admin/MenuManager.php:2989
 msgid "Active Holds"
-msgstr ""
+msgstr "Active Holds"
 
 #: includes/Admin/MenuManager.php:2993
 msgid "Expired Holds (to cleanup)"
-msgstr ""
+msgstr "Expired Holds (to cleanup)"
 
 #: includes/Admin/MenuManager.php:2997
 msgid "Cleanup Now"
-msgstr ""
+msgstr "Cleanup Now"
 
 #: includes/Admin/MenuManager.php:3002
 msgid "Next Cleanup"
-msgstr ""
+msgstr "Next Cleanup"
 
 #: includes/Admin/MenuManager.php:3009
 msgid "Not scheduled"
-msgstr ""
+msgstr "Not scheduled"
 
-#: includes/Admin/MenuManager.php:3025
-#: includes/Admin/SetupWizard.php:485
+#: includes/Admin/MenuManager.php:3025 includes/Admin/SetupWizard.php:485
 msgid "Google Analytics 4"
-msgstr ""
+msgstr "Google Analytics 4"
 
-#: includes/Admin/MenuManager.php:3030
-#: includes/Admin/SetupWizard.php:489
+#: includes/Admin/MenuManager.php:3030 includes/Admin/SetupWizard.php:489
 msgid "Measurement ID"
-msgstr ""
+msgstr "Measurement ID"
 
 #: includes/Admin/MenuManager.php:3039
 msgid "Your Google Analytics 4 Measurement ID (starts with G-)."
-msgstr ""
+msgstr "Your Google Analytics 4 Measurement ID (starts with G-)."
 
 #: includes/Admin/MenuManager.php:3045
 msgid "Enhanced eCommerce"
-msgstr ""
+msgstr "Enhanced eCommerce"
 
 #: includes/Admin/MenuManager.php:3054
 msgid "Enable enhanced eCommerce tracking (recommended)"
-msgstr ""
+msgstr "Enable enhanced eCommerce tracking (recommended)"
 
 #: includes/Admin/MenuManager.php:3056
 msgid "Track purchase events and conversion data for better analytics."
-msgstr ""
+msgstr "Track purchase events and conversion data for better analytics."
 
-#: includes/Admin/MenuManager.php:3062
-#: includes/Admin/SetupWizard.php:507
+#: includes/Admin/MenuManager.php:3062 includes/Admin/SetupWizard.php:507
 msgid "Google Ads"
-msgstr ""
+msgstr "Google Ads"
 
-#: includes/Admin/MenuManager.php:3067
-#: includes/Admin/SetupWizard.php:511
+#: includes/Admin/MenuManager.php:3067 includes/Admin/SetupWizard.php:511
 msgid "Conversion ID"
-msgstr ""
+msgstr "Conversion ID"
 
 #: includes/Admin/MenuManager.php:3076
-msgid "Your Google Ads Conversion ID (starts with AW-). Configure conversion actions in Google Ads dashboard."
+msgid ""
+"Your Google Ads Conversion ID (starts with AW-). Configure conversion "
+"actions in Google Ads dashboard."
 msgstr ""
+"Your Google Ads Conversion ID (starts with AW-). Configure conversion "
+"actions in Google Ads dashboard."
 
-#: includes/Admin/MenuManager.php:3082
-#: includes/Admin/SetupWizard.php:520
+#: includes/Admin/MenuManager.php:3082 includes/Admin/SetupWizard.php:520
 msgid "Purchase Conversion Label"
-msgstr ""
+msgstr "Purchase Conversion Label"
 
 #: includes/Admin/MenuManager.php:3091
-msgid "Conversion label for purchase events (found in Google Ads conversion action settings)."
+msgid ""
+"Conversion label for purchase events (found in Google Ads conversion action "
+"settings)."
 msgstr ""
+"Conversion label for purchase events (found in Google Ads conversion action "
+"settings)."
 
-#: includes/Admin/MenuManager.php:3097
-#: includes/Admin/SetupWizard.php:529
+#: includes/Admin/MenuManager.php:3097 includes/Admin/SetupWizard.php:529
 msgid "Meta Pixel (Facebook)"
-msgstr ""
+msgstr "Meta Pixel (Facebook)"
 
-#: includes/Admin/MenuManager.php:3102
-#: includes/Admin/SetupWizard.php:533
+#: includes/Admin/MenuManager.php:3102 includes/Admin/SetupWizard.php:533
 msgid "Pixel ID"
-msgstr ""
+msgstr "Pixel ID"
 
 #: includes/Admin/MenuManager.php:3111
 msgid "Your Meta (Facebook) Pixel ID number."
-msgstr ""
+msgstr "Your Meta (Facebook) Pixel ID number."
 
 #: includes/Admin/MenuManager.php:3117
 msgid "Conversions API"
-msgstr ""
+msgstr "Conversions API"
 
 #: includes/Admin/MenuManager.php:3126
 msgid "Enable server-side Meta Conversions API tracking"
-msgstr ""
+msgstr "Enable server-side Meta Conversions API tracking"
 
 #: includes/Admin/MenuManager.php:3128
-msgid "Server-side tracking for improved data accuracy and iOS 14.5+ compliance."
+msgid ""
+"Server-side tracking for improved data accuracy and iOS 14.5+ compliance."
 msgstr ""
+"Server-side tracking for improved data accuracy and iOS 14.5+ compliance."
 
-#: includes/Admin/MenuManager.php:3134
-#: includes/Admin/SetupWizard.php:552
+#: includes/Admin/MenuManager.php:3134 includes/Admin/SetupWizard.php:552
 msgid "Access Token"
-msgstr ""
+msgstr "Access Token"
 
 #: includes/Admin/MenuManager.php:3142
-msgid "Meta Conversions API access token (generate in Facebook Business Manager)."
+msgid ""
+"Meta Conversions API access token (generate in Facebook Business Manager)."
 msgstr ""
+"Meta Conversions API access token (generate in Facebook Business Manager)."
 
-#: includes/Admin/MenuManager.php:3148
-#: includes/Admin/SetupWizard.php:561
+#: includes/Admin/MenuManager.php:3148 includes/Admin/SetupWizard.php:561
 msgid "Dataset ID"
-msgstr ""
+msgstr "Dataset ID"
 
 #: includes/Admin/MenuManager.php:3156
 msgid "Test Connection"
-msgstr ""
+msgstr "Test Connection"
 
 #: includes/Admin/MenuManager.php:3157
 msgid "Meta Conversions API dataset ID (found in Events Manager)."
-msgstr ""
+msgstr "Meta Conversions API dataset ID (found in Events Manager)."
 
 #: includes/Admin/MenuManager.php:3163
 msgid "Consent Mode v2"
-msgstr ""
+msgstr "Consent Mode v2"
 
 #: includes/Admin/MenuManager.php:3168
 msgid "Enable Consent Mode"
-msgstr ""
+msgstr "Enable Consent Mode"
 
 #: includes/Admin/MenuManager.php:3177
 msgid "Use Consent Mode v2 for tracking compliance"
-msgstr ""
+msgstr "Use Consent Mode v2 for tracking compliance"
 
 #: includes/Admin/MenuManager.php:3179
-msgid "When enabled, GA4 and Meta Pixel events only fire if marketing consent is granted. Requires integration with a Consent Management Platform (CMP)."
+msgid ""
+"When enabled, GA4 and Meta Pixel events only fire if marketing consent is "
+"granted. Requires integration with a Consent Management Platform (CMP)."
 msgstr ""
+"When enabled, GA4 and Meta Pixel events only fire if marketing consent is "
+"granted. Requires integration with a Consent Management Platform (CMP)."
 
-#: includes/Admin/MenuManager.php:3185
-#: includes/Admin/SetupWizard.php:638
+#: includes/Admin/MenuManager.php:3185 includes/Admin/SetupWizard.php:638
 msgid "Consent Cookie Name"
-msgstr ""
+msgstr "Consent Cookie Name"
 
 #: includes/Admin/MenuManager.php:3194
-msgid "Name of the cookie that stores marketing consent status (should contain \"true\" or \"1\" for granted)."
+msgid ""
+"Name of the cookie that stores marketing consent status (should contain "
+"\"true\" or \"1\" for granted)."
 msgstr ""
+"Name of the cookie that stores marketing consent status (should contain "
+"\"true\" or \"1\" for granted)."
 
 #: includes/Admin/MenuManager.php:3200
 msgid "Consent JavaScript Function"
-msgstr ""
+msgstr "Consent JavaScript Function"
 
 #: includes/Admin/MenuManager.php:3209
-msgid "Optional: JavaScript function path that returns boolean consent status. Use either this OR cookie name, not both."
+msgid ""
+"Optional: JavaScript function path that returns boolean consent status. Use "
+"either this OR cookie name, not both."
 msgstr ""
+"Optional: JavaScript function path that returns boolean consent status. Use "
+"either this OR cookie name, not both."
 
-#: includes/Admin/MenuManager.php:3215
-#: includes/Admin/SetupWizard.php:582
+#: includes/Admin/MenuManager.php:3215 includes/Admin/SetupWizard.php:582
 msgid "Brevo (Email Marketing)"
-msgstr ""
+msgstr "Brevo (Email Marketing)"
 
-#: includes/Admin/MenuManager.php:3220
-#: includes/Admin/SetupWizard.php:586
+#: includes/Admin/MenuManager.php:3220 includes/Admin/SetupWizard.php:586
 msgid "API Key v3"
-msgstr ""
+msgstr "API Key v3"
 
 #: includes/Admin/MenuManager.php:3228
 msgid "Your Brevo API key v3 for email list management."
-msgstr ""
+msgstr "Your Brevo API key v3 for email list management."
 
-#: includes/Admin/MenuManager.php:3234
-#: includes/Admin/SetupWizard.php:595
+#: includes/Admin/MenuManager.php:3234 includes/Admin/SetupWizard.php:595
 msgid "List ID (Italian)"
-msgstr ""
+msgstr "List ID (Italian)"
 
 #: includes/Admin/MenuManager.php:3242
 msgid "Brevo list ID for Italian customers."
-msgstr ""
+msgstr "Brevo list ID for Italian customers."
 
-#: includes/Admin/MenuManager.php:3248
-#: includes/Admin/SetupWizard.php:603
+#: includes/Admin/MenuManager.php:3248 includes/Admin/SetupWizard.php:603
 msgid "List ID (English)"
-msgstr ""
+msgstr "List ID (English)"
 
 #: includes/Admin/MenuManager.php:3256
 msgid "Brevo list ID for English customers."
-msgstr ""
+msgstr "Brevo list ID for English customers."
 
-#: includes/Admin/MenuManager.php:3262
-#: includes/Admin/SetupWizard.php:611
+#: includes/Admin/MenuManager.php:3262 includes/Admin/SetupWizard.php:611
 msgid "Google Places API"
-msgstr ""
+msgstr "Google Places API"
 
 #: includes/Admin/MenuManager.php:3267
 #: includes/Admin/Settings/AutoTranslateSettings.php:103
 #: includes/Admin/SetupWizard.php:615
 msgid "API Key"
-msgstr ""
+msgstr "API Key"
 
 #: includes/Admin/MenuManager.php:3275
 msgid "Google Places API key for retrieving reviews and location data."
-msgstr ""
+msgstr "Google Places API key for retrieving reviews and location data."
 
 #: includes/Admin/MenuManager.php:3281
 msgid "Display Reviews"
-msgstr ""
+msgstr "Display Reviews"
 
 #: includes/Admin/MenuManager.php:3290
 msgid "Show Google reviews on Meeting Point pages"
-msgstr ""
+msgstr "Show Google reviews on Meeting Point pages"
 
 #: includes/Admin/MenuManager.php:3292
 msgid "Display Google reviews for meeting points when available."
-msgstr ""
+msgstr "Display Google reviews for meeting points when available."
 
 #: includes/Admin/MenuManager.php:3298
 msgid "Reviews Limit"
-msgstr ""
+msgstr "Reviews Limit"
 
 #: includes/Admin/MenuManager.php:3308
 msgid "Maximum number of reviews to display (1-10)."
-msgstr ""
+msgstr "Maximum number of reviews to display (1-10)."
 
 #: includes/Admin/MenuManager.php:3314
 msgid "Cache TTL (minutes)"
-msgstr ""
+msgstr "Cache TTL (minutes)"
 
 #: includes/Admin/MenuManager.php:3324
 msgid "How long to cache Google Places data (5-1440 minutes)."
-msgstr ""
+msgstr "How long to cache Google Places data (5-1440 minutes)."
 
 #: includes/Admin/MenuManager.php:3331
 msgid "Google Business Profile API (Optional)"
-msgstr ""
+msgstr "Google Business Profile API (Optional)"
 
 #: includes/Admin/MenuManager.php:3336
 #: includes/Integrations/GoogleBusinessProfileManager.php:129
 msgid "OAuth Client ID"
-msgstr ""
+msgstr "OAuth Client ID"
 
-#: includes/Admin/MenuManager.php:3344
-#: includes/Admin/MenuManager.php:3360
+#: includes/Admin/MenuManager.php:3344 includes/Admin/MenuManager.php:3360
 #: includes/Integrations/GoogleBusinessProfileManager.php:132
 #: includes/Integrations/GoogleBusinessProfileManager.php:138
 msgid "Coming soon - OAuth integration"
-msgstr ""
+msgstr "Coming soon - OAuth integration"
 
 #: includes/Admin/MenuManager.php:3346
-msgid "Google OAuth Client ID for Business Profile access (placeholder for future implementation)."
+msgid ""
+"Google OAuth Client ID for Business Profile access (placeholder for future "
+"implementation)."
 msgstr ""
+"Google OAuth Client ID for Business Profile access (placeholder for future "
+"implementation)."
 
 #: includes/Admin/MenuManager.php:3352
 #: includes/Integrations/GoogleBusinessProfileManager.php:135
 msgid "OAuth Client Secret"
-msgstr ""
+msgstr "OAuth Client Secret"
 
 #: includes/Admin/MenuManager.php:3362
-msgid "Google OAuth Client Secret (keep secure) - placeholder for future implementation."
+msgid ""
+"Google OAuth Client Secret (keep secure) - placeholder for future "
+"implementation."
 msgstr ""
+"Google OAuth Client Secret (keep secure) - placeholder for future "
+"implementation."
 
 #: includes/Admin/MenuManager.php:3368
 msgid "Requirements"
-msgstr ""
+msgstr "Requirements"
 
 #: includes/Admin/MenuManager.php:3372
 msgid "Note:"
-msgstr ""
+msgstr "Note:"
 
 #: includes/Admin/MenuManager.php:3373
-msgid "You must be the verified owner of the Google Business Profile to use this feature. OAuth integration will be implemented in a future version."
+msgid ""
+"You must be the verified owner of the Google Business Profile to use this "
+"feature. OAuth integration will be implemented in a future version."
 msgstr ""
+"You must be the verified owner of the Google Business Profile to use this "
+"feature. OAuth integration will be implemented in a future version."
 
 #: includes/Admin/MenuManager.php:3380
 msgid "Google Business Profile API"
-msgstr ""
+msgstr "Google Business Profile API"
 
 #: includes/Admin/MenuManager.php:3382
 msgid "Roadmap Feature:"
-msgstr ""
+msgstr "Roadmap Feature:"
 
 #: includes/Admin/MenuManager.php:3383
-msgid "Google Business Profile integration is planned for a future release. This will allow automatic posting of experiences and enhanced review management."
+msgid ""
+"Google Business Profile integration is planned for a future release. This "
+"will allow automatic posting of experiences and enhanced review management."
 msgstr ""
+"Google Business Profile integration is planned for a future release. This "
+"will allow automatic posting of experiences and enhanced review management."
 
 #: includes/Admin/MenuManager.php:3399
 msgid "Please fill in all Meta Conversions API fields before testing."
-msgstr ""
+msgstr "Please fill in all Meta Conversions API fields before testing."
 
 #: includes/Admin/MenuManager.php:3467
 msgid "Save Integrations"
-msgstr ""
+msgstr "Save Integrations"
 
 #: includes/Admin/MenuManager.php:3472
 msgid "Booking Notifications"
-msgstr ""
+msgstr "Booking Notifications"
 
 #: includes/Admin/MenuManager.php:3477
 msgid "Staff Notifications"
-msgstr ""
+msgstr "Staff Notifications"
 
 #: includes/Admin/MenuManager.php:3486
 msgid "Send email notifications to staff when new bookings are made"
-msgstr ""
+msgstr "Send email notifications to staff when new bookings are made"
 
 #: includes/Admin/MenuManager.php:3493
 msgid "Staff Email Addresses"
-msgstr ""
+msgstr "Staff Email Addresses"
 
 #: includes/Admin/MenuManager.php:3502
-msgid "Enter one email address per line. These emails will receive notifications when new bookings are created."
+msgid ""
+"Enter one email address per line. These emails will receive notifications "
+"when new bookings are created."
 msgstr ""
+"Enter one email address per line. These emails will receive notifications "
+"when new bookings are created."
 
 #: includes/Admin/MenuManager.php:3509
 msgid "ICS Calendar Attachments"
-msgstr ""
+msgstr "ICS Calendar Attachments"
 
 #: includes/Admin/MenuManager.php:3518
 msgid "Attach ICS calendar files to order completion emails"
-msgstr ""
+msgstr "Attach ICS calendar files to order completion emails"
 
 #: includes/Admin/MenuManager.php:3521
-msgid "When enabled, customers will receive an ICS calendar file attachment with their booking details in order confirmation emails."
+msgid ""
+"When enabled, customers will receive an ICS calendar file attachment with "
+"their booking details in order confirmation emails."
 msgstr ""
+"When enabled, customers will receive an ICS calendar file attachment with "
+"their booking details in order confirmation emails."
 
 #: includes/Admin/MenuManager.php:3527
 msgid "ICS Calendar Endpoints"
-msgstr ""
+msgstr "ICS Calendar Endpoints"
 
 #: includes/Admin/MenuManager.php:3528
-msgid "The following REST API endpoints are available for calendar integration:"
+msgid ""
+"The following REST API endpoints are available for calendar integration:"
 msgstr ""
+"The following REST API endpoints are available for calendar integration:"
 
 #: includes/Admin/MenuManager.php:3532
 msgid "Product Calendar"
-msgstr ""
+msgstr "Product Calendar"
 
 #: includes/Admin/MenuManager.php:3535
-msgid "Public endpoint to get calendar of available slots for a specific experience product."
+msgid ""
+"Public endpoint to get calendar of available slots for a specific experience "
+"product."
 msgstr ""
+"Public endpoint to get calendar of available slots for a specific experience "
+"product."
 
 #: includes/Admin/MenuManager.php:3540
 msgid "User Bookings Calendar"
-msgstr ""
+msgstr "User Bookings Calendar"
 
 #: includes/Admin/MenuManager.php:3543
-msgid "Private endpoint (requires authentication) to get calendar of user's confirmed bookings."
+msgid ""
+"Private endpoint (requires authentication) to get calendar of user's "
+"confirmed bookings."
 msgstr ""
+"Private endpoint (requires authentication) to get calendar of user's "
+"confirmed bookings."
 
 #: includes/Admin/MenuManager.php:3548
 msgid "Single Booking Calendar"
-msgstr ""
+msgstr "Single Booking Calendar"
 
 #: includes/Admin/MenuManager.php:3551
-msgid "Token-protected endpoint that serves stored ICS files for individual bookings."
+msgid ""
+"Token-protected endpoint that serves stored ICS files for individual "
+"bookings."
 msgstr ""
+"Token-protected endpoint that serves stored ICS files for individual "
+"bookings."
 
 #: includes/Admin/MenuManager.php:3556
 msgid "Save Notification Settings"
-msgstr ""
+msgstr "Save Notification Settings"
 
 #: includes/Admin/MenuManager.php:3563
 msgid "Webhook Configuration"
-msgstr ""
+msgstr "Webhook Configuration"
 
 #: includes/Admin/MenuManager.php:3564
-msgid "Configure webhook URLs to receive real-time notifications about booking events."
+msgid ""
+"Configure webhook URLs to receive real-time notifications about booking "
+"events."
 msgstr ""
+"Configure webhook URLs to receive real-time notifications about booking "
+"events."
 
 #: includes/Admin/MenuManager.php:3569
 msgid "New Booking URL"
-msgstr ""
+msgstr "New Booking URL"
 
-#: includes/Admin/MenuManager.php:3577
-#: includes/Admin/MenuManager.php:3592
+#: includes/Admin/MenuManager.php:3577 includes/Admin/MenuManager.php:3592
 #: includes/Admin/MenuManager.php:3607
 msgid "Test"
-msgstr ""
+msgstr "Test"
 
 #: includes/Admin/MenuManager.php:3578
 msgid "Webhook URL called when a new booking is created."
-msgstr ""
+msgstr "Webhook URL called when a new booking is created."
 
 #: includes/Admin/MenuManager.php:3584
 msgid "Cancellation URL"
-msgstr ""
+msgstr "Cancellation URL"
 
 #: includes/Admin/MenuManager.php:3593
 msgid "Webhook URL called when a booking is cancelled."
-msgstr ""
+msgstr "Webhook URL called when a booking is cancelled."
 
 #: includes/Admin/MenuManager.php:3599
 msgid "Reschedule URL"
-msgstr ""
+msgstr "Reschedule URL"
 
 #: includes/Admin/MenuManager.php:3608
 msgid "Webhook URL called when a booking is rescheduled."
-msgstr ""
+msgstr "Webhook URL called when a booking is rescheduled."
 
 #: includes/Admin/MenuManager.php:3614
 msgid "Webhook Secret"
-msgstr ""
+msgstr "Webhook Secret"
 
 #: includes/Admin/MenuManager.php:3622
 msgid "Generate New"
-msgstr ""
+msgstr "Generate New"
 
 #: includes/Admin/MenuManager.php:3623
-msgid "Secret key used to sign webhook payloads with HMAC-SHA256. Use X-FP-Signature header to verify authenticity."
+msgid ""
+"Secret key used to sign webhook payloads with HMAC-SHA256. Use X-FP-"
+"Signature header to verify authenticity."
 msgstr ""
+"Secret key used to sign webhook payloads with HMAC-SHA256. Use X-FP-"
+"Signature header to verify authenticity."
 
 #: includes/Admin/MenuManager.php:3629
 msgid "Hide Personal Information"
-msgstr ""
+msgstr "Hide Personal Information"
 
 #: includes/Admin/MenuManager.php:3637
 msgid "Exclude customer notes and personal data from webhook payloads"
-msgstr ""
+msgstr "Exclude customer notes and personal data from webhook payloads"
 
 #: includes/Admin/MenuManager.php:3638
 msgid "Enable for GDPR compliance when sending data to third-party services."
-msgstr ""
+msgstr "Enable for GDPR compliance when sending data to third-party services."
 
 #: includes/Admin/MenuManager.php:3643
 msgid "Webhook Payload Format"
-msgstr ""
+msgstr "Webhook Payload Format"
 
 #: includes/Admin/MenuManager.php:3644
 msgid "Webhooks send JSON payloads with the following structure:"
-msgstr ""
+msgstr "Webhooks send JSON payloads with the following structure:"
 
 #: includes/Admin/MenuManager.php:3665
 msgid "Retry Policy"
-msgstr ""
+msgstr "Retry Policy"
 
 #: includes/Admin/MenuManager.php:3666
-msgid "Failed webhooks are retried up to 5 times with exponential backoff: 2, 4, 8, 16, 32 minutes."
+msgid ""
+"Failed webhooks are retried up to 5 times with exponential backoff: 2, 4, 8, "
+"16, 32 minutes."
 msgstr ""
+"Failed webhooks are retried up to 5 times with exponential backoff: 2, 4, 8, "
+"16, 32 minutes."
 
 #: includes/Admin/MenuManager.php:3668
 msgid "Save Webhook Settings"
-msgstr ""
+msgstr "Save Webhook Settings"
 
 #: includes/Admin/MenuManager.php:4007
 #, php-format
 msgid "Invalid email address: %s"
-msgstr ""
+msgstr "Invalid email address: %s"
 
 #: includes/Admin/MenuManager.php:4037
 msgid "Settings saved successfully!"
-msgstr ""
+msgstr "Settings saved successfully!"
 
 #: includes/Admin/MenuManager.php:4065
 msgid "Invalid booking status."
-msgstr ""
+msgstr "Invalid booking status."
 
 #: includes/Admin/MenuManager.php:4091
 msgid "Booking status updated successfully."
-msgstr ""
+msgstr "Booking status updated successfully."
 
 #: includes/Admin/MenuManager.php:4097
 msgid "Failed to update booking status."
-msgstr ""
+msgstr "Failed to update booking status."
 
-#: includes/Admin/MenuManager.php:4112
-#: includes/Admin/MenuManager.php:4264
-#: includes/Admin/MenuManager.php:4292
-#: includes/Admin/MenuManager.php:4324
-#: includes/Admin/MenuManager.php:4347
-#: includes/Admin/MenuManager.php:4400
-#: includes/Admin/MenuManager.php:4428
-#: includes/Admin/MenuManager.php:4445
-#: includes/Admin/ReportsManager.php:387
-#: includes/Admin/ReportsManager.php:468
-#: includes/Admin/ReportsManager.php:490
-#: includes/Admin/ReportsManager.php:510
+#: includes/Admin/MenuManager.php:4112 includes/Admin/MenuManager.php:4264
+#: includes/Admin/MenuManager.php:4292 includes/Admin/MenuManager.php:4324
+#: includes/Admin/MenuManager.php:4347 includes/Admin/MenuManager.php:4400
+#: includes/Admin/MenuManager.php:4428 includes/Admin/MenuManager.php:4445
+#: includes/Admin/ReportsManager.php:387 includes/Admin/ReportsManager.php:468
+#: includes/Admin/ReportsManager.php:490 includes/Admin/ReportsManager.php:510
 msgid "Insufficient permissions."
-msgstr ""
+msgstr "Insufficient permissions."
 
 #: includes/Admin/MenuManager.php:4143
 msgid "Booking ID"
-msgstr ""
+msgstr "Booking ID"
 
 #: includes/Admin/MenuManager.php:4144
 msgid "Order ID"
-msgstr ""
+msgstr "Order ID"
 
-#: includes/Admin/MenuManager.php:4147
-#: includes/ProductType/Experience.php:976
-#: assets/js/admin.js:236
-#: assets/js/admin.js:639
+#: includes/Admin/MenuManager.php:4147 includes/ProductType/Experience.php:976
+#: assets/js/admin.js:236 assets/js/admin.js:639
 msgid "Time"
-msgstr ""
+msgstr "Time"
 
-#: includes/Admin/MenuManager.php:4148
-#: includes/Booking/Cart_Hooks.php:265
-#: includes/Booking/Cart_Hooks.php:380
-#: includes/ProductType/Experience.php:2049
-#: templates/single-experience.php:591
-#: assets/js/booking-widget.js:387
+#: includes/Admin/MenuManager.php:4148 includes/Booking/Cart_Hooks.php:265
+#: includes/Booking/Cart_Hooks.php:380 includes/ProductType/Experience.php:2049
+#: templates/single-experience.php:591 assets/js/booking-widget.js:387
 msgid "Adults"
-msgstr ""
+msgstr "Adults"
 
-#: includes/Admin/MenuManager.php:4149
-#: includes/Booking/Cart_Hooks.php:272
-#: includes/Booking/Cart_Hooks.php:384
-#: includes/ProductType/Experience.php:2053
-#: templates/single-experience.php:618
-#: assets/js/booking-widget.js:391
+#: includes/Admin/MenuManager.php:4149 includes/Booking/Cart_Hooks.php:272
+#: includes/Booking/Cart_Hooks.php:384 includes/ProductType/Experience.php:2053
+#: templates/single-experience.php:618 assets/js/booking-widget.js:391
 msgid "Children"
-msgstr ""
+msgstr "Children"
 
 #: includes/Admin/MenuManager.php:4150
 msgid "Total Participants"
-msgstr ""
+msgstr "Total Participants"
 
 #: includes/Admin/MenuManager.php:4153
 msgid "Customer Notes"
-msgstr ""
+msgstr "Customer Notes"
 
 #: includes/Admin/MenuManager.php:4154
 msgid "Admin Notes"
-msgstr ""
+msgstr "Admin Notes"
 
 #: includes/Admin/MenuManager.php:4226
 msgid "You do not have sufficient permissions to access this page."
-msgstr ""
+msgstr "You do not have sufficient permissions to access this page."
 
-#: includes/Admin/MenuManager.php:4275
-#: includes/Admin/MenuManager.php:4305
+#: includes/Admin/MenuManager.php:4275 includes/Admin/MenuManager.php:4305
 msgid "Invalid parameters."
-msgstr ""
+msgstr "Invalid parameters."
 
-#: includes/Admin/MenuManager.php:4334
-#: includes/Admin/MenuManager.php:4358
+#: includes/Admin/MenuManager.php:4334 includes/Admin/MenuManager.php:4358
 msgid "Invalid booking ID."
-msgstr ""
+msgstr "Invalid booking ID."
 
-#: includes/Admin/MenuManager.php:4367
-#: includes/Booking/BookingManager.php:401
-#: includes/Booking/BookingManager.php:602
-#: includes/REST/ICSAPI.php:231
+#: includes/Admin/MenuManager.php:4367 includes/Booking/BookingManager.php:401
+#: includes/Booking/BookingManager.php:602 includes/REST/ICSAPI.php:231
 msgid "Booking not found."
-msgstr ""
+msgstr "Booking not found."
 
 #: includes/Admin/MenuManager.php:4371
 #, php-format
 msgid "Cancelled by admin. Reason: %s"
-msgstr ""
+msgstr "Cancelled by admin. Reason: %s"
 
 #: includes/Admin/MenuManager.php:4386
 msgid "Failed to cancel booking."
-msgstr ""
+msgstr "Failed to cancel booking."
 
 #: includes/Admin/MenuManager.php:4392
 msgid "Booking cancelled successfully."
-msgstr ""
+msgstr "Booking cancelled successfully."
 
-#: includes/Admin/MenuManager.php:4411
-#: includes/Core/WebhookManager.php:279
+#: includes/Admin/MenuManager.php:4411 includes/Core/WebhookManager.php:279
 msgid "Invalid webhook URL."
-msgstr ""
+msgstr "Invalid webhook URL."
 
 #: includes/Admin/MenuManager.php:4437
 #, php-format
 msgid "Cleaned up %d expired holds"
-msgstr ""
+msgstr "Cleaned up %d expired holds"
 
 #: includes/Admin/PerformanceSettings.php:47
 msgid "Performance Settings"
-msgstr ""
+msgstr "Performance Settings"
 
 #: includes/Admin/PerformanceSettings.php:66
 #, php-format
 msgid "Cleared %d cache entries."
-msgstr ""
+msgstr "Cleared %d cache entries."
 
 #: includes/Admin/PerformanceSettings.php:75
 msgid "Regenerated minified assets."
-msgstr ""
+msgstr "Regenerated minified assets."
 
 #: includes/Admin/PerformanceSettings.php:84
 msgid "Started pre-building availability cache."
-msgstr ""
+msgstr "Started pre-building availability cache."
 
 #: includes/Admin/PerformanceSettings.php:98
 msgid "Cache Settings"
-msgstr ""
+msgstr "Cache Settings"
 
 #: includes/Admin/PerformanceSettings.php:103
 msgid "Pre-build Days"
-msgstr ""
+msgstr "Pre-build Days"
 
 #: includes/Admin/PerformanceSettings.php:113
-msgid "Number of days ahead to pre-build availability cache. Set to 0 to disable pre-building."
+msgid ""
+"Number of days ahead to pre-build availability cache. Set to 0 to disable "
+"pre-building."
 msgstr ""
+"Number of days ahead to pre-build availability cache. Set to 0 to disable "
+"pre-building."
 
 #: includes/Admin/PerformanceSettings.php:122
 msgid "Cache Statistics"
-msgstr ""
+msgstr "Cache Statistics"
 
 #: includes/Admin/PerformanceSettings.php:126
 msgid "Availability Caches"
-msgstr ""
+msgstr "Availability Caches"
 
 #: includes/Admin/PerformanceSettings.php:130
 msgid "Archive Caches"
-msgstr ""
+msgstr "Archive Caches"
 
 #: includes/Admin/PerformanceSettings.php:134
 msgid "Total Caches"
-msgstr ""
+msgstr "Total Caches"
 
 #: includes/Admin/PerformanceSettings.php:140
 msgid "Asset Optimization Statistics"
-msgstr ""
+msgstr "Asset Optimization Statistics"
 
 #: includes/Admin/PerformanceSettings.php:144
 msgid "Original Size"
-msgstr ""
+msgstr "Original Size"
 
 #: includes/Admin/PerformanceSettings.php:148
 msgid "Minified Size"
-msgstr ""
+msgstr "Minified Size"
 
 #: includes/Admin/PerformanceSettings.php:152
 msgid "Compression Ratio"
-msgstr ""
+msgstr "Compression Ratio"
 
 #: includes/Admin/PerformanceSettings.php:156
 msgid "Minified Assets Available"
-msgstr ""
+msgstr "Minified Assets Available"
 
 #: includes/Admin/PerformanceSettings.php:158
-#: includes/Booking/Cart_Hooks.php:298
-#: includes/Booking/Cart_Hooks.php:403
+#: includes/Booking/Cart_Hooks.php:298 includes/Booking/Cart_Hooks.php:403
 #: includes/Data/VoucherManager.php:47
 msgid "Yes"
-msgstr ""
+msgstr "Yes"
 
 #: includes/Admin/PerformanceSettings.php:159
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: includes/Admin/PerformanceSettings.php:164
 msgid "Performance Actions"
-msgstr ""
+msgstr "Performance Actions"
 
 #: includes/Admin/PerformanceSettings.php:171
 msgid "Clear All Caches"
-msgstr ""
+msgstr "Clear All Caches"
 
 #: includes/Admin/PerformanceSettings.php:172
 msgid "Are you sure you want to clear all caches?"
-msgstr ""
+msgstr "Are you sure you want to clear all caches?"
 
 #: includes/Admin/PerformanceSettings.php:179
 msgid "Regenerate Minified Assets"
-msgstr ""
+msgstr "Regenerate Minified Assets"
 
 #: includes/Admin/PerformanceSettings.php:186
 msgid "Pre-build Cache Now"
-msgstr ""
+msgstr "Pre-build Cache Now"
 
 #: includes/Admin/PerformanceSettings.php:191
 msgid "Performance Tips"
-msgstr ""
+msgstr "Performance Tips"
 
 #: includes/Admin/PerformanceSettings.php:194
 #: includes/Admin/Settings/AutoTranslateSettings.php:111
 msgid "Cache TTL"
-msgstr ""
+msgstr "Cache TTL"
 
 #: includes/Admin/PerformanceSettings.php:194
 msgid "Availability caches are stored for 10 minutes by default."
-msgstr ""
+msgstr "Availability caches are stored for 10 minutes by default."
 
 #: includes/Admin/PerformanceSettings.php:195
 msgid "Smart Invalidation"
-msgstr ""
+msgstr "Smart Invalidation"
 
 #: includes/Admin/PerformanceSettings.php:195
-msgid "Caches are automatically cleared when bookings are made or overrides are changed."
+msgid ""
+"Caches are automatically cleared when bookings are made or overrides are "
+"changed."
 msgstr ""
+"Caches are automatically cleared when bookings are made or overrides are "
+"changed."
 
 #: includes/Admin/PerformanceSettings.php:196
 msgid "Asset Optimization"
-msgstr ""
+msgstr "Asset Optimization"
 
 #: includes/Admin/PerformanceSettings.php:196
-msgid "CSS and JS files are automatically minified and concatenated for better performance."
+msgid ""
+"CSS and JS files are automatically minified and concatenated for better "
+"performance."
 msgstr ""
+"CSS and JS files are automatically minified and concatenated for better "
+"performance."
 
 #: includes/Admin/PerformanceSettings.php:197
 msgid "Lazy Loading"
-msgstr ""
+msgstr "Lazy Loading"
 
 #: includes/Admin/PerformanceSettings.php:197
-msgid "All images include lazy loading attributes for improved page load times."
+msgid ""
+"All images include lazy loading attributes for improved page load times."
 msgstr ""
+"All images include lazy loading attributes for improved page load times."
 
 #: includes/Admin/PerformanceSettings.php:198
 msgid "Script Deferring"
-msgstr ""
+msgstr "Script Deferring"
 
 #: includes/Admin/PerformanceSettings.php:198
 msgid "Non-critical scripts are deferred to improve page rendering speed."
-msgstr ""
+msgstr "Non-critical scripts are deferred to improve page rendering speed."
 
 #: includes/Admin/SEOSettings.php:43
 msgid "Schema.org Settings"
-msgstr ""
+msgstr "Schema.org Settings"
 
-#: includes/Admin/SEOSettings.php:50
-#: includes/Admin/SEOSettings.php:162
+#: includes/Admin/SEOSettings.php:50 includes/Admin/SEOSettings.php:162
 msgid "Enhanced Schema.org"
-msgstr ""
+msgstr "Enhanced Schema.org"
 
-#: includes/Admin/SEOSettings.php:58
-#: includes/Admin/SEOSettings.php:167
+#: includes/Admin/SEOSettings.php:58 includes/Admin/SEOSettings.php:167
 msgid "FAQ Schema"
-msgstr ""
+msgstr "FAQ Schema"
 
-#: includes/Admin/SEOSettings.php:66
-#: includes/Admin/SEOSettings.php:172
+#: includes/Admin/SEOSettings.php:66 includes/Admin/SEOSettings.php:172
 msgid "Breadcrumb Schema"
-msgstr ""
+msgstr "Breadcrumb Schema"
 
 #: includes/Admin/SEOSettings.php:74
 msgid "Social Media Settings"
-msgstr ""
+msgstr "Social Media Settings"
 
 #: includes/Admin/SEOSettings.php:81
 msgid "Open Graph Tags"
-msgstr ""
+msgstr "Open Graph Tags"
 
 #: includes/Admin/SEOSettings.php:89
 msgid "Twitter Cards"
-msgstr ""
+msgstr "Twitter Cards"
 
 #: includes/Admin/SEOSettings.php:131
 msgid "SEO Settings"
-msgstr ""
+msgstr "SEO Settings"
 
 #: includes/Admin/SEOSettings.php:132
 msgid "SEO"
-msgstr ""
+msgstr "SEO"
 
 #: includes/Admin/SEOSettings.php:159
 msgid "SEO Features Overview"
-msgstr ""
+msgstr "SEO Features Overview"
 
 #: includes/Admin/SEOSettings.php:163
-msgid "Automatically adds Event or Trip schema based on experience type, includes meeting point location and pricing information."
+msgid ""
+"Automatically adds Event or Trip schema based on experience type, includes "
+"meeting point location and pricing information."
 msgstr ""
+"Automatically adds Event or Trip schema based on experience type, includes "
+"meeting point location and pricing information."
 
 #: includes/Admin/SEOSettings.php:168
-msgid "When FAQ data is available, adds FAQPage schema markup for better search visibility."
+msgid ""
+"When FAQ data is available, adds FAQPage schema markup for better search "
+"visibility."
 msgstr ""
+"When FAQ data is available, adds FAQPage schema markup for better search "
+"visibility."
 
 #: includes/Admin/SEOSettings.php:173
-msgid "Adds structured breadcrumb navigation for experiences: Shop → Experience."
+msgid ""
+"Adds structured breadcrumb navigation for experiences: Shop → Experience."
 msgstr ""
+"Adds structured breadcrumb navigation for experiences: Shop → Experience."
 
 #: includes/Admin/SEOSettings.php:177
 msgid "Social Media Tags"
-msgstr ""
+msgstr "Social Media Tags"
 
 #: includes/Admin/SEOSettings.php:178
-msgid "Open Graph and Twitter Card meta tags for better social media sharing of experiences."
+msgid ""
+"Open Graph and Twitter Card meta tags for better social media sharing of "
+"experiences."
 msgstr ""
+"Open Graph and Twitter Card meta tags for better social media sharing of "
+"experiences."
 
 #: includes/Admin/SEOSettings.php:215
-msgid "Configure Schema.org structured data markup for better search engine visibility."
+msgid ""
+"Configure Schema.org structured data markup for better search engine "
+"visibility."
 msgstr ""
+"Configure Schema.org structured data markup for better search engine "
+"visibility."
 
 #: includes/Admin/SEOSettings.php:222
-msgid "Configure social media meta tags for better sharing on social platforms."
+msgid ""
+"Configure social media meta tags for better sharing on social platforms."
 msgstr ""
+"Configure social media meta tags for better sharing on social platforms."
 
 #: includes/Admin/SEOSettings.php:234
 msgid "Enable enhanced Event/Trip schema markup"
-msgstr ""
+msgstr "Enable enhanced Event/Trip schema markup"
 
 #: includes/Admin/SEOSettings.php:236
-msgid "Automatically selects Event schema for guided experiences with specific times, or Trip schema for tour experiences."
+msgid ""
+"Automatically selects Event schema for guided experiences with specific "
+"times, or Trip schema for tour experiences."
 msgstr ""
+"Automatically selects Event schema for guided experiences with specific "
+"times, or Trip schema for tour experiences."
 
 #: includes/Admin/SEOSettings.php:248
 msgid "Enable FAQ schema markup"
-msgstr ""
+msgstr "Enable FAQ schema markup"
 
 #: includes/Admin/SEOSettings.php:250
 msgid "Adds FAQPage schema when FAQ data is available for the experience."
-msgstr ""
+msgstr "Adds FAQPage schema when FAQ data is available for the experience."
 
 #: includes/Admin/SEOSettings.php:262
 msgid "Enable breadcrumb schema markup"
-msgstr ""
+msgstr "Enable breadcrumb schema markup"
 
 #: includes/Admin/SEOSettings.php:264
 msgid "Adds BreadcrumbList schema for experience pages."
-msgstr ""
+msgstr "Adds BreadcrumbList schema for experience pages."
 
 #: includes/Admin/SEOSettings.php:276
 msgid "Enable Open Graph meta tags"
-msgstr ""
+msgstr "Enable Open Graph meta tags"
 
 #: includes/Admin/SEOSettings.php:278
 msgid "Adds Open Graph meta tags for better Facebook and LinkedIn sharing."
-msgstr ""
+msgstr "Adds Open Graph meta tags for better Facebook and LinkedIn sharing."
 
 #: includes/Admin/SEOSettings.php:290
 msgid "Enable Twitter Card meta tags"
-msgstr ""
+msgstr "Enable Twitter Card meta tags"
 
 #: includes/Admin/SEOSettings.php:292
 msgid "Adds Twitter Card meta tags for better Twitter sharing."
-msgstr ""
+msgstr "Adds Twitter Card meta tags for better Twitter sharing."
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:44
 msgid "Translation cache cleared."
-msgstr ""
+msgstr "Translation cache cleared."
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:88
 msgid "Auto Translation"
-msgstr ""
+msgstr "Auto Translation"
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:95
 msgid "API Endpoint"
-msgstr ""
+msgstr "API Endpoint"
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:119
 msgid "Enable logging"
-msgstr ""
+msgstr "Enable logging"
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:127
 #: includes/Admin/Settings/AutoTranslateSettings.php:180
 msgid "Svuota cache"
-msgstr ""
+msgstr "Svuota cache"
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:138
 msgid "Configure automatic translation service."
-msgstr ""
+msgstr "Configure automatic translation service."
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:155
 msgid "Optional API key for the translation service."
-msgstr ""
+msgstr "Optional API key for the translation service."
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:164
 msgid "Time in seconds to cache translations."
-msgstr ""
+msgstr "Time in seconds to cache translations."
 
 #: includes/Admin/Settings/AutoTranslateSettings.php:172
 msgid "Enable translation logging"
-msgstr ""
+msgstr "Enable translation logging"
 
 #: includes/Admin/Settings/TranslationHelp.php:31
 #: includes/Admin/Settings/TranslationHelp.php:32
 #: includes/Admin/Settings/TranslationHelp.php:45
 msgid "Translation Help"
-msgstr ""
+msgstr "Translation Help"
 
 #. translators: %s: WPML translation modes documentation URL
 #: includes/Admin/Settings/TranslationHelp.php:52
 #, php-format
-msgid "Enable WPML and select the <strong>Translate Everything</strong> mode in <a href=\"%s\" target=\"_blank\">WPML → Settings</a>."
+msgid ""
+"Enable WPML and select the <strong>Translate Everything</strong> mode in <a "
+"href=\"%s\" target=\"_blank\">WPML → Settings</a>."
 msgstr ""
+"Enable WPML and select the <strong>Translate Everything</strong> mode in <a "
+"href=\"%s\" target=\"_blank\">WPML → Settings</a>."
 
 #: includes/Admin/Settings/TranslationHelp.php:59
 msgid "Register dynamic strings with I18nManager::translateString:"
-msgstr ""
+msgstr "Register dynamic strings with I18nManager::translateString:"
 
 #. translators: %s: LibreTranslate URL
 #: includes/Admin/Settings/TranslationHelp.php:67
 #, php-format
-msgid "Configure the automatic translator endpoint (e.g., %1$sLibreTranslate%2$s) in the Auto Translation settings page."
+msgid ""
+"Configure the automatic translator endpoint (e.g., %1$sLibreTranslate%2$s) "
+"in the Auto Translation settings page."
 msgstr ""
+"Configure the automatic translator endpoint (e.g., %1$sLibreTranslate%2$s) "
+"in the Auto Translation settings page."
 
 #. translators: %s: WPML docs URL
 #: includes/Admin/Settings/TranslationHelp.php:80
 #, php-format
 msgid "See the %1$sWPML documentation%2$s for further details."
-msgstr ""
+msgstr "See the %1$sWPML documentation%2$s for further details."
 
 #: includes/Admin/Settings/TranslationHelp.php:87
 msgid "WPML Translate Everything screenshot"
-msgstr ""
+msgstr "WPML Translate Everything screenshot"
 
 #: includes/Admin/Settings/TranslationHelp.php:88
 msgid "Video: WPML Translate Everything overview"
-msgstr ""
+msgstr "Video: WPML Translate Everything overview"
 
-#: includes/Admin/SetupWizard.php:43
-#: includes/Admin/SetupWizard.php:44
+#: includes/Admin/SetupWizard.php:43 includes/Admin/SetupWizard.php:44
 msgid "Setup Wizard"
-msgstr ""
+msgstr "Setup Wizard"
 
 #: includes/Admin/SetupWizard.php:290
 msgid "FP Esperienze Setup Wizard"
-msgstr ""
+msgstr "FP Esperienze Setup Wizard"
 
-#: includes/Admin/SetupWizard.php:300
-#: includes/Admin/SetupWizard.php:393
+#: includes/Admin/SetupWizard.php:300 includes/Admin/SetupWizard.php:393
 msgid "Basic Settings"
-msgstr ""
+msgstr "Basic Settings"
 
 #: includes/Admin/SetupWizard.php:302
 msgid "Brand & PDF"
-msgstr ""
+msgstr "Brand & PDF"
 
-#: includes/Admin/SetupWizard.php:320
-#: includes/Frontend/Shortcodes.php:459
+#: includes/Admin/SetupWizard.php:320 includes/Frontend/Shortcodes.php:459
 msgid "Previous"
-msgstr ""
+msgstr "Previous"
 
 #: includes/Admin/SetupWizard.php:324
 msgid "Skip"
-msgstr ""
+msgstr "Skip"
 
 #: includes/Admin/SetupWizard.php:328
 msgid "Finish Setup"
-msgstr ""
+msgstr "Finish Setup"
 
-#: includes/Admin/SetupWizard.php:328
-#: includes/Frontend/Shortcodes.php:485
+#: includes/Admin/SetupWizard.php:328 includes/Frontend/Shortcodes.php:485
 msgid "Next"
-msgstr ""
+msgstr "Next"
 
-#: includes/Admin/SetupWizard.php:344
-#: includes/Admin/SetupWizard.php:691
+#: includes/Admin/SetupWizard.php:344 includes/Admin/SetupWizard.php:691
 msgid "Upload Logo"
-msgstr ""
+msgstr "Upload Logo"
 
 #: includes/Admin/SetupWizard.php:395
 msgid "Configure the basic settings for your experience booking system."
-msgstr ""
+msgstr "Configure the basic settings for your experience booking system."
 
 #: includes/Admin/SetupWizard.php:401
 msgid "Currency"
-msgstr ""
+msgstr "Currency"
 
 #: includes/Admin/SetupWizard.php:417
 msgid "Default currency for experience pricing."
-msgstr ""
+msgstr "Default currency for experience pricing."
 
 #: includes/Admin/SetupWizard.php:422
 msgid "Timezone"
-msgstr ""
+msgstr "Timezone"
 
 #: includes/Admin/SetupWizard.php:426
 msgid "Use WordPress default"
-msgstr ""
+msgstr "Use WordPress default"
 
 #: includes/Admin/SetupWizard.php:436
 msgid "Timezone for booking schedules and availability."
-msgstr ""
+msgstr "Timezone for booking schedules and availability."
 
-#: includes/Admin/SetupWizard.php:441
-#: includes/ProductType/Experience.php:144
+#: includes/Admin/SetupWizard.php:441 includes/ProductType/Experience.php:144
 msgid "Default Duration (minutes)"
-msgstr ""
+msgstr "Default Duration (minutes)"
 
 #: includes/Admin/SetupWizard.php:445
 msgid "Default duration for new experiences."
-msgstr ""
+msgstr "Default duration for new experiences."
 
 #: includes/Admin/SetupWizard.php:450
 msgid "Default Capacity"
-msgstr ""
+msgstr "Default Capacity"
 
 #: includes/Admin/SetupWizard.php:454
 msgid "Default maximum participants for new experiences."
-msgstr ""
+msgstr "Default maximum participants for new experiences."
 
-#: includes/Admin/SetupWizard.php:459
-#: includes/ProductType/Experience.php:172
+#: includes/Admin/SetupWizard.php:459 includes/ProductType/Experience.php:172
 msgid "Default Language"
-msgstr ""
+msgstr "Default Language"
 
 #: includes/Admin/SetupWizard.php:463
 msgid "English"
-msgstr ""
+msgstr "English"
 
 #: includes/Admin/SetupWizard.php:464
 msgid "Italian"
-msgstr ""
+msgstr "Italian"
 
 #: includes/Admin/SetupWizard.php:466
 msgid "Default language for customer communications."
-msgstr ""
+msgstr "Default language for customer communications."
 
 #: includes/Admin/SetupWizard.php:480
 msgid "Third-Party Integrations"
-msgstr ""
+msgstr "Third-Party Integrations"
 
 #: includes/Admin/SetupWizard.php:482
-msgid "Configure integrations with Google Analytics, Google Ads, Meta Pixel, Brevo, and Google Places. You can skip this step and configure these later in Settings."
+msgid ""
+"Configure integrations with Google Analytics, Google Ads, Meta Pixel, Brevo, "
+"and Google Places. You can skip this step and configure these later in "
+"Settings."
 msgstr ""
+"Configure integrations with Google Analytics, Google Ads, Meta Pixel, Brevo, "
+"and Google Places. You can skip this step and configure these later in "
+"Settings."
 
 #: includes/Admin/SetupWizard.php:493
 msgid "Your GA4 Measurement ID for tracking events and conversions."
-msgstr ""
+msgstr "Your GA4 Measurement ID for tracking events and conversions."
 
 #: includes/Admin/SetupWizard.php:501
 msgid "Enable Enhanced eCommerce tracking"
-msgstr ""
+msgstr "Enable Enhanced eCommerce tracking"
 
 #: includes/Admin/SetupWizard.php:515
 msgid "Your Google Ads Conversion ID for tracking bookings."
-msgstr ""
+msgstr "Your Google Ads Conversion ID for tracking bookings."
 
 #: includes/Admin/SetupWizard.php:524
 msgid "Conversion label for purchase events (optional but recommended)."
-msgstr ""
+msgstr "Conversion label for purchase events (optional but recommended)."
 
 #: includes/Admin/SetupWizard.php:537
 msgid "Your Meta (Facebook) Pixel ID for frontend tracking."
-msgstr ""
+msgstr "Your Meta (Facebook) Pixel ID for frontend tracking."
 
 #: includes/Admin/SetupWizard.php:545
 msgid "Enable Meta Conversions API (server-side tracking)"
-msgstr ""
+msgstr "Enable Meta Conversions API (server-side tracking)"
 
 #: includes/Admin/SetupWizard.php:547
-msgid "Enables server-side tracking for better data accuracy and iOS 14.5+ compliance."
+msgid ""
+"Enables server-side tracking for better data accuracy and iOS 14.5+ "
+"compliance."
 msgstr ""
+"Enables server-side tracking for better data accuracy and iOS 14.5+ "
+"compliance."
 
 #: includes/Admin/SetupWizard.php:556
 msgid "Meta app access token for Conversions API."
-msgstr ""
+msgstr "Meta app access token for Conversions API."
 
 #: includes/Admin/SetupWizard.php:565
 msgid "Dataset ID for Meta Conversions API (found in Events Manager)."
-msgstr ""
+msgstr "Dataset ID for Meta Conversions API (found in Events Manager)."
 
 #: includes/Admin/SetupWizard.php:590
 msgid "Your Brevo API key for email list management."
-msgstr ""
+msgstr "Your Brevo API key for email list management."
 
 #: includes/Admin/SetupWizard.php:619
 msgid "Google Places API key for location and reviews integration."
-msgstr ""
+msgstr "Google Places API key for location and reviews integration."
 
 #: includes/Admin/SetupWizard.php:624
 msgid "Privacy & Consent"
-msgstr ""
+msgstr "Privacy & Consent"
 
 #: includes/Admin/SetupWizard.php:631
 msgid "Enable Consent Mode (GDPR Compliance)"
-msgstr ""
+msgstr "Enable Consent Mode (GDPR Compliance)"
 
 #: includes/Admin/SetupWizard.php:633
 msgid "Requires user consent before loading tracking scripts."
-msgstr ""
+msgstr "Requires user consent before loading tracking scripts."
 
 #: includes/Admin/SetupWizard.php:642
 msgid "Name of cookie that stores consent status."
-msgstr ""
+msgstr "Name of cookie that stores consent status."
 
 #: includes/Admin/SetupWizard.php:647
 msgid "JavaScript Function (Optional)"
-msgstr ""
+msgstr "JavaScript Function (Optional)"
 
 #: includes/Admin/SetupWizard.php:651
-msgid "JavaScript function to check consent status. Leave blank to use cookie only."
+msgid ""
+"JavaScript function to check consent status. Leave blank to use cookie only."
 msgstr ""
+"JavaScript function to check consent status. Leave blank to use cookie only."
 
 #: includes/Admin/SetupWizard.php:679
 msgid "Brand & PDF Settings"
-msgstr ""
+msgstr "Brand & PDF Settings"
 
 #: includes/Admin/SetupWizard.php:681
-msgid "Configure your brand settings for voucher PDFs and customer communications."
+msgid ""
+"Configure your brand settings for voucher PDFs and customer communications."
 msgstr ""
+"Configure your brand settings for voucher PDFs and customer communications."
 
 #: includes/Admin/SetupWizard.php:687
 msgid "PDF Logo"
-msgstr ""
+msgstr "PDF Logo"
 
 #: includes/Admin/SetupWizard.php:697
 msgid "Logo to display on voucher PDFs and emails."
-msgstr ""
+msgstr "Logo to display on voucher PDFs and emails."
 
 #: includes/Admin/SetupWizard.php:706
 msgid "Primary brand color for PDFs and styling."
-msgstr ""
+msgstr "Primary brand color for PDFs and styling."
 
 #: includes/Admin/SetupWizard.php:711
 msgid "Voucher Terms"
-msgstr ""
+msgstr "Voucher Terms"
 
 #: includes/Admin/SetupWizard.php:715
 msgid "Terms and conditions text displayed on vouchers."
-msgstr ""
+msgstr "Terms and conditions text displayed on vouchers."
 
-#: includes/Admin/SystemStatus.php:33
-#: includes/Admin/SystemStatus.php:34
+#: includes/Admin/SystemStatus.php:33 includes/Admin/SystemStatus.php:34
 msgid "System Status"
-msgstr ""
+msgstr "System Status"
 
 #: includes/Admin/SystemStatus.php:89
 msgid "FP Esperienze System Status"
-msgstr ""
+msgstr "FP Esperienze System Status"
 
 #: includes/Admin/SystemStatus.php:98
 msgid "Database tables have been created successfully."
-msgstr ""
+msgstr "Database tables have been created successfully."
 
 #: includes/Admin/SystemStatus.php:101
 msgid "Rewrite rules have been flushed successfully."
-msgstr ""
+msgstr "Rewrite rules have been flushed successfully."
 
 #: includes/Admin/SystemStatus.php:185
 msgid "System Information"
-msgstr ""
+msgstr "System Information"
 
 #: includes/Admin/SystemStatus.php:188
 msgid "WordPress Version"
-msgstr ""
+msgstr "WordPress Version"
 
-#: includes/Admin/SystemStatus.php:192
-#: includes/Admin/SystemStatus.php:204
+#: includes/Admin/SystemStatus.php:192 includes/Admin/SystemStatus.php:204
 #: includes/Admin/SystemStatus.php:218
 msgid "Compatible"
-msgstr ""
+msgstr "Compatible"
 
 #: includes/Admin/SystemStatus.php:194
 msgid "Requires WordPress 6.5+"
-msgstr ""
+msgstr "Requires WordPress 6.5+"
 
 #: includes/Admin/SystemStatus.php:199
 msgid "WooCommerce Version"
-msgstr ""
+msgstr "WooCommerce Version"
 
 #: includes/Admin/SystemStatus.php:206
 msgid "Requires WooCommerce 8.0+"
-msgstr ""
+msgstr "Requires WooCommerce 8.0+"
 
 #: includes/Admin/SystemStatus.php:209
 msgid "WooCommerce not detected"
-msgstr ""
+msgstr "WooCommerce not detected"
 
 #: includes/Admin/SystemStatus.php:214
 msgid "PHP Version"
-msgstr ""
+msgstr "PHP Version"
 
 #: includes/Admin/SystemStatus.php:220
 msgid "Requires PHP 8.1+"
-msgstr ""
+msgstr "Requires PHP 8.1+"
 
 #: includes/Admin/SystemStatus.php:225
 msgid "Plugin Version"
-msgstr ""
+msgstr "Plugin Version"
 
 #: includes/Admin/SystemStatus.php:229
 msgid "WordPress Timezone"
-msgstr ""
+msgstr "WordPress Timezone"
 
 #: includes/Admin/SystemStatus.php:286
 msgid "System Checks"
-msgstr ""
+msgstr "System Checks"
 
-#: includes/Admin/SystemStatus.php:339
-#: includes/Admin/SystemStatus.php:346
+#: includes/Admin/SystemStatus.php:339 includes/Admin/SystemStatus.php:346
 msgid "Database Tables"
-msgstr ""
+msgstr "Database Tables"
 
 #: includes/Admin/SystemStatus.php:341
 msgid "All required tables present"
-msgstr ""
+msgstr "All required tables present"
 
 #: includes/Admin/SystemStatus.php:348
 #, php-format
 msgid "%d missing tables"
-msgstr ""
+msgstr "%d missing tables"
 
 #: includes/Admin/SystemStatus.php:349
 msgid "Missing tables: "
-msgstr ""
+msgstr "Missing tables: "
 
 #: includes/Admin/SystemStatus.php:351
 msgid "Create Tables"
-msgstr ""
+msgstr "Create Tables"
 
-#: includes/Admin/SystemStatus.php:366
-#: includes/Admin/SystemStatus.php:374
+#: includes/Admin/SystemStatus.php:366 includes/Admin/SystemStatus.php:374
 msgid "WordPress Cron"
-msgstr ""
+msgstr "WordPress Cron"
 
 #: includes/Admin/SystemStatus.php:368
 msgid "Disabled via DISABLE_WP_CRON"
-msgstr ""
+msgstr "Disabled via DISABLE_WP_CRON"
 
 #: includes/Admin/SystemStatus.php:369
 msgid "WordPress cron is disabled. Scheduled tasks may not work properly."
-msgstr ""
+msgstr "WordPress cron is disabled. Scheduled tasks may not work properly."
 
 #: includes/Admin/SystemStatus.php:376
 msgid "Enabled"
-msgstr ""
+msgstr "Enabled"
 
 #: includes/Admin/SystemStatus.php:394
-msgid "SSL certificate validation failed. Please verify your server configuration."
+msgid ""
+"SSL certificate validation failed. Please verify your server configuration."
 msgstr ""
+"SSL certificate validation failed. Please verify your server configuration."
 
-#: includes/Admin/SystemStatus.php:398
-#: includes/Admin/SystemStatus.php:408
+#: includes/Admin/SystemStatus.php:398 includes/Admin/SystemStatus.php:408
 #: includes/Admin/SystemStatus.php:415
 msgid "Remote Requests"
-msgstr ""
+msgstr "Remote Requests"
 
 #: includes/Admin/SystemStatus.php:400
 msgid "Failed"
-msgstr ""
+msgstr "Failed"
 
 #: includes/Admin/SystemStatus.php:410
 #, php-format
 msgid "Unexpected response code: %d"
-msgstr ""
+msgstr "Unexpected response code: %d"
 
 #: includes/Admin/SystemStatus.php:417
 msgid "Working"
-msgstr ""
+msgstr "Working"
 
-#: includes/Admin/SystemStatus.php:430
-#: includes/Admin/SystemStatus.php:438
+#: includes/Admin/SystemStatus.php:430 includes/Admin/SystemStatus.php:438
 msgid "File Permissions"
-msgstr ""
+msgstr "File Permissions"
 
 #: includes/Admin/SystemStatus.php:432
 msgid "Uploads directory not writable"
-msgstr ""
+msgstr "Uploads directory not writable"
 
 #: includes/Admin/SystemStatus.php:433
-msgid "PDF vouchers cannot be generated without write access to uploads directory."
+msgid ""
+"PDF vouchers cannot be generated without write access to uploads directory."
 msgstr ""
+"PDF vouchers cannot be generated without write access to uploads directory."
 
 #: includes/Admin/SystemStatus.php:440
 msgid "Uploads directory writable"
-msgstr ""
+msgstr "Uploads directory writable"
 
-#: includes/Admin/SystemStatus.php:459
-#: includes/Admin/SystemStatus.php:467
+#: includes/Admin/SystemStatus.php:459 includes/Admin/SystemStatus.php:467
 msgid "PHP Extensions"
-msgstr ""
+msgstr "PHP Extensions"
 
 #: includes/Admin/SystemStatus.php:461
 #, php-format
 msgid "%d missing extensions"
-msgstr ""
+msgstr "%d missing extensions"
 
 #: includes/Admin/SystemStatus.php:462
 msgid "Missing extensions: "
-msgstr ""
+msgstr "Missing extensions: "
 
 #: includes/Admin/SystemStatus.php:469
 msgid "All required extensions loaded"
-msgstr ""
+msgstr "All required extensions loaded"
 
 #: includes/Admin/SystemStatus.php:492
 msgid "Database Information"
-msgstr ""
+msgstr "Database Information"
 
 #: includes/Admin/SystemStatus.php:504
 #, php-format
 msgid "%d records"
-msgstr ""
+msgstr "%d records"
 
 #: includes/Admin/SystemStatus.php:507
 msgid "Table missing"
-msgstr ""
+msgstr "Table missing"
 
 #: includes/Admin/SystemStatus.php:548
 msgid "Integration Status"
-msgstr ""
+msgstr "Integration Status"
 
 #: includes/Admin/SystemStatus.php:556
 msgid "Configured"
-msgstr ""
+msgstr "Configured"
 
 #: includes/Admin/SystemStatus.php:558
 msgid "Not configured"
-msgstr ""
+msgstr "Not configured"
 
 #: includes/Admin/SystemStatus.php:561
 msgid "Configure"
-msgstr ""
+msgstr "Configure"
 
 #: includes/Admin/SystemStatus.php:565
 msgid "Documentation"
-msgstr ""
+msgstr "Documentation"
 
 #: includes/AI/AIFeaturesManager.php:217
 msgid "AI settings updated successfully"
-msgstr ""
+msgstr "AI settings updated successfully"
 
 #: includes/AI/AIFeaturesManager.php:995
 msgid "Customers who booked this also booked"
-msgstr ""
+msgstr "Customers who booked this also booked"
 
 #: includes/AI/AIFeaturesManager.php:996
 msgid "Similar experiences you might enjoy"
-msgstr ""
+msgstr "Similar experiences you might enjoy"
 
 #: includes/AI/AIFeaturesManager.php:997
 msgid "Recommended for you"
-msgstr ""
+msgstr "Recommended for you"
 
 #: includes/AI/AIFeaturesManager.php:998
 msgid "Similar experiences"
-msgstr ""
+msgstr "Similar experiences"
 
 #: includes/AI/AIFeaturesManager.php:1001
 msgid "Recommended"
-msgstr ""
+msgstr "Recommended"
 
 #: includes/AI/AIFeaturesManager.php:1010
 msgid "You might also like"
-msgstr ""
+msgstr "You might also like"
 
 #: includes/Booking/BookingManager.php:163
 #, php-format
 msgid "Created from order #%d"
-msgstr ""
+msgstr "Created from order #%d"
 
 #: includes/Booking/BookingManager.php:409
 msgid "Only confirmed bookings can be rescheduled."
-msgstr ""
+msgstr "Only confirmed bookings can be rescheduled."
 
 #: includes/Booking/BookingManager.php:452
 msgid "Failed to update booking."
-msgstr ""
+msgstr "Failed to update booking."
 
 #: includes/Booking/BookingManager.php:464
 msgid "Booking rescheduled successfully."
-msgstr ""
+msgstr "Booking rescheduled successfully."
 
 #: includes/Booking/BookingManager.php:483
 msgid "Invalid date/time format."
-msgstr ""
+msgstr "Invalid date/time format."
 
-#: includes/Booking/BookingManager.php:494
-#: includes/Booking/Cart_Hooks.php:182
+#: includes/Booking/BookingManager.php:494 includes/Booking/Cart_Hooks.php:182
 #, php-format
-msgid "This time slot is too close to departure. Please book at least %d minutes in advance."
+msgid ""
+"This time slot is too close to departure. Please book at least %d minutes in "
+"advance."
 msgstr ""
+"This time slot is too close to departure. Please book at least %d minutes in "
+"advance."
 
 #: includes/Booking/BookingManager.php:528
 msgid "Time slot not available."
-msgstr ""
+msgstr "Time slot not available."
 
-#: includes/Booking/BookingManager.php:536
-#: includes/Data/HoldManager.php:379
+#: includes/Booking/BookingManager.php:536 includes/Data/HoldManager.php:379
 #, php-format
 msgid "Not enough capacity. Only %d spots available."
-msgstr ""
+msgstr "Not enough capacity. Only %d spots available."
 
 #: includes/Booking/BookingManager.php:571
 #, php-format
 msgid "Booking Rescheduled - %s"
-msgstr ""
+msgstr "Booking Rescheduled - %s"
 
 #: includes/Booking/BookingManager.php:574
 #, php-format
-msgid "Your booking has been rescheduled:\\n\\nProduct: %s\\nOriginal Date: %s at %s\\nNew Date: %s at %s\\n\\nOrder: #%d\\nBooking ID: %d"
+msgid ""
+"Your booking has been rescheduled:\\n\\nProduct: %s\\nOriginal Date: %s at "
+"%s\\nNew Date: %s at %s\\n\\nOrder: #%d\\nBooking ID: %d"
 msgstr ""
+"Your booking has been rescheduled:\\n\\nProduct: %s\\nOriginal Date: %s at "
+"%s\\nNew Date: %s at %s\\n\\nOrder: #%d\\nBooking ID: %d"
 
 #: includes/Booking/BookingManager.php:609
 msgid "Only confirmed bookings can be cancelled."
-msgstr ""
+msgstr "Only confirmed bookings can be cancelled."
 
 #: includes/Booking/BookingManager.php:622
 msgid "Invalid booking date/time."
-msgstr ""
+msgstr "Invalid booking date/time."
 
 #: includes/Booking/BookingManager.php:639
 msgid "Free cancellation available."
-msgstr ""
+msgstr "Free cancellation available."
 
 #: includes/Booking/BookingManager.php:640
 #, php-format
 msgid "Cancellation fee: %s%%"
-msgstr ""
+msgstr "Cancellation fee: %s%%"
 
 #: includes/Booking/Cart_Hooks.php:71
 msgid "Invalid extras payload"
-msgstr ""
+msgstr "Invalid extras payload"
 
 #: includes/Booking/Cart_Hooks.php:145
 msgid "Please select a time slot."
-msgstr ""
+msgstr "Please select a time slot."
 
 #: includes/Booking/Cart_Hooks.php:150
 msgid "Please select at least one participant."
-msgstr ""
+msgstr "Please select at least one participant."
 
 #: includes/Booking/Cart_Hooks.php:157
 msgid "Please enter the recipient name for gift purchase."
-msgstr ""
+msgstr "Please enter the recipient name for gift purchase."
 
 #: includes/Booking/Cart_Hooks.php:162
 msgid "Please enter a valid recipient email for gift purchase."
-msgstr ""
+msgstr "Please enter a valid recipient email for gift purchase."
 
 #: includes/Booking/Cart_Hooks.php:170
 msgid "Invalid time slot format."
-msgstr ""
+msgstr "Invalid time slot format."
 
 #: includes/Booking/Cart_Hooks.php:209
 #, php-format
-msgid "Only %d spots available for this time slot. You selected %d participants."
+msgid ""
+"Only %d spots available for this time slot. You selected %d participants."
 msgstr ""
+"Only %d spots available for this time slot. You selected %d participants."
 
-#: includes/Booking/Cart_Hooks.php:251
-#: includes/Booking/Cart_Hooks.php:368
+#: includes/Booking/Cart_Hooks.php:251 includes/Booking/Cart_Hooks.php:368
 msgid "Time Slot"
-msgstr ""
+msgstr "Time Slot"
 
-#: includes/Booking/Cart_Hooks.php:258
-#: includes/Booking/Cart_Hooks.php:376
-#: includes/Frontend/Shortcodes.php:346
-#: includes/ProductType/Experience.php:513
+#: includes/Booking/Cart_Hooks.php:258 includes/Booking/Cart_Hooks.php:376
+#: includes/Frontend/Shortcodes.php:346 includes/ProductType/Experience.php:513
 #: includes/ProductType/Experience.php:726
-#: includes/ProductType/Experience.php:873
-#: templates/admin/reports.php:57
-#: templates/single-experience.php:572
-#: assets/js/archive-block.js:87
+#: includes/ProductType/Experience.php:873 templates/admin/reports.php:57
+#: templates/single-experience.php:572 assets/js/archive-block.js:87
 msgid "Language"
-msgstr ""
+msgstr "Language"
 
-#: includes/Booking/Cart_Hooks.php:285
-#: includes/Booking/Cart_Hooks.php:393
+#: includes/Booking/Cart_Hooks.php:285 includes/Booking/Cart_Hooks.php:393
 #, php-format
 msgid "Qty: %d"
-msgstr ""
+msgstr "Qty: %d"
 
-#: includes/Booking/Cart_Hooks.php:297
-#: includes/Booking/Cart_Hooks.php:403
+#: includes/Booking/Cart_Hooks.php:297 includes/Booking/Cart_Hooks.php:403
 msgid "Gift Purchase"
-msgstr ""
+msgstr "Gift Purchase"
 
-#: includes/Booking/Cart_Hooks.php:308
-#: templates/single-experience.php:128
-#: templates/single-experience.php:531
-#: templates/single-experience.php:877
+#: includes/Booking/Cart_Hooks.php:308 templates/single-experience.php:128
+#: templates/single-experience.php:531 templates/single-experience.php:877
 msgid "From"
-msgstr ""
+msgstr "From"
 
-#: includes/Booking/Cart_Hooks.php:315
-#: includes/Booking/Cart_Hooks.php:415
+#: includes/Booking/Cart_Hooks.php:315 includes/Booking/Cart_Hooks.php:415
 msgid "Send Date"
-msgstr ""
+msgstr "Send Date"
 
-#: includes/Booking/Cart_Hooks.php:334
-#: includes/Booking/Cart_Hooks.php:423
+#: includes/Booking/Cart_Hooks.php:334 includes/Booking/Cart_Hooks.php:423
 msgid "Voucher Applied"
-msgstr ""
+msgstr "Voucher Applied"
 
-#: includes/Booking/Cart_Hooks.php:339
-#: templates/voucher-form.php:55
+#: includes/Booking/Cart_Hooks.php:339 templates/voucher-form.php:55
 msgid "Full discount"
-msgstr ""
+msgstr "Full discount"
 
-#: includes/Booking/Cart_Hooks.php:340
-#: templates/voucher-form.php:56
+#: includes/Booking/Cart_Hooks.php:340 templates/voucher-form.php:56
 #, php-format
 msgid "Up to %s"
-msgstr ""
+msgstr "Up to %s"
 
 #: includes/Booking/Cart_Hooks.php:372
 msgid "Meeting Point ID"
-msgstr ""
+msgstr "Meeting Point ID"
 
 #: includes/Booking/Cart_Hooks.php:404
 msgid "Recipient Name"
-msgstr ""
+msgstr "Recipient Name"
 
 #: includes/Booking/Cart_Hooks.php:405
 msgid "Recipient Email"
-msgstr ""
+msgstr "Recipient Email"
 
 #: includes/Booking/Cart_Hooks.php:408
 msgid "Sender Name"
-msgstr ""
+msgstr "Sender Name"
 
 #: includes/Booking/Cart_Hooks.php:412
 msgid "Gift Message"
-msgstr ""
+msgstr "Gift Message"
 
 #: includes/Booking/Cart_Hooks.php:508
-msgid "Full discount vouchers cannot be combined with other coupons. The voucher has been removed."
+msgid ""
+"Full discount vouchers cannot be combined with other coupons. The voucher "
+"has been removed."
 msgstr ""
+"Full discount vouchers cannot be combined with other coupons. The voucher "
+"has been removed."
 
 #: includes/Booking/Cart_Hooks.php:547
 msgid "Too many voucher redemption attempts. Please try again in a minute."
-msgstr ""
+msgstr "Too many voucher redemption attempts. Please try again in a minute."
 
-#: includes/Booking/Cart_Hooks.php:556
-#: assets/js/frontend.js:96
+#: includes/Booking/Cart_Hooks.php:556 assets/js/frontend.js:96
 msgid "Please enter a voucher code."
-msgstr ""
+msgstr "Please enter a voucher code."
 
 #: includes/Booking/Cart_Hooks.php:573
-msgid "Full discount vouchers cannot be combined with other coupons. Please remove existing coupons first."
+msgid ""
+"Full discount vouchers cannot be combined with other coupons. Please remove "
+"existing coupons first."
 msgstr ""
+"Full discount vouchers cannot be combined with other coupons. Please remove "
+"existing coupons first."
 
 #: includes/Booking/Cart_Hooks.php:595
 msgid "Voucher applied successfully!"
-msgstr ""
+msgstr "Voucher applied successfully!"
 
 #: includes/Booking/Cart_Hooks.php:610
 msgid "Invalid cart item."
-msgstr ""
+msgstr "Invalid cart item."
 
 #: includes/Booking/Cart_Hooks.php:623
 msgid "Voucher removed successfully."
-msgstr ""
+msgstr "Voucher removed successfully."
 
 #: includes/Booking/Cart_Hooks.php:648
 #, php-format
 msgid "Voucher %s redeemed for this order."
-msgstr ""
+msgstr "Voucher %s redeemed for this order."
 
 #: includes/Booking/Cart_Hooks.php:675
 #, php-format
 msgid "Voucher %s restored to active status due to order cancellation/refund."
-msgstr ""
+msgstr "Voucher %s restored to active status due to order cancellation/refund."
 
 #: includes/Booking/Cart_Hooks.php:730
 msgid "Full experience discount"
-msgstr ""
+msgstr "Full experience discount"
 
 #: includes/Booking/Cart_Hooks.php:737
 #, php-format
 msgid "Discount up to %s"
-msgstr ""
+msgstr "Discount up to %s"
 
 #: includes/Booking/Cart_Hooks.php:790
 #, php-format
-msgid "Full discount vouchers cannot be combined with coupon \"%s\". Conflicting vouchers have been removed."
+msgid ""
+"Full discount vouchers cannot be combined with coupon \"%s\". Conflicting "
+"vouchers have been removed."
 msgstr ""
+"Full discount vouchers cannot be combined with coupon \"%s\". Conflicting "
+"vouchers have been removed."
 
 #: includes/Booking/Cart_Hooks.php:890
 msgid "Adult Price Adjustments:"
-msgstr ""
+msgstr "Adult Price Adjustments:"
 
 #: includes/Booking/Cart_Hooks.php:905
 msgid "Child Price Adjustments:"
-msgstr ""
+msgstr "Child Price Adjustments:"
 
-#: includes/Booking/Cart_Hooks.php:922
-#: includes/ProductType/Experience.php:124
+#: includes/Booking/Cart_Hooks.php:922 includes/ProductType/Experience.php:124
 msgid "Dynamic Pricing"
-msgstr ""
+msgstr "Dynamic Pricing"
 
 #: includes/Core/CapabilityManager.php:134
 msgid "Permission Denied"
-msgstr ""
+msgstr "Permission Denied"
 
-#: includes/Core/Plugin.php:338
-#: assets/js/frontend.js:440
+#: includes/Core/Plugin.php:338 assets/js/frontend.js:440
 msgid "Failed to load availability."
-msgstr ""
+msgstr "Failed to load availability."
 
-#: includes/Core/Plugin.php:339
-#: assets/js/booking-widget.js:528
+#: includes/Core/Plugin.php:339 assets/js/booking-widget.js:528
 msgid "Booking system temporarily unavailable. Please try again."
-msgstr ""
+msgstr "Booking system temporarily unavailable. Please try again."
 
-#: includes/Core/Plugin.php:340
-#: assets/js/booking-widget.js:303
+#: includes/Core/Plugin.php:340 assets/js/booking-widget.js:303
 msgid "No availability for this date."
-msgstr ""
+msgstr "No availability for this date."
 
-#: includes/Core/Plugin.php:341
-#: assets/js/booking-widget.js:308
+#: includes/Core/Plugin.php:341 assets/js/booking-widget.js:308
 msgid "spots left"
-msgstr ""
+msgstr "spots left"
 
-#: includes/Core/Plugin.php:342
-#: assets/js/booking-widget.js:309
+#: includes/Core/Plugin.php:342 assets/js/booking-widget.js:309
 msgid "Sold out"
-msgstr ""
+msgstr "Sold out"
 
-#: includes/Core/Plugin.php:343
-#: assets/js/booking-widget.js:266
+#: includes/Core/Plugin.php:343 assets/js/booking-widget.js:266
 msgid "Loading available times..."
-msgstr ""
+msgstr "Loading available times..."
 
 #: includes/Core/Plugin.php:451
 msgid "No data available"
-msgstr ""
+msgstr "No data available"
 
-#: includes/Core/Plugin.php:452
-#: includes/ProductType/Experience.php:2457
-#: templates/admin/reports.php:85
-#: templates/admin/reports.php:92
-#: templates/admin/reports.php:99
-#: templates/admin/reports.php:106
-#: templates/admin/reports.php:136
-#: templates/admin/reports.php:146
-#: templates/admin/reports.php:154
-#: assets/js/admin.js:2582
+#: includes/Core/Plugin.php:452 includes/ProductType/Experience.php:2457
+#: templates/admin/reports.php:85 templates/admin/reports.php:92
+#: templates/admin/reports.php:99 templates/admin/reports.php:106
+#: templates/admin/reports.php:136 templates/admin/reports.php:146
+#: templates/admin/reports.php:154 assets/js/admin.js:2582
 #: assets/js/admin.js:2591
 msgid "Loading..."
-msgstr ""
+msgstr "Loading..."
 
 #: includes/Core/Plugin.php:453
 msgid "Failed to load data"
-msgstr ""
+msgstr "Failed to load data"
 
 #: includes/Core/Plugin.php:579
 msgid "Every 5 Minutes (FP Esperienze)"
-msgstr ""
+msgstr "Every 5 Minutes (FP Esperienze)"
 
 #: includes/Core/RateLimiter.php:112
 msgid "Rate limit exceeded. Please try again later."
-msgstr ""
+msgstr "Rate limit exceeded. Please try again later."
 
 #: includes/Core/WebhookManager.php:324
 msgid "Webhook test successful"
-msgstr ""
+msgstr "Webhook test successful"
 
 #: includes/Core/WebhookManager.php:325
 #, php-format
 msgid "Webhook test failed with status %d"
-msgstr ""
+msgstr "Webhook test failed with status %d"
 
 #: includes/Data/DynamicPricingHooks.php:110
 #: includes/Data/DynamicPricingHooks.php:149
 #: includes/Data/DynamicPricingHooks.php:168
 msgid "Permission denied."
-msgstr ""
+msgstr "Permission denied."
 
 #: includes/Data/DynamicPricingHooks.php:134
 msgid "Pricing rule saved successfully."
-msgstr ""
+msgstr "Pricing rule saved successfully."
 
 #: includes/Data/DynamicPricingHooks.php:138
 msgid "Failed to save pricing rule."
-msgstr ""
+msgstr "Failed to save pricing rule."
 
 #: includes/Data/DynamicPricingHooks.php:155
 msgid "Pricing rule deleted successfully."
-msgstr ""
+msgstr "Pricing rule deleted successfully."
 
 #: includes/Data/DynamicPricingHooks.php:157
 msgid "Failed to delete pricing rule."
-msgstr ""
+msgstr "Failed to delete pricing rule."
 
 #: includes/Data/HoldManager.php:44
 msgid "Holds system disabled"
-msgstr ""
+msgstr "Holds system disabled"
 
 #: includes/Data/HoldManager.php:55
 msgid "Invalid session"
-msgstr ""
+msgstr "Invalid session"
 
-#: includes/Data/HoldManager.php:61
-#: includes/Data/HoldManager.php:241
+#: includes/Data/HoldManager.php:61 includes/Data/HoldManager.php:241
 #: includes/Data/HoldManager.php:351
 msgid "Invalid slot format"
-msgstr ""
+msgstr "Invalid slot format"
 
 #: includes/Data/HoldManager.php:90
 msgid "Failed to create hold"
-msgstr ""
+msgstr "Failed to create hold"
 
 #: includes/Data/HoldManager.php:99
 #, php-format
 msgid "Spots reserved for %d minutes"
-msgstr ""
+msgstr "Spots reserved for %d minutes"
 
 #: includes/Data/HoldManager.php:265
 msgid "Hold expired or not found. Please try again."
-msgstr ""
+msgstr "Hold expired or not found. Please try again."
 
 #: includes/Data/HoldManager.php:275
 msgid "Hold quantity insufficient for booking."
-msgstr ""
+msgstr "Hold quantity insufficient for booking."
 
-#: includes/Data/HoldManager.php:290
-#: includes/Data/HoldManager.php:397
+#: includes/Data/HoldManager.php:290 includes/Data/HoldManager.php:397
 msgid "Failed to create booking."
-msgstr ""
+msgstr "Failed to create booking."
 
 #: includes/Data/HoldManager.php:307
 msgid "Failed to remove hold after booking creation."
-msgstr ""
+msgstr "Failed to remove hold after booking creation."
 
-#: includes/Data/HoldManager.php:326
-#: includes/Data/HoldManager.php:409
+#: includes/Data/HoldManager.php:326 includes/Data/HoldManager.php:409
 msgid "Booking created successfully."
-msgstr ""
+msgstr "Booking created successfully."
 
-#: includes/Data/HoldManager.php:333
-#: includes/Data/HoldManager.php:416
+#: includes/Data/HoldManager.php:333 includes/Data/HoldManager.php:416
 msgid "Transaction failed. Please try again."
-msgstr ""
+msgstr "Transaction failed. Please try again."
 
 #: includes/Data/ICSGenerator.php:59
 #, php-format
 msgid "Participants: %d adults, %d children"
-msgstr ""
+msgstr "Participants: %d adults, %d children"
 
 #: includes/Data/ICSGenerator.php:63
 msgid "Notes: "
-msgstr ""
+msgstr "Notes: "
 
 #: includes/Data/ICSGenerator.php:246
 #, php-format
 msgid "Booking ID: %d"
-msgstr ""
+msgstr "Booking ID: %d"
 
 #: includes/Data/MeetingPointManager.php:232
 msgid "Select a meeting point"
-msgstr ""
+msgstr "Select a meeting point"
 
 #: includes/Data/NotificationManager.php:103
 #, php-format
 msgid "[%s] New Booking: %s"
-msgstr ""
+msgstr "[%s] New Booking: %s"
 
 #: includes/Data/NotificationManager.php:162
 #, php-format
 msgid "New Booking - %s"
-msgstr ""
+msgstr "New Booking - %s"
 
-#: includes/Data/NotificationManager.php:166
-#: assets/js/admin.js:242
+#: includes/Data/NotificationManager.php:166 assets/js/admin.js:242
 msgid "Booking Details"
-msgstr ""
+msgstr "Booking Details"
 
 #: includes/Data/NotificationManager.php:167
-#: includes/Data/VoucherManager.php:367
-#: includes/PDF/Voucher_Pdf.php:269
+#: includes/Data/VoucherManager.php:367 includes/PDF/Voucher_Pdf.php:269
 msgid "Experience:"
-msgstr ""
+msgstr "Experience:"
 
 #: includes/Data/NotificationManager.php:168
 msgid "Date:"
-msgstr ""
+msgstr "Date:"
 
 #: includes/Data/NotificationManager.php:169
 msgid "Time:"
-msgstr ""
+msgstr "Time:"
 
 #: includes/Data/NotificationManager.php:170
 msgid "Participants:"
-msgstr ""
+msgstr "Participants:"
 
 #: includes/Data/NotificationManager.php:171
 #, php-format
 msgid "%d adults, %d children"
-msgstr ""
+msgstr "%d adults, %d children"
 
 #: includes/Data/NotificationManager.php:175
 msgid "Meeting Point:"
-msgstr ""
+msgstr "Meeting Point:"
 
 #: includes/Data/NotificationManager.php:182
 msgid "Booking ID:"
-msgstr ""
+msgstr "Booking ID:"
 
 #: includes/Data/NotificationManager.php:183
 msgid "Order ID:"
-msgstr ""
+msgstr "Order ID:"
 
 #: includes/Data/NotificationManager.php:187
 msgid "Customer Information"
-msgstr ""
+msgstr "Customer Information"
 
 #: includes/Data/NotificationManager.php:188
 msgid "Name:"
-msgstr ""
+msgstr "Name:"
 
 #: includes/Data/NotificationManager.php:189
 msgid "Email:"
-msgstr ""
+msgstr "Email:"
 
 #: includes/Data/NotificationManager.php:192
 msgid "Phone:"
-msgstr ""
+msgstr "Phone:"
 
 #: includes/Data/NotificationManager.php:196
 msgid "Customer Notes:"
-msgstr ""
+msgstr "Customer Notes:"
 
 #: includes/Data/NotificationManager.php:206
 msgid "View Bookings"
-msgstr ""
+msgstr "View Bookings"
 
 #: includes/Data/NotificationManager.php:211
 msgid "View Order"
-msgstr ""
+msgstr "View Order"
 
 #: includes/Data/NotificationManager.php:216
 #, php-format
 msgid "This notification was sent automatically by %s"
-msgstr ""
+msgstr "This notification was sent automatically by %s"
 
 #: includes/Data/NotificationManager.php:279
 #, php-format
 msgid "Booking #%d ICS calendar access: %s"
-msgstr ""
+msgstr "Booking #%d ICS calendar access: %s"
 
 #: includes/Data/VoucherManager.php:194
 #, php-format
 msgid "You have received a gift voucher from %s"
-msgstr ""
+msgstr "You have received a gift voucher from %s"
 
 #: includes/Data/VoucherManager.php:237
 #, php-format
 msgid "Gift voucher sent: %s"
-msgstr ""
+msgstr "Gift voucher sent: %s"
 
 #: includes/Data/VoucherManager.php:286
 msgid "You have received a gift voucher!"
-msgstr ""
+msgstr "You have received a gift voucher!"
 
-#: includes/Data/VoucherManager.php:289
-#: includes/Data/VoucherManager.php:358
+#: includes/Data/VoucherManager.php:289 includes/Data/VoucherManager.php:358
 #, php-format
 msgid "Hi %s,"
-msgstr ""
+msgstr "Hi %s,"
 
 #: includes/Data/VoucherManager.php:295
 #, php-format
 msgid "%s has sent you a gift voucher for an amazing experience!"
-msgstr ""
+msgstr "%s has sent you a gift voucher for an amazing experience!"
 
 #: includes/Data/VoucherManager.php:299
 msgid "You have received a gift voucher for an amazing experience!"
-msgstr ""
+msgstr "You have received a gift voucher for an amazing experience!"
 
-#: includes/Data/VoucherManager.php:304
-#: includes/PDF/Voucher_Pdf.php:285
+#: includes/Data/VoucherManager.php:304 includes/PDF/Voucher_Pdf.php:285
 msgid "Personal Message:"
-msgstr ""
+msgstr "Personal Message:"
 
 #: includes/Data/VoucherManager.php:313
 #, php-format
 msgid "Valid until: %s"
-msgstr ""
+msgstr "Valid until: %s"
 
 #: includes/Data/VoucherManager.php:319
-msgid "To redeem your voucher, visit our website and use the code above during checkout. You can also present the attached PDF with the QR code."
+msgid ""
+"To redeem your voucher, visit our website and use the code above during "
+"checkout. You can also present the attached PDF with the QR code."
 msgstr ""
+"To redeem your voucher, visit our website and use the code above during "
+"checkout. You can also present the attached PDF with the QR code."
 
 #: includes/Data/VoucherManager.php:324
 msgid "Book Your Experience"
-msgstr ""
+msgstr "Book Your Experience"
 
-#: includes/Data/VoucherManager.php:328
-#: includes/Data/VoucherManager.php:375
+#: includes/Data/VoucherManager.php:328 includes/Data/VoucherManager.php:375
 #, php-format
 msgid "This email was sent by %s"
-msgstr ""
+msgstr "This email was sent by %s"
 
 #: includes/Data/VoucherManager.php:355
 msgid "Gift voucher confirmation"
-msgstr ""
+msgstr "Gift voucher confirmation"
 
 #: includes/Data/VoucherManager.php:362
 msgid "Your gift voucher has been successfully created and sent!"
-msgstr ""
+msgstr "Your gift voucher has been successfully created and sent!"
 
 #: includes/Data/VoucherManager.php:365
 msgid "Gift Details:"
-msgstr ""
+msgstr "Gift Details:"
 
 #: includes/Data/VoucherManager.php:366
 msgid "Recipient:"
-msgstr ""
+msgstr "Recipient:"
 
 #: includes/Data/VoucherManager.php:368
 msgid "Voucher Code:"
-msgstr ""
+msgstr "Voucher Code:"
 
 #: includes/Data/VoucherManager.php:369
 msgid "Valid Until:"
-msgstr ""
+msgstr "Valid Until:"
 
 #: includes/Data/VoucherManager.php:372
 msgid "A copy of the voucher PDF is attached to this email for your records."
-msgstr ""
+msgstr "A copy of the voucher PDF is attached to this email for your records."
 
 #: includes/Data/VoucherManager.php:412
 #, php-format
 msgid "Missing required field: %s"
-msgstr ""
+msgstr "Missing required field: %s"
 
 #: includes/Data/VoucherManager.php:420
 msgid "Invalid product ID or product is not an experience."
-msgstr ""
+msgstr "Invalid product ID or product is not an experience."
 
 #: includes/Data/VoucherManager.php:426
 msgid "Invalid recipient email address."
-msgstr ""
+msgstr "Invalid recipient email address."
 
 #: includes/Data/VoucherManager.php:433
 msgid "Invalid expiration date format. Use Y-m-d format."
-msgstr ""
+msgstr "Invalid expiration date format. Use Y-m-d format."
 
 #: includes/Data/VoucherManager.php:479
 msgid "Failed to create voucher in database."
-msgstr ""
+msgstr "Failed to create voucher in database."
 
 #: includes/Data/VoucherManager.php:488
 msgid "Voucher created successfully."
-msgstr ""
+msgstr "Voucher created successfully."
 
 #: includes/Data/VoucherManager.php:613
 msgid "Invalid voucher code."
-msgstr ""
+msgstr "Invalid voucher code."
 
 #: includes/Data/VoucherManager.php:621
 msgid "This voucher has already been used."
-msgstr ""
+msgstr "This voucher has already been used."
 
-#: includes/Data/VoucherManager.php:624
-#: includes/Data/VoucherManager.php:644
+#: includes/Data/VoucherManager.php:624 includes/Data/VoucherManager.php:644
 msgid "This voucher has expired."
-msgstr ""
+msgstr "This voucher has expired."
 
 #: includes/Data/VoucherManager.php:627
 msgid "This voucher has been voided."
-msgstr ""
+msgstr "This voucher has been voided."
 
 #: includes/Data/VoucherManager.php:630
 msgid "This voucher is not valid."
-msgstr ""
+msgstr "This voucher is not valid."
 
 #: includes/Data/VoucherManager.php:652
 msgid "Invalid voucher signature."
-msgstr ""
+msgstr "Invalid voucher signature."
 
 #: includes/Data/VoucherManager.php:658
 msgid "Voucher code mismatch."
-msgstr ""
+msgstr "Voucher code mismatch."
 
 #: includes/Data/VoucherManager.php:668
 #, php-format
 msgid "This voucher is only valid for \"%s\"."
-msgstr ""
+msgstr "This voucher is only valid for \"%s\"."
 
 #: includes/Data/VoucherManager.php:682
 msgid "Voucher is valid and ready to apply."
-msgstr ""
+msgstr "Voucher is valid and ready to apply."
 
-#: includes/Frontend/SEOManager.php:297
-#: includes/ProductType/Experience.php:198
+#: includes/Frontend/SEOManager.php:297 includes/ProductType/Experience.php:198
 #: includes/ProductType/Experience.php:541
 #: includes/ProductType/Experience.php:747
 #: includes/ProductType/Experience.php:900
 #: includes/ProductType/Experience.php:1146
 msgid "Adult Price"
-msgstr ""
+msgstr "Adult Price"
 
-#: includes/Frontend/SEOManager.php:308
-#: includes/ProductType/Experience.php:212
+#: includes/Frontend/SEOManager.php:308 includes/ProductType/Experience.php:212
 #: includes/ProductType/Experience.php:556
 #: includes/ProductType/Experience.php:757
 #: includes/ProductType/Experience.php:912
 #: includes/ProductType/Experience.php:1157
 msgid "Child Price"
-msgstr ""
+msgstr "Child Price"
 
 #: includes/Frontend/SEOManager.php:481
 msgid "Home"
-msgstr ""
+msgstr "Home"
 
 #: includes/Frontend/Shortcodes.php:87
 msgid "No experiences found."
-msgstr ""
+msgstr "No experiences found."
 
 #: includes/Frontend/Shortcodes.php:331
 msgid "Filter by meeting point"
-msgstr ""
+msgstr "Filter by meeting point"
 
 #: includes/Frontend/Shortcodes.php:332
 msgid "All locations"
-msgstr ""
+msgstr "All locations"
 
 #: includes/Frontend/Shortcodes.php:347
 msgid "Filter by language"
-msgstr ""
+msgstr "Filter by language"
 
 #: includes/Frontend/Shortcodes.php:348
 msgid "All languages"
-msgstr ""
+msgstr "All languages"
 
-#: includes/Frontend/Shortcodes.php:362
-#: includes/ProductType/Experience.php:978
-#: templates/single-experience.php:146
-#: assets/js/admin.js:641
-#: assets/js/archive-block.js:77
-#: assets/js/archive-block.js:89
+#: includes/Frontend/Shortcodes.php:362 includes/ProductType/Experience.php:978
+#: templates/single-experience.php:146 assets/js/admin.js:641
+#: assets/js/archive-block.js:77 assets/js/archive-block.js:89
 msgid "Duration"
-msgstr ""
+msgstr "Duration"
 
 #: includes/Frontend/Shortcodes.php:363
 msgid "Filter by duration"
-msgstr ""
+msgstr "Filter by duration"
 
 #: includes/Frontend/Shortcodes.php:364
 msgid "Any duration"
-msgstr ""
+msgstr "Any duration"
 
 #: includes/Frontend/Shortcodes.php:365
 msgid "Up to 1.5 hours"
-msgstr ""
+msgstr "Up to 1.5 hours"
 
 #: includes/Frontend/Shortcodes.php:366
 msgid "1.5 - 3 hours"
-msgstr ""
+msgstr "1.5 - 3 hours"
 
 #: includes/Frontend/Shortcodes.php:367
 msgid "More than 3 hours"
-msgstr ""
+msgstr "More than 3 hours"
 
 #: includes/Frontend/Shortcodes.php:374
 msgid "Available on"
-msgstr ""
+msgstr "Available on"
 
 #: includes/Frontend/Shortcodes.php:378
 msgid "Filter by available date"
-msgstr ""
+msgstr "Filter by available date"
 
 #: includes/Frontend/Shortcodes.php:386
 msgid "Apply Filters"
-msgstr ""
+msgstr "Apply Filters"
 
 #: includes/Frontend/Shortcodes.php:453
 msgid "Archive pagination"
-msgstr ""
+msgstr "Archive pagination"
 
 #: includes/Frontend/Shortcodes.php:536
 #, php-format
 msgid "%d min"
-msgstr ""
+msgstr "%d min"
 
 #: includes/Frontend/Shortcodes.php:566
 #, php-format
 msgid "From %s"
-msgstr ""
+msgstr "From %s"
 
 #: includes/Frontend/Shortcodes.php:575
 msgid "Dettagli"
-msgstr ""
+msgstr "Dettagli"
 
 #: includes/Integrations/BrevoManager.php:307
 #: includes/Integrations/GooglePlacesManager.php:269
 msgid "Invalid API URL"
-msgstr ""
+msgstr "Invalid API URL"
 
 #: includes/Integrations/EmailMarketingManager.php:204
 msgid "How was your experience?"
-msgstr ""
+msgstr "How was your experience?"
 
 #: includes/Integrations/EmailMarketingManager.php:214
 #: includes/Integrations/EmailMarketingManager.php:241
 #: includes/Integrations/EmailMarketingManager.php:267
 #: includes/REST/MobileAPIManager.php:1047
 msgid "Unauthorized"
-msgstr ""
+msgstr "Unauthorized"
 
 #: includes/Integrations/EmailMarketingManager.php:223
 #: includes/REST/MobileAPIManager.php:252
 msgid "Invalid email address"
-msgstr ""
+msgstr "Invalid email address"
 
 #: includes/Integrations/EmailMarketingManager.php:297
 #: includes/Integrations/EmailMarketingManager.php:743
 msgid "Booking Confirmation"
-msgstr ""
+msgstr "Booking Confirmation"
 
 #: includes/Integrations/EmailMarketingManager.php:318
 msgid "Thank you for your experience!"
-msgstr ""
+msgstr "Thank you for your experience!"
 
 #: includes/Integrations/EmailMarketingManager.php:395
 msgid "Complete your booking - Special offer inside!"
-msgstr ""
+msgstr "Complete your booking - Special offer inside!"
 
 #: includes/Integrations/EmailMarketingManager.php:418
 msgid "Discover new amazing experiences!"
-msgstr ""
+msgstr "Discover new amazing experiences!"
 
 #: includes/Integrations/EmailMarketingManager.php:726
 #, php-format
 msgid "Campaign sent: %d successful, %d failed"
-msgstr ""
+msgstr "Campaign sent: %d successful, %d failed"
 
 #: includes/Integrations/EmailMarketingManager.php:744
 msgid "Sent when a booking is confirmed"
-msgstr ""
+msgstr "Sent when a booking is confirmed"
 
 #: includes/Integrations/EmailMarketingManager.php:747
 msgid "Booking Completion"
-msgstr ""
+msgstr "Booking Completion"
 
 #: includes/Integrations/EmailMarketingManager.php:748
 msgid "Sent when an experience is completed"
-msgstr ""
+msgstr "Sent when an experience is completed"
 
 #: includes/Integrations/EmailMarketingManager.php:751
 msgid "Abandoned Cart Recovery"
-msgstr ""
+msgstr "Abandoned Cart Recovery"
 
 #: includes/Integrations/EmailMarketingManager.php:752
 msgid "Sent to recover abandoned carts"
-msgstr ""
+msgstr "Sent to recover abandoned carts"
 
 #: includes/Integrations/EmailMarketingManager.php:755
 msgid "Review Request"
-msgstr ""
+msgstr "Review Request"
 
 #: includes/Integrations/EmailMarketingManager.php:756
 msgid "Request for customer reviews"
-msgstr ""
+msgstr "Request for customer reviews"
 
 #: includes/Integrations/EmailMarketingManager.php:759
 msgid "Upselling Campaign"
-msgstr ""
+msgstr "Upselling Campaign"
 
 #: includes/Integrations/EmailMarketingManager.php:760
 msgid "Promote related experiences"
-msgstr ""
+msgstr "Promote related experiences"
 
 #: includes/Integrations/GoogleBusinessProfileManager.php:131
 msgid "Google OAuth Client ID for Business Profile access"
-msgstr ""
+msgstr "Google OAuth Client ID for Business Profile access"
 
 #: includes/Integrations/GoogleBusinessProfileManager.php:137
 msgid "Google OAuth Client Secret (keep secure)"
-msgstr ""
+msgstr "Google OAuth Client Secret (keep secure)"
 
 #: includes/Integrations/MetaCAPIManager.php:193
 msgid "Meta Conversions API is not properly configured."
-msgstr ""
+msgstr "Meta Conversions API is not properly configured."
 
 #: includes/Integrations/MetaCAPIManager.php:226
 msgid "Invalid Meta dataset ID."
-msgstr ""
+msgstr "Invalid Meta dataset ID."
 
 #: includes/Integrations/MetaCAPIManager.php:243
 msgid "Connection failed: "
-msgstr ""
+msgstr "Connection failed: "
 
 #: includes/Integrations/MetaCAPIManager.php:255
 msgid "Meta Conversions API connection successful!"
-msgstr ""
+msgstr "Meta Conversions API connection successful!"
 
 #: includes/Integrations/MetaCAPIManager.php:263
 msgid "API call failed. Status: "
-msgstr ""
+msgstr "API call failed. Status: "
 
 #: includes/PDF/Voucher_Pdf.php:149
 msgid "Prepaid Ticket"
-msgstr ""
+msgstr "Prepaid Ticket"
 
-#: includes/PDF/Voucher_Pdf.php:157
-#: includes/PDF/Voucher_Pdf.php:257
+#: includes/PDF/Voucher_Pdf.php:157 includes/PDF/Voucher_Pdf.php:257
 msgid "Gift Voucher"
-msgstr ""
+msgstr "Gift Voucher"
 
 #: includes/PDF/Voucher_Pdf.php:265
 msgid "For:"
-msgstr ""
+msgstr "For:"
 
 #: includes/PDF/Voucher_Pdf.php:273
 msgid "Value:"
-msgstr ""
+msgstr "Value:"
 
 #: includes/PDF/Voucher_Pdf.php:277
 msgid "Expires:"
-msgstr ""
+msgstr "Expires:"
 
 #: includes/PDF/Voucher_Pdf.php:292
 msgid "QR Code for voucher redemption"
-msgstr ""
+msgstr "QR Code for voucher redemption"
 
 #: includes/PDF/Voucher_Pdf.php:293
 msgid "Scan this QR code to redeem your voucher"
-msgstr ""
+msgstr "Scan this QR code to redeem your voucher"
 
 #: includes/PDF/Voucher_Pdf.php:297
 msgid "How to Redeem:"
-msgstr ""
+msgstr "How to Redeem:"
 
 #: includes/PDF/Voucher_Pdf.php:299
 #, php-format
-msgid "Visit %s to book your experience and use the voucher code above or scan the QR code during checkout."
+msgid ""
+"Visit %s to book your experience and use the voucher code above or scan the "
+"QR code during checkout."
 msgstr ""
+"Visit %s to book your experience and use the voucher code above or scan the "
+"QR code during checkout."
 
 #: includes/ProductType/Experience.php:147
 msgid "Default experience duration in minutes (used as fallback for schedules)"
 msgstr ""
+"Default experience duration in minutes (used as fallback for schedules)"
 
 #: includes/ProductType/Experience.php:158
 msgid "Default Max Capacity"
-msgstr ""
+msgstr "Default Max Capacity"
 
 #: includes/ProductType/Experience.php:161
 msgid "Default maximum number of participants (used as fallback for schedules)"
 msgstr ""
+"Default maximum number of participants (used as fallback for schedules)"
 
 #: includes/ProductType/Experience.php:175
 msgid "Default language code for this experience (e.g., en, it, es)"
-msgstr ""
+msgstr "Default language code for this experience (e.g., en, it, es)"
 
 #: includes/ProductType/Experience.php:184
 msgid "Default Child Price"
-msgstr ""
+msgstr "Default Child Price"
 
 #: includes/ProductType/Experience.php:187
 msgid "Default price per child participant (used as fallback for schedules)"
-msgstr ""
+msgstr "Default price per child participant (used as fallback for schedules)"
 
 #: includes/ProductType/Experience.php:201
 msgid "Price per adult participant"
-msgstr ""
+msgstr "Price per adult participant"
 
 #: includes/ProductType/Experience.php:215
 msgid "Price per child participant"
-msgstr ""
+msgstr "Price per child participant"
 
 #: includes/ProductType/Experience.php:227
 msgid "Adult Tax Class"
-msgstr ""
+msgstr "Adult Tax Class"
 
 #: includes/ProductType/Experience.php:230
 msgid "Tax class for adult price"
-msgstr ""
+msgstr "Tax class for adult price"
 
 #: includes/ProductType/Experience.php:236
 msgid "Child Tax Class"
-msgstr ""
+msgstr "Child Tax Class"
 
 #: includes/ProductType/Experience.php:239
 msgid "Tax class for child price"
-msgstr ""
+msgstr "Tax class for child price"
 
-#: includes/ProductType/Experience.php:245
-#: templates/single-experience.php:156
+#: includes/ProductType/Experience.php:245 templates/single-experience.php:156
 msgid "Languages"
-msgstr ""
+msgstr "Languages"
 
 #: includes/ProductType/Experience.php:246
 msgid "Italian, English, Spanish"
-msgstr ""
+msgstr "Italian, English, Spanish"
 
 #: includes/ProductType/Experience.php:248
 msgid "Available languages for this experience"
-msgstr ""
+msgstr "Available languages for this experience"
 
 #: includes/ProductType/Experience.php:256
 msgid "Default Meeting Point"
-msgstr ""
+msgstr "Default Meeting Point"
 
 #: includes/ProductType/Experience.php:259
 msgid "Default meeting point for this experience"
-msgstr ""
+msgstr "Default meeting point for this experience"
 
 #: includes/ProductType/Experience.php:265
 msgid "Booking Cutoff (minutes)"
-msgstr ""
+msgstr "Booking Cutoff (minutes)"
 
 #: includes/ProductType/Experience.php:268
 msgid "Minimum minutes before experience start time to allow bookings"
-msgstr ""
+msgstr "Minimum minutes before experience start time to allow bookings"
 
-#: includes/ProductType/Experience.php:279
-#: templates/single-experience.php:226
+#: includes/ProductType/Experience.php:279 templates/single-experience.php:226
 msgid "What's Included"
-msgstr ""
+msgstr "What's Included"
 
 #: includes/ProductType/Experience.php:280
 msgid ""
@@ -3674,15 +3709,17 @@ msgid ""
 "All activities as described\n"
 "Small group experience"
 msgstr ""
+"Professional guide\n"
+"All activities as described\n"
+"Small group experience"
 
 #: includes/ProductType/Experience.php:282
 msgid "List what is included in the experience (one item per line)"
-msgstr ""
+msgstr "List what is included in the experience (one item per line)"
 
-#: includes/ProductType/Experience.php:289
-#: templates/single-experience.php:244
+#: includes/ProductType/Experience.php:289 templates/single-experience.php:244
 msgid "What's Not Included"
-msgstr ""
+msgstr "What's Not Included"
 
 #: includes/ProductType/Experience.php:290
 msgid ""
@@ -3691,255 +3728,273 @@ msgid ""
 "Personal expenses\n"
 "Gratuities"
 msgstr ""
+"Hotel pickup and drop-off\n"
+"Food and drinks\n"
+"Personal expenses\n"
+"Gratuities"
 
 #: includes/ProductType/Experience.php:292
 msgid "List what is not included in the experience (one item per line)"
-msgstr ""
+msgstr "List what is not included in the experience (one item per line)"
 
 #: includes/ProductType/Experience.php:299
 msgid "Cancellation Rules"
-msgstr ""
+msgstr "Cancellation Rules"
 
 #: includes/ProductType/Experience.php:306
 msgid "Free Cancellation Until (minutes)"
-msgstr ""
+msgstr "Free Cancellation Until (minutes)"
 
 #: includes/ProductType/Experience.php:309
-msgid "Minutes before experience start when customers can cancel for free (e.g., 1440 = 24 hours)"
+msgid ""
+"Minutes before experience start when customers can cancel for free (e.g., "
+"1440 = 24 hours)"
 msgstr ""
+"Minutes before experience start when customers can cancel for free (e.g., "
+"1440 = 24 hours)"
 
 #: includes/ProductType/Experience.php:320
 msgid "Cancellation Fee (%)"
-msgstr ""
+msgstr "Cancellation Fee (%)"
 
 #: includes/ProductType/Experience.php:323
-msgid "Percentage of total price to charge as cancellation fee after free cancellation period"
+msgid ""
+"Percentage of total price to charge as cancellation fee after free "
+"cancellation period"
 msgstr ""
+"Percentage of total price to charge as cancellation fee after free "
+"cancellation period"
 
 #: includes/ProductType/Experience.php:335
 msgid "No-Show Policy"
-msgstr ""
+msgstr "No-Show Policy"
 
 #: includes/ProductType/Experience.php:337
 msgid "No refund"
-msgstr ""
+msgstr "No refund"
 
 #: includes/ProductType/Experience.php:338
 msgid "Partial refund (use cancellation fee %)"
-msgstr ""
+msgstr "Partial refund (use cancellation fee %)"
 
 #: includes/ProductType/Experience.php:339
 msgid "Full refund"
-msgstr ""
+msgstr "Full refund"
 
 #: includes/ProductType/Experience.php:342
 msgid "Policy for customers who do not show up for their experience"
-msgstr ""
+msgstr "Policy for customers who do not show up for their experience"
 
 #: includes/ProductType/Experience.php:349
 msgid "Recurring Time Slots"
-msgstr ""
+msgstr "Recurring Time Slots"
 
 #: includes/ProductType/Experience.php:353
-msgid "Configure weekly recurring time slots for your experience. Each slot can run on multiple days and can have custom settings that override the default product values above."
+msgid ""
+"Configure weekly recurring time slots for your experience. Each slot can run "
+"on multiple days and can have custom settings that override the default "
+"product values above."
 msgstr ""
+"Configure weekly recurring time slots for your experience. Each slot can run "
+"on multiple days and can have custom settings that override the default "
+"product values above."
 
 #: includes/ProductType/Experience.php:361
 msgid "Advanced Mode (Raw Schedules)"
-msgstr ""
+msgstr "Advanced Mode (Raw Schedules)"
 
 #: includes/ProductType/Experience.php:366
 msgid "Add Schedule"
-msgstr ""
+msgstr "Add Schedule"
 
 #: includes/ProductType/Experience.php:373
 msgid "Show Advanced Mode"
-msgstr ""
+msgstr "Show Advanced Mode"
 
 #: includes/ProductType/Experience.php:375
 msgid "Enable to view/edit individual schedule rows directly"
-msgstr ""
+msgstr "Enable to view/edit individual schedule rows directly"
 
 #: includes/ProductType/Experience.php:381
 msgid "Date-Specific Overrides"
-msgstr ""
+msgstr "Date-Specific Overrides"
 
 #: includes/ProductType/Experience.php:385
-msgid "Add exceptions for specific dates: close the experience, change capacity, or modify prices for particular days."
+msgid ""
+"Add exceptions for specific dates: close the experience, change capacity, or "
+"modify prices for particular days."
 msgstr ""
+"Add exceptions for specific dates: close the experience, change capacity, or "
+"modify prices for particular days."
 
-#: includes/ProductType/Experience.php:393
-#: assets/js/admin.js:2128
+#: includes/ProductType/Experience.php:393 assets/js/admin.js:2128
 #: assets/js/admin.js:2289
 msgid "Add Date Override"
-msgstr ""
+msgstr "Add Date Override"
 
 #: includes/ProductType/Experience.php:435
 #: includes/ProductType/Experience.php:607
 msgid "Sunday"
-msgstr ""
+msgstr "Sunday"
 
 #: includes/ProductType/Experience.php:436
 #: includes/ProductType/Experience.php:601
 msgid "Monday"
-msgstr ""
+msgstr "Monday"
 
 #: includes/ProductType/Experience.php:437
 #: includes/ProductType/Experience.php:602
 msgid "Tuesday"
-msgstr ""
+msgstr "Tuesday"
 
 #: includes/ProductType/Experience.php:438
 #: includes/ProductType/Experience.php:603
 msgid "Wednesday"
-msgstr ""
+msgstr "Wednesday"
 
 #: includes/ProductType/Experience.php:439
 #: includes/ProductType/Experience.php:604
 msgid "Thursday"
-msgstr ""
+msgstr "Thursday"
 
 #: includes/ProductType/Experience.php:440
 #: includes/ProductType/Experience.php:605
 msgid "Friday"
-msgstr ""
+msgstr "Friday"
 
 #: includes/ProductType/Experience.php:441
 #: includes/ProductType/Experience.php:606
 msgid "Saturday"
-msgstr ""
+msgstr "Saturday"
 
 #: includes/ProductType/Experience.php:451
 msgid "Day of Week"
-msgstr ""
+msgstr "Day of Week"
 
 #: includes/ProductType/Experience.php:452
 msgid "Which day of the week this schedule applies to"
-msgstr ""
+msgstr "Which day of the week this schedule applies to"
 
 #: includes/ProductType/Experience.php:455
 msgid "Select Day"
-msgstr ""
+msgstr "Select Day"
 
 #: includes/ProductType/Experience.php:466
 #: includes/ProductType/Experience.php:655
 #: includes/ProductType/Experience.php:791
 msgid "Start Time"
-msgstr ""
+msgstr "Start Time"
 
 #: includes/ProductType/Experience.php:467
 msgid "When the experience starts (24-hour format)"
-msgstr ""
+msgstr "When the experience starts (24-hour format)"
 
 #: includes/ProductType/Experience.php:474
 msgid "Experience start time"
-msgstr ""
+msgstr "Experience start time"
 
 #: includes/ProductType/Experience.php:479
 #: includes/ProductType/Experience.php:708
 #: includes/ProductType/Experience.php:852
 #: includes/ProductType/Experience.php:2413
 msgid "Duration (minutes)"
-msgstr ""
+msgstr "Duration (minutes)"
 
 #: includes/ProductType/Experience.php:480
 msgid "How long the experience lasts in minutes"
-msgstr ""
+msgstr "How long the experience lasts in minutes"
 
 #: includes/ProductType/Experience.php:490
 msgid "Duration in minutes (minimum 1)"
-msgstr ""
+msgstr "Duration in minutes (minimum 1)"
 
 #: includes/ProductType/Experience.php:495
 msgid "Max Capacity"
-msgstr ""
+msgstr "Max Capacity"
 
 #: includes/ProductType/Experience.php:496
 msgid "Maximum number of participants for this schedule"
-msgstr ""
+msgstr "Maximum number of participants for this schedule"
 
 #: includes/ProductType/Experience.php:506
 msgid "Maximum participants (minimum 1)"
-msgstr ""
+msgstr "Maximum participants (minimum 1)"
 
 #: includes/ProductType/Experience.php:514
 msgid "Experience language code (e.g., en, it, es)"
-msgstr ""
+msgstr "Experience language code (e.g., en, it, es)"
 
 #: includes/ProductType/Experience.php:522
 msgid "Language code (ISO format preferred)"
-msgstr ""
+msgstr "Language code (ISO format preferred)"
 
 #: includes/ProductType/Experience.php:528
 msgid "Where participants should meet for this experience"
-msgstr ""
+msgstr "Where participants should meet for this experience"
 
 #: includes/ProductType/Experience.php:542
 msgid "Price per adult participant (leave empty to use default product price)"
-msgstr ""
+msgstr "Price per adult participant (leave empty to use default product price)"
 
 #: includes/ProductType/Experience.php:551
 msgid "Adult price (optional override)"
-msgstr ""
+msgstr "Adult price (optional override)"
 
 #: includes/ProductType/Experience.php:557
-msgid "Price per child participant (leave empty to use default or no child pricing)"
+msgid ""
+"Price per child participant (leave empty to use default or no child pricing)"
 msgstr ""
+"Price per child participant (leave empty to use default or no child pricing)"
 
 #: includes/ProductType/Experience.php:566
 msgid "Child price (optional)"
-msgstr ""
+msgstr "Child price (optional)"
 
 #: includes/ProductType/Experience.php:573
 msgid "Remove Schedule"
-msgstr ""
+msgstr "Remove Schedule"
 
-#: includes/ProductType/Experience.php:619
-#: assets/js/admin.js:1790
+#: includes/ProductType/Experience.php:619 assets/js/admin.js:1790
 msgid "No time slots configured yet. Add your first time slot below."
-msgstr ""
+msgstr "No time slots configured yet. Add your first time slot below."
 
-#: includes/ProductType/Experience.php:632
-#: assets/js/admin.js:634
-#: assets/js/admin.js:1800
-#: assets/js/admin.js:1802
-#: assets/js/admin.js:2098
+#: includes/ProductType/Experience.php:632 assets/js/admin.js:634
+#: assets/js/admin.js:1800 assets/js/admin.js:1802 assets/js/admin.js:2098
 msgid "Add Time Slot"
-msgstr ""
+msgstr "Add Time Slot"
 
 #: includes/ProductType/Experience.php:667
 #: includes/ProductType/Experience.php:806
 msgid "Days of Week"
-msgstr ""
+msgstr "Days of Week"
 
 #: includes/ProductType/Experience.php:698
 #: includes/ProductType/Experience.php:841
 msgid "Advanced Settings"
-msgstr ""
+msgstr "Advanced Settings"
 
 #: includes/ProductType/Experience.php:700
 #: includes/ProductType/Experience.php:843
 msgid "Override default values for this specific time slot"
-msgstr ""
+msgstr "Override default values for this specific time slot"
 
 #: includes/ProductType/Experience.php:717
 #: includes/ProductType/Experience.php:863
-#: includes/ProductType/Experience.php:979
-#: assets/js/admin.js:642
+#: includes/ProductType/Experience.php:979 assets/js/admin.js:642
 msgid "Capacity"
-msgstr ""
+msgstr "Capacity"
 
 #: includes/ProductType/Experience.php:737
 msgid "Use default"
-msgstr ""
+msgstr "Use default"
 
 #: includes/ProductType/Experience.php:799
 msgid "Enter the start time for this experience slot in 24-hour format"
-msgstr ""
+msgstr "Enter the start time for this experience slot in 24-hour format"
 
 #: includes/ProductType/Experience.php:825
 msgid "Select which days of the week this time slot is available"
-msgstr ""
+msgstr "Select which days of the week this time slot is available"
 
 #: includes/ProductType/Experience.php:857
 #: includes/ProductType/Experience.php:868
@@ -3947,95 +4002,98 @@ msgstr ""
 #: includes/ProductType/Experience.php:889
 #, php-format
 msgid "Default: %s"
-msgstr ""
+msgstr "Default: %s"
 
 #: includes/ProductType/Experience.php:889
-#: includes/ProductType/Experience.php:1030
-#: assets/js/admin.js:663
+#: includes/ProductType/Experience.php:1030 assets/js/admin.js:663
 msgid "None"
-msgstr ""
+msgstr "None"
 
 #: includes/ProductType/Experience.php:905
 #: includes/ProductType/Experience.php:917
 #, php-format
 msgid "Default: %.2f"
-msgstr ""
+msgstr "Default: %.2f"
 
 #: includes/ProductType/Experience.php:945
 msgid "Configured Time Slots Overview"
-msgstr ""
+msgstr "Configured Time Slots Overview"
 
 #: includes/ProductType/Experience.php:954
 msgid "No time slots configured yet"
-msgstr ""
+msgstr "No time slots configured yet"
 
 #: includes/ProductType/Experience.php:957
-msgid "Create recurring weekly time slots to make your experience bookable. Each slot can have different settings and run on multiple days."
+msgid ""
+"Create recurring weekly time slots to make your experience bookable. Each "
+"slot can have different settings and run on multiple days."
 msgstr ""
+"Create recurring weekly time slots to make your experience bookable. Each "
+"slot can have different settings and run on multiple days."
 
 #: includes/ProductType/Experience.php:960
 msgid "Examples:"
-msgstr ""
+msgstr "Examples:"
 
 #: includes/ProductType/Experience.php:962
 msgid "Morning tour: 09:00 on Mon, Wed, Fri"
-msgstr ""
+msgstr "Morning tour: 09:00 on Mon, Wed, Fri"
 
 #: includes/ProductType/Experience.php:963
 msgid "Afternoon tour: 14:30 on Tue, Thu, Sat"
-msgstr ""
+msgstr "Afternoon tour: 14:30 on Tue, Thu, Sat"
 
 #: includes/ProductType/Experience.php:964
 msgid "Weekend special: 10:00 on Sat, Sun with different pricing"
-msgstr ""
+msgstr "Weekend special: 10:00 on Sat, Sun with different pricing"
 
 #: includes/ProductType/Experience.php:969
 msgid "Add Your First Time Slot"
-msgstr ""
+msgstr "Add Your First Time Slot"
 
 #: includes/ProductType/Experience.php:977
 #: includes/ProductType/Experience.php:2195
-#: includes/ProductType/Experience.php:2308
-#: assets/js/admin.js:640
+#: includes/ProductType/Experience.php:2308 assets/js/admin.js:640
 msgid "Days"
-msgstr ""
+msgstr "Days"
 
-#: includes/ProductType/Experience.php:980
-#: assets/js/admin.js:643
+#: includes/ProductType/Experience.php:980 assets/js/admin.js:643
 msgid "Customized"
-msgstr ""
+msgstr "Customized"
 
 #: includes/ProductType/Experience.php:1008
-#: includes/ProductType/Experience.php:1018
-#: assets/js/admin.js:661
+#: includes/ProductType/Experience.php:1018 assets/js/admin.js:661
 #: assets/js/admin.js:662
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 #. translators: %d: number of customized settings
 #: includes/ProductType/Experience.php:1028
 #, php-format
 msgid "%d setting"
 msgid_plural "%d settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d setting"
+msgstr[1] "%d settings"
 
-#: includes/ProductType/Experience.php:1061
-#: assets/js/admin.js:2283
-msgid "No date overrides configured. Add exceptions below for specific dates when you need to close, change capacity, or modify pricing."
+#: includes/ProductType/Experience.php:1061 assets/js/admin.js:2283
+msgid ""
+"No date overrides configured. Add exceptions below for specific dates when "
+"you need to close, change capacity, or modify pricing."
 msgstr ""
+"No date overrides configured. Add exceptions below for specific dates when "
+"you need to close, change capacity, or modify pricing."
 
 #: includes/ProductType/Experience.php:1112
 #: includes/ProductType/Experience.php:1214
 #: includes/ProductType/Experience.php:1328
 #: includes/ProductType/Experience.php:1432
 msgid "Closed"
-msgstr ""
+msgstr "Closed"
 
 #: includes/ProductType/Experience.php:1126
 #: includes/ProductType/Experience.php:1225
 msgid "Capacity Override"
-msgstr ""
+msgstr "Capacity Override"
 
 #: includes/ProductType/Experience.php:1131
 #: includes/ProductType/Experience.php:1151
@@ -4047,1294 +4105,1265 @@ msgstr ""
 #: includes/ProductType/Experience.php:1349
 #: includes/ProductType/Experience.php:1361
 msgid "Leave empty = use default"
-msgstr ""
+msgstr "Leave empty = use default"
 
 #: includes/ProductType/Experience.php:1137
 msgid "Reason/Note"
-msgstr ""
+msgstr "Reason/Note"
 
 #: includes/ProductType/Experience.php:1142
 msgid "Optional note (e.g., Holiday, Maintenance)"
-msgstr ""
+msgstr "Optional note (e.g., Holiday, Maintenance)"
 
 #: includes/ProductType/Experience.php:1203
 #: includes/ProductType/Experience.php:1303
 #: includes/ProductType/Experience.php:1415
 msgid "Override date"
-msgstr ""
+msgstr "Override date"
 
 #: includes/ProductType/Experience.php:1216
 #: includes/ProductType/Experience.php:1380
 #: includes/ProductType/Experience.php:1474
 msgid "Remove this override"
-msgstr ""
+msgstr "Remove this override"
 
 #: includes/ProductType/Experience.php:1233
 #: includes/ProductType/Experience.php:1341
 #: includes/ProductType/Experience.php:1443
 msgid "Capacity override"
-msgstr ""
+msgstr "Capacity override"
 
 #: includes/ProductType/Experience.php:1238
 msgid "Adult Price (€)"
-msgstr ""
+msgstr "Adult Price (€)"
 
 #: includes/ProductType/Experience.php:1246
 #: includes/ProductType/Experience.php:1353
 #: includes/ProductType/Experience.php:1453
 msgid "Adult price override"
-msgstr ""
+msgstr "Adult price override"
 
 #: includes/ProductType/Experience.php:1251
 msgid "Child Price (€)"
-msgstr ""
+msgstr "Child Price (€)"
 
 #: includes/ProductType/Experience.php:1259
 #: includes/ProductType/Experience.php:1365
 #: includes/ProductType/Experience.php:1463
 msgid "Child price override"
-msgstr ""
+msgstr "Child price override"
 
 #: includes/ProductType/Experience.php:1264
 msgid "Reason (Optional)"
-msgstr ""
+msgstr "Reason (Optional)"
 
 #: includes/ProductType/Experience.php:1269
 msgid "Holiday, Maintenance, etc."
-msgstr ""
+msgstr "Holiday, Maintenance, etc."
 
 #: includes/ProductType/Experience.php:1270
 #: includes/ProductType/Experience.php:1375
 #: includes/ProductType/Experience.php:1471
 msgid "Reason for this override"
-msgstr ""
+msgstr "Reason for this override"
 
 #: includes/ProductType/Experience.php:1308
 #: includes/ProductType/Experience.php:2459
 msgid "This date is very far in the future. Please verify it's correct."
-msgstr ""
+msgstr "This date is very far in the future. Please verify it's correct."
 
 #: includes/ProductType/Experience.php:1314
 msgid "This date is in the past."
-msgstr ""
+msgstr "This date is in the past."
 
 #: includes/ProductType/Experience.php:1373
 msgid "Optional: Holiday, Maintenance, etc."
-msgstr ""
+msgstr "Optional: Holiday, Maintenance, etc."
 
 #: includes/ProductType/Experience.php:1419
 msgid "Very distant date - please verify"
-msgstr ""
+msgstr "Very distant date - please verify"
 
 #: includes/ProductType/Experience.php:1439
 msgid "Capacity (empty = default)"
-msgstr ""
+msgstr "Capacity (empty = default)"
 
 #: includes/ProductType/Experience.php:1449
 msgid "Adult € (empty = default)"
-msgstr ""
+msgstr "Adult € (empty = default)"
 
 #: includes/ProductType/Experience.php:1459
 msgid "Child € (empty = default)"
-msgstr ""
+msgstr "Child € (empty = default)"
 
 #: includes/ProductType/Experience.php:1469
 msgid "Reason (optional)"
-msgstr ""
+msgstr "Reason (optional)"
 
 #: includes/ProductType/Experience.php:1494
 msgid "Select which extras are available for this experience:"
-msgstr ""
+msgstr "Select which extras are available for this experience:"
 
 #: includes/ProductType/Experience.php:1500
 #, php-format
 msgid "No extras available. <a href=\"%s\">Create some extras</a> first."
-msgstr ""
+msgstr "No extras available. <a href=\"%s\">Create some extras</a> first."
 
-#: includes/ProductType/Experience.php:1519
-#: templates/single-experience.php:130
-#: templates/single-experience.php:533
-#: templates/single-experience.php:667
+#: includes/ProductType/Experience.php:1519 templates/single-experience.php:130
+#: templates/single-experience.php:533 templates/single-experience.php:667
 msgid "per person"
-msgstr ""
+msgstr "per person"
 
-#: includes/ProductType/Experience.php:1519
-#: templates/single-experience.php:669
+#: includes/ProductType/Experience.php:1519 templates/single-experience.php:669
 msgid "per booking"
-msgstr ""
+msgstr "per booking"
 
 #: includes/ProductType/Experience.php:1785
 #, php-format
-msgid "Time slot %d: Invalid time format \"%s\". Use HH:MM format (e.g., 09:30)."
+msgid ""
+"Time slot %d: Invalid time format \"%s\". Use HH:MM format (e.g., 09:30)."
 msgstr ""
+"Time slot %d: Invalid time format \"%s\". Use HH:MM format (e.g., 09:30)."
 
 #: includes/ProductType/Experience.php:1899
 #, php-format
 msgid "Row %d: Invalid time format. Use HH:MM format."
-msgstr ""
+msgstr "Row %d: Invalid time format. Use HH:MM format."
 
 #: includes/ProductType/Experience.php:2022
 msgid "Dynamic Pricing Rules"
-msgstr ""
+msgstr "Dynamic Pricing Rules"
 
 #: includes/ProductType/Experience.php:2031
 msgid "Add Pricing Rule"
-msgstr ""
+msgstr "Add Pricing Rule"
 
 #: includes/ProductType/Experience.php:2036
 msgid "Pricing Preview"
-msgstr ""
+msgstr "Pricing Preview"
 
 #: includes/ProductType/Experience.php:2041
 msgid "Booking Date"
-msgstr ""
+msgstr "Booking Date"
 
 #: includes/ProductType/Experience.php:2045
 msgid "Purchase Date"
-msgstr ""
+msgstr "Purchase Date"
 
 #: includes/ProductType/Experience.php:2058
 msgid "Calculate"
-msgstr ""
+msgstr "Calculate"
 
 #: includes/ProductType/Experience.php:2098
 msgid "Price Breakdown"
-msgstr ""
+msgstr "Price Breakdown"
 
 #: includes/ProductType/Experience.php:2101
 msgid "Base Adult Price"
-msgstr ""
+msgstr "Base Adult Price"
 
 #: includes/ProductType/Experience.php:2102
 msgid "Base Child Price"
-msgstr ""
+msgstr "Base Child Price"
 
 #: includes/ProductType/Experience.php:2103
 msgid "Final Adult Price"
-msgstr ""
+msgstr "Final Adult Price"
 
 #: includes/ProductType/Experience.php:2104
 msgid "Final Child Price"
-msgstr ""
+msgstr "Final Child Price"
 
 #: includes/ProductType/Experience.php:2105
 msgid "Total Base"
-msgstr ""
+msgstr "Total Base"
 
 #: includes/ProductType/Experience.php:2106
 msgid "Total Final"
-msgstr ""
+msgstr "Total Final"
 
 #: includes/ProductType/Experience.php:2110
 msgid "Applied Rules"
-msgstr ""
+msgstr "Applied Rules"
 
 #: includes/ProductType/Experience.php:2155
 #: includes/ProductType/Experience.php:2156
 #: includes/ProductType/Experience.php:2251
 #: includes/ProductType/Experience.php:2254
 msgid "Rule Name"
-msgstr ""
+msgstr "Rule Name"
 
 #: includes/ProductType/Experience.php:2159
 #: includes/ProductType/Experience.php:2258
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: includes/ProductType/Experience.php:2161
 #: includes/ProductType/Experience.php:2260
 msgid "Select Type"
-msgstr ""
+msgstr "Select Type"
 
 #: includes/ProductType/Experience.php:2162
 #: includes/ProductType/Experience.php:2261
 msgid "Seasonal"
-msgstr ""
+msgstr "Seasonal"
 
 #: includes/ProductType/Experience.php:2163
 #: includes/ProductType/Experience.php:2262
 msgid "Weekend/Weekday"
-msgstr ""
+msgstr "Weekend/Weekday"
 
 #: includes/ProductType/Experience.php:2164
 #: includes/ProductType/Experience.php:2263
 msgid "Early Bird"
-msgstr ""
+msgstr "Early Bird"
 
 #: includes/ProductType/Experience.php:2165
 #: includes/ProductType/Experience.php:2264
 msgid "Group Discount"
-msgstr ""
+msgstr "Group Discount"
 
 #: includes/ProductType/Experience.php:2169
 #: includes/ProductType/Experience.php:2269
 msgid "Priority"
-msgstr ""
+msgstr "Priority"
 
 #: includes/ProductType/Experience.php:2181
-#: includes/ProductType/Experience.php:2288
-#: templates/admin/reports.php:23
+#: includes/ProductType/Experience.php:2288 templates/admin/reports.php:23
 msgid "Date Range"
-msgstr ""
+msgstr "Date Range"
 
 #: includes/ProductType/Experience.php:2182
 #: includes/ProductType/Experience.php:2290
 msgid "Start Date"
-msgstr ""
+msgstr "Start Date"
 
 #: includes/ProductType/Experience.php:2183
 #: includes/ProductType/Experience.php:2292
 msgid "End Date"
-msgstr ""
+msgstr "End Date"
 
 #: includes/ProductType/Experience.php:2186
 #: includes/ProductType/Experience.php:2296
 msgid "Applies To"
-msgstr ""
+msgstr "Applies To"
 
 #: includes/ProductType/Experience.php:2188
 #: includes/ProductType/Experience.php:2298
 msgid "Select..."
-msgstr ""
+msgstr "Select..."
 
 #: includes/ProductType/Experience.php:2189
 #: includes/ProductType/Experience.php:2299
 msgid "Weekend"
-msgstr ""
+msgstr "Weekend"
 
 #: includes/ProductType/Experience.php:2190
 #: includes/ProductType/Experience.php:2300
 msgid "Weekday"
-msgstr ""
+msgstr "Weekday"
 
 #: includes/ProductType/Experience.php:2194
 #: includes/ProductType/Experience.php:2305
 msgid "Days Before"
-msgstr ""
+msgstr "Days Before"
 
 #: includes/ProductType/Experience.php:2198
 #: includes/ProductType/Experience.php:2312
 msgid "Minimum Participants"
-msgstr ""
+msgstr "Minimum Participants"
 
 #: includes/ProductType/Experience.php:2199
 #: includes/ProductType/Experience.php:2315
 msgid "Min Participants"
-msgstr ""
+msgstr "Min Participants"
 
 #: includes/ProductType/Experience.php:2203
 #: includes/ProductType/Experience.php:2321
 msgid "Adjustment Type"
-msgstr ""
+msgstr "Adjustment Type"
 
 #: includes/ProductType/Experience.php:2205
 #: includes/ProductType/Experience.php:2323
 msgid "Percentage (%)"
-msgstr ""
+msgstr "Percentage (%)"
 
 #: includes/ProductType/Experience.php:2206
 #: includes/ProductType/Experience.php:2324
 msgid "Fixed Amount"
-msgstr ""
+msgstr "Fixed Amount"
 
 #: includes/ProductType/Experience.php:2210
 #: includes/ProductType/Experience.php:2329
 msgid "Adult Adjustment"
-msgstr ""
+msgstr "Adult Adjustment"
 
 #: includes/ProductType/Experience.php:2214
 #: includes/ProductType/Experience.php:2336
 msgid "Child Adjustment"
-msgstr ""
+msgstr "Child Adjustment"
 
 #: includes/ProductType/Experience.php:2365
 msgid "Schedule Validation Errors:"
-msgstr ""
+msgstr "Schedule Validation Errors:"
 
 #: includes/ProductType/Experience.php:2378
 #, php-format
 msgid "%d invalid schedule was discarded."
 msgid_plural "%d invalid schedules were discarded."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d invalid schedule was discarded."
+msgstr[1] "%d invalid schedules were discarded."
 
 #: includes/ProductType/Experience.php:2390
 #, php-format
 msgid "%d schedule saved successfully."
 msgid_plural "%d schedules saved successfully."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d schedule saved successfully."
+msgstr[1] "%d schedules saved successfully."
 
 #: includes/ProductType/Experience.php:2416
 msgid "Experience duration in minutes"
-msgstr ""
+msgstr "Experience duration in minutes"
 
-#: includes/ProductType/Experience.php:2456
-#: templates/single-experience.php:547
+#: includes/ProductType/Experience.php:2456 templates/single-experience.php:547
 #: templates/single-experience.php:883
 msgid "Select Date"
-msgstr ""
+msgstr "Select Date"
 
-#: includes/ProductType/Experience.php:2458
-#: assets/js/admin.js:1085
+#: includes/ProductType/Experience.php:2458 assets/js/admin.js:1085
 #: assets/js/admin.js:1338
 msgid "Are you sure you want to remove this date override?"
-msgstr ""
+msgstr "Are you sure you want to remove this date override?"
 
-#: includes/ProductType/Experience.php:2460
-#: assets/js/admin.js:566
+#: includes/ProductType/Experience.php:2460 assets/js/admin.js:566
 msgid "You have unsaved changes. Are you sure you want to leave?"
-msgstr ""
+msgstr "You have unsaved changes. Are you sure you want to leave?"
 
 #: includes/ProductType/Experience.php:2461
 msgid "Please fix the validation errors before saving."
-msgstr ""
+msgstr "Please fix the validation errors before saving."
 
 #: includes/REST/AvailabilityAPI.php:93
 msgid "Product not found or is not an experience."
-msgstr ""
+msgstr "Product not found or is not an experience."
 
 #: includes/REST/AvailabilityAPI.php:104
 msgid "Invalid date format. Use YYYY-MM-DD."
-msgstr ""
+msgstr "Invalid date format. Use YYYY-MM-DD."
 
 #: includes/REST/AvailabilityAPI.php:116
 msgid "Cannot check availability for past dates."
-msgstr ""
+msgstr "Cannot check availability for past dates."
 
-#: includes/REST/BookingsAPI.php:100
-#: includes/REST/BookingsAPI.php:137
+#: includes/REST/BookingsAPI.php:100 includes/REST/BookingsAPI.php:137
 msgid "Invalid start date format"
-msgstr ""
+msgstr "Invalid start date format"
 
-#: includes/REST/BookingsAPI.php:108
-#: includes/REST/BookingsAPI.php:141
+#: includes/REST/BookingsAPI.php:108 includes/REST/BookingsAPI.php:141
 msgid "Invalid end date format"
-msgstr ""
+msgstr "Invalid end date format"
 
 #: includes/REST/BookingsController.php:64
 msgid "You do not have permission to access bookings data."
-msgstr ""
+msgstr "You do not have permission to access bookings data."
 
 #: includes/REST/BookingsController.php:149
 msgid "Failed to fetch booking events. Please try again."
-msgstr ""
+msgstr "Failed to fetch booking events. Please try again."
 
 #: includes/REST/ICSAPI.php:127
 msgid "Product not found or not an experience."
-msgstr ""
+msgstr "Product not found or not an experience."
 
 #: includes/REST/ICSAPI.php:136
 msgid "Product is not available."
-msgstr ""
+msgstr "Product is not available."
 
 #: includes/REST/ICSAPI.php:146
 msgid "No events available for this product."
-msgstr ""
+msgstr "No events available for this product."
 
 #: includes/REST/ICSAPI.php:176
 msgid "User not found."
-msgstr ""
+msgstr "User not found."
 
 #: includes/REST/ICSAPI.php:186
 msgid "No bookings found for this user."
-msgstr ""
+msgstr "No bookings found for this user."
 
-#: includes/REST/ICSAPI.php:215
-#: includes/REST/ICSAPI.php:296
+#: includes/REST/ICSAPI.php:215 includes/REST/ICSAPI.php:296
 msgid "Invalid access token."
-msgstr ""
+msgstr "Invalid access token."
 
 #: includes/REST/ICSAPI.php:245
 msgid "Failed to generate calendar."
-msgstr ""
+msgstr "Failed to generate calendar."
 
 #: includes/REST/ICSAPI.php:277
 msgid "ICS file not found."
-msgstr ""
+msgstr "ICS file not found."
 
-#: includes/REST/ICSAPI.php:285
-#: includes/REST/ICSAPI.php:303
+#: includes/REST/ICSAPI.php:285 includes/REST/ICSAPI.php:303
 msgid "Access denied."
-msgstr ""
+msgstr "Access denied."
 
-#: includes/REST/ICSAPI.php:334
-#: includes/REST/SecurePDFAPI.php:84
+#: includes/REST/ICSAPI.php:334 includes/REST/SecurePDFAPI.php:84
 msgid "Authentication required."
-msgstr ""
+msgstr "Authentication required."
 
 #: includes/REST/ICSAPI.php:346
 msgid "You do not have permission to access these bookings."
-msgstr ""
+msgstr "You do not have permission to access these bookings."
 
 #: includes/REST/MobileAPIManager.php:172
 msgid "Too many login attempts. Please try again later."
-msgstr ""
+msgstr "Too many login attempts. Please try again later."
 
 #: includes/REST/MobileAPIManager.php:180
 msgid "Username and password are required"
-msgstr ""
+msgstr "Username and password are required"
 
 #: includes/REST/MobileAPIManager.php:188
 msgid "Invalid username or password"
-msgstr ""
+msgstr "Invalid username or password"
 
 #: includes/REST/MobileAPIManager.php:197
 msgid "Please verify your email before logging in."
-msgstr ""
+msgstr "Please verify your email before logging in."
 
 #: includes/REST/MobileAPIManager.php:238
 msgid "Too many registration attempts. Please try again later."
-msgstr ""
+msgstr "Too many registration attempts. Please try again later."
 
 #: includes/REST/MobileAPIManager.php:248
 msgid "Username, email and password are required"
-msgstr ""
+msgstr "Username, email and password are required"
 
 #: includes/REST/MobileAPIManager.php:256
 msgid "Username or email already exists"
-msgstr ""
+msgstr "Username or email already exists"
 
 #: includes/REST/MobileAPIManager.php:277
 msgid "Confirm your account"
-msgstr ""
+msgstr "Confirm your account"
 
 #: includes/REST/MobileAPIManager.php:279
 #, php-format
 msgid "Please confirm your account by clicking the following link: %s"
-msgstr ""
+msgstr "Please confirm your account by clicking the following link: %s"
 
 #: includes/REST/MobileAPIManager.php:287
-msgid "Registration successful. Please check your email to confirm your account."
+msgid ""
+"Registration successful. Please check your email to confirm your account."
 msgstr ""
+"Registration successful. Please check your email to confirm your account."
 
 #: includes/REST/MobileAPIManager.php:302
 msgid "Invalid verification link."
-msgstr ""
+msgstr "Invalid verification link."
 
 #: includes/REST/MobileAPIManager.php:308
 msgid "Invalid or expired token."
-msgstr ""
+msgstr "Invalid or expired token."
 
 #: includes/REST/MobileAPIManager.php:316
 msgid "Email verified. You can now login."
-msgstr ""
+msgstr "Email verified. You can now login."
 
 #: includes/REST/MobileAPIManager.php:362
 msgid "Invalid date format. Use Y-m-d format."
-msgstr ""
+msgstr "Invalid date format. Use Y-m-d format."
 
 #: includes/REST/MobileAPIManager.php:367
 msgid "Category does not exist"
-msgstr ""
+msgstr "Category does not exist"
 
 #: includes/REST/MobileAPIManager.php:442
 msgid "Experience not found"
-msgstr ""
+msgstr "Experience not found"
 
 #: includes/REST/MobileAPIManager.php:587
 #: includes/REST/MobileAPIManager.php:642
 #: includes/REST/MobileAPIManager.php:682
 #: includes/REST/MobileAPIManager.php:722
 msgid "Booking not found"
-msgstr ""
+msgstr "Booking not found"
 
 #: includes/REST/MobileAPIManager.php:668
 msgid "Invalid QR code"
-msgstr ""
+msgstr "Invalid QR code"
 
 #: includes/REST/MobileAPIManager.php:726
 msgid "Booking cannot be checked in"
-msgstr ""
+msgstr "Booking cannot be checked in"
 
 #: includes/REST/MobileAPIManager.php:730
 msgid "Booking already checked in"
-msgstr ""
+msgstr "Booking already checked in"
 
 #: includes/REST/MobileAPIManager.php:746
 msgid "Check-in failed"
-msgstr ""
+msgstr "Check-in failed"
 
 #: includes/REST/MobileAPIManager.php:754
 msgid "Customer checked in successfully"
-msgstr ""
+msgstr "Customer checked in successfully"
 
 #: includes/REST/MobileAPIManager.php:770
 #: includes/REST/MobileAPIManager.php:821
 msgid "Too many requests"
-msgstr ""
+msgstr "Too many requests"
 
 #: includes/REST/MobileAPIManager.php:808
 msgid "Push token registered successfully"
-msgstr ""
+msgstr "Push token registered successfully"
 
 #: includes/REST/MobileAPIManager.php:841
 msgid "Recipient, title and message are required"
-msgstr ""
+msgstr "Recipient, title and message are required"
 
 #: includes/REST/MobileAPIManager.php:849
 msgid "Notification sent successfully"
-msgstr ""
+msgstr "Notification sent successfully"
 
 #: includes/REST/MobileAPIManager.php:852
 msgid "Failed to send notification"
-msgstr ""
+msgstr "Failed to send notification"
 
 #: includes/REST/MobileAPIManager.php:867
 #: includes/REST/MobileAPIManager.php:966
 msgid "Invalid date format. Expected YYYY-MM-DD"
-msgstr ""
+msgstr "Invalid date format. Expected YYYY-MM-DD"
 
 #: includes/REST/MobileAPIManager.php:991
 msgid "Invalid action type"
-msgstr ""
+msgstr "Invalid action type"
 
 #: includes/REST/MobileAPIManager.php:998
 #: includes/REST/MobileAPIManager.php:1005
 msgid "Invalid location data"
-msgstr ""
+msgstr "Invalid location data"
 
 #: includes/REST/MobileAPIManager.php:1030
 msgid "Failed to record attendance"
-msgstr ""
+msgstr "Failed to record attendance"
 
 #: includes/REST/MobileAPIManager.php:1035
 #, php-format
 msgid "%s recorded successfully"
-msgstr ""
+msgstr "%s recorded successfully"
 
 #: includes/REST/MobileAPIManager.php:1051
 msgid "Email not verified"
-msgstr ""
+msgstr "Email not verified"
 
 #: includes/REST/MobileAPIManager.php:1302
 msgid "Invalid product"
-msgstr ""
+msgstr "Invalid product"
 
 #: includes/REST/MobileAPIManager.php:1306
 msgid "Invalid booking date"
-msgstr ""
+msgstr "Invalid booking date"
 
 #: includes/REST/MobileAPIManager.php:1310
 msgid "At least one participant required"
-msgstr ""
+msgstr "At least one participant required"
 
 #: includes/REST/MobileAPIManager.php:1425
 msgid "Check-in Confirmed"
-msgstr ""
+msgstr "Check-in Confirmed"
 
 #: includes/REST/MobileAPIManager.php:1426
 msgid "You have been successfully checked in for your experience"
-msgstr ""
+msgstr "You have been successfully checked in for your experience"
 
 #: includes/REST/SecurePDFAPI.php:112
 msgid "You do not have permission to download this voucher."
-msgstr ""
+msgstr "You do not have permission to download this voucher."
 
-#: includes/REST/SecurePDFAPI.php:139
-#: includes/REST/SecurePDFAPI.php:148
+#: includes/REST/SecurePDFAPI.php:139 includes/REST/SecurePDFAPI.php:148
 msgid "PDF file not found."
-msgstr ""
+msgstr "PDF file not found."
 
 #: includes/REST/SecurePDFAPI.php:158
 msgid "Access to the requested file is denied."
-msgstr ""
+msgstr "Access to the requested file is denied."
 
-#: includes/REST/SecurePDFAPI.php:168
-#: includes/REST/SecurePDFAPI.php:184
+#: includes/REST/SecurePDFAPI.php:168 includes/REST/SecurePDFAPI.php:184
 msgid "Unable to read PDF file."
-msgstr ""
+msgstr "Unable to read PDF file."
 
 #: templates/admin/reports.php:12
 msgid "Reports & Analytics"
-msgstr ""
+msgstr "Reports & Analytics"
 
-#: templates/admin/reports.php:16
-#: assets/js/archive-block.js:128
+#: templates/admin/reports.php:16 assets/js/archive-block.js:128
 msgid "Filters"
-msgstr ""
+msgstr "Filters"
 
 #: templates/admin/reports.php:34
 msgid "All Experiences"
-msgstr ""
+msgstr "All Experiences"
 
 #: templates/admin/reports.php:47
 msgid "All Meeting Points"
-msgstr ""
+msgstr "All Meeting Points"
 
 #: templates/admin/reports.php:60
 msgid "All Languages"
-msgstr ""
+msgstr "All Languages"
 
 #: templates/admin/reports.php:73
 msgid "Update Reports"
-msgstr ""
+msgstr "Update Reports"
 
 #: templates/admin/reports.php:83
 msgid "Total Revenue"
-msgstr ""
+msgstr "Total Revenue"
 
 #: templates/admin/reports.php:90
 msgid "Seats Sold"
-msgstr ""
+msgstr "Seats Sold"
 
 #: templates/admin/reports.php:104
 msgid "Avg Booking Value"
-msgstr ""
+msgstr "Avg Booking Value"
 
 #: templates/admin/reports.php:117
 msgid "Revenue & Seats Trends"
-msgstr ""
+msgstr "Revenue & Seats Trends"
 
 #: templates/admin/reports.php:120
 msgid "Daily"
-msgstr ""
+msgstr "Daily"
 
 #: templates/admin/reports.php:123
 msgid "Weekly"
-msgstr ""
+msgstr "Weekly"
 
 #: templates/admin/reports.php:126
 msgid "Monthly"
-msgstr ""
+msgstr "Monthly"
 
 #: templates/admin/reports.php:134
 msgid "Top 10 Experiences"
-msgstr ""
+msgstr "Top 10 Experiences"
 
 #: templates/admin/reports.php:144
 msgid "Traffic Source Conversions"
-msgstr ""
+msgstr "Traffic Source Conversions"
 
 #: templates/admin/reports.php:152
 msgid "Load Factors by Experience"
-msgstr ""
+msgstr "Load Factors by Experience"
 
 #: templates/admin/reports.php:160
 msgid "Export Report Data"
-msgstr ""
+msgstr "Export Report Data"
 
 #: templates/admin/reports.php:173
 msgid "Export Format"
-msgstr ""
+msgstr "Export Format"
 
 #: templates/admin/reports.php:177
 msgid "CSV"
-msgstr ""
+msgstr "CSV"
 
 #: templates/admin/reports.php:181
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #: templates/admin/reports.php:190
 msgid "Export Data"
-msgstr ""
+msgstr "Export Data"
 
 #: templates/admin/reports.php:201
 msgid "Loading report data..."
-msgstr ""
+msgstr "Loading report data..."
 
 #: templates/single-experience.php:147
 #, php-format
 msgid "%d minutes"
-msgstr ""
+msgstr "%d minutes"
 
 #: templates/single-experience.php:192
 msgid "Cancellation"
-msgstr ""
+msgstr "Cancellation"
 
 #: templates/single-experience.php:193
 msgid "Free cancellation up to 24 hours"
-msgstr ""
+msgstr "Free cancellation up to 24 hours"
 
 #: templates/single-experience.php:201
 msgid "Instant confirmation"
-msgstr ""
+msgstr "Instant confirmation"
 
 #: templates/single-experience.php:215
 msgid "About This Experience"
-msgstr ""
+msgstr "About This Experience"
 
 #: templates/single-experience.php:236
 msgid "Professional guide"
-msgstr ""
+msgstr "Professional guide"
 
 #: templates/single-experience.php:237
 msgid "All activities as described"
-msgstr ""
+msgstr "All activities as described"
 
 #: templates/single-experience.php:238
 msgid "Small group experience"
-msgstr ""
+msgstr "Small group experience"
 
 #: templates/single-experience.php:254
 msgid "Hotel pickup and drop-off"
-msgstr ""
+msgstr "Hotel pickup and drop-off"
 
 #: templates/single-experience.php:255
 msgid "Food and drinks"
-msgstr ""
+msgstr "Food and drinks"
 
 #: templates/single-experience.php:256
 msgid "Personal expenses"
-msgstr ""
+msgstr "Personal expenses"
 
 #: templates/single-experience.php:257
 msgid "Gratuities"
-msgstr ""
+msgstr "Gratuities"
 
 #: templates/single-experience.php:277
 msgid "Meeting Instructions:"
-msgstr ""
+msgstr "Meeting Instructions:"
 
 #: templates/single-experience.php:288
 msgid "Open meeting point in Google Maps"
-msgstr ""
+msgstr "Open meeting point in Google Maps"
 
 #: templates/single-experience.php:289
 msgid "Open in Google Maps"
-msgstr ""
+msgstr "Open in Google Maps"
 
-#: templates/single-experience.php:298
-#: templates/single-experience.php:307
+#: templates/single-experience.php:298 templates/single-experience.php:307
 msgid "Map showing meeting point location"
-msgstr ""
+msgstr "Map showing meeting point location"
 
 #: templates/single-experience.php:313
 msgid "Map coordinates not available"
-msgstr ""
+msgstr "Map coordinates not available"
 
-#: templates/single-experience.php:345
-#: templates/single-experience.php:425
+#: templates/single-experience.php:345 templates/single-experience.php:425
 msgid "Reviews"
-msgstr ""
+msgstr "Reviews"
 
-#: templates/single-experience.php:352
-#: templates/single-experience.php:428
+#: templates/single-experience.php:352 templates/single-experience.php:428
 #, php-format
 msgid "%s out of 5 stars"
-msgstr ""
+msgstr "%s out of 5 stars"
 
-#: templates/single-experience.php:366
-#: templates/single-experience.php:442
+#: templates/single-experience.php:366 templates/single-experience.php:442
 #, php-format
 msgid "%d review"
 msgid_plural "%d reviews"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d review"
+msgstr[1] "%d reviews"
 
 #: templates/single-experience.php:385
 #, php-format
 msgid "%d out of 5 stars"
-msgstr ""
+msgstr "%d out of 5 stars"
 
-#: templates/single-experience.php:408
-#: templates/single-experience.php:448
+#: templates/single-experience.php:408 templates/single-experience.php:448
 msgid "Reviews via Google"
-msgstr ""
+msgstr "Reviews via Google"
 
-#: templates/single-experience.php:414
-#: templates/single-experience.php:453
+#: templates/single-experience.php:414 templates/single-experience.php:453
 msgid "View on Google Maps"
-msgstr ""
+msgstr "View on Google Maps"
 
 #: templates/single-experience.php:471
 msgid "Frequently Asked Questions"
-msgstr ""
+msgstr "Frequently Asked Questions"
 
 #: templates/single-experience.php:504
 msgid "Customer Reviews"
-msgstr ""
+msgstr "Customer Reviews"
 
 #: templates/single-experience.php:506
-msgid "Reviews integration will be available in a future update. Real customer reviews from Google will be displayed here."
+msgid ""
+"Reviews integration will be available in a future update. Real customer "
+"reviews from Google will be displayed here."
 msgstr ""
+"Reviews integration will be available in a future update. Real customer "
+"reviews from Google will be displayed here."
 
 #: templates/single-experience.php:516
 msgid "Based on authentic reviews"
-msgstr ""
+msgstr "Based on authentic reviews"
 
 #: templates/single-experience.php:528
 msgid "Book This Experience"
-msgstr ""
+msgstr "Book This Experience"
 
 #: templates/single-experience.php:554
 msgid "Choose your preferred date"
-msgstr ""
+msgstr "Choose your preferred date"
 
 #: templates/single-experience.php:560
 msgid "Available Times"
-msgstr ""
+msgstr "Available Times"
 
 #: templates/single-experience.php:565
 msgid "Please select a date to see available times."
-msgstr ""
+msgstr "Please select a date to see available times."
 
 #: templates/single-experience.php:579
 msgid "Experience language"
-msgstr ""
+msgstr "Experience language"
 
 #: templates/single-experience.php:592
 msgid "Age 13+"
-msgstr ""
+msgstr "Age 13+"
 
 #: templates/single-experience.php:598
 msgid "Decrease adult count"
-msgstr ""
+msgstr "Decrease adult count"
 
 #: templates/single-experience.php:606
 msgid "Number of adults"
-msgstr ""
+msgstr "Number of adults"
 
 #: templates/single-experience.php:610
 msgid "Increase adult count"
-msgstr ""
+msgstr "Increase adult count"
 
 #: templates/single-experience.php:619
 msgid "Age 3-12"
-msgstr ""
+msgstr "Age 3-12"
 
 #: templates/single-experience.php:625
 msgid "Decrease child count"
-msgstr ""
+msgstr "Decrease child count"
 
 #: templates/single-experience.php:633
 msgid "Number of children"
-msgstr ""
+msgstr "Number of children"
 
 #: templates/single-experience.php:637
 msgid "Increase child count"
-msgstr ""
+msgstr "Increase child count"
 
 #: templates/single-experience.php:652
 msgid "Add Extras"
-msgstr ""
+msgstr "Add Extras"
 
 #: templates/single-experience.php:694
 msgid "Quantity"
-msgstr ""
+msgstr "Quantity"
 
 #: templates/single-experience.php:698
 #, php-format
 msgid "Decrease %s quantity"
-msgstr ""
+msgstr "Decrease %s quantity"
 
 #: templates/single-experience.php:705
 #, php-format
 msgid "%s quantity"
-msgstr ""
+msgstr "%s quantity"
 
 #: templates/single-experience.php:708
 #, php-format
 msgid "Increase %s quantity"
-msgstr ""
+msgstr "Increase %s quantity"
 
 #: templates/single-experience.php:728
 msgid "Gift this experience"
-msgstr ""
+msgstr "Gift this experience"
 
 #: templates/single-experience.php:735
 msgid "Your name (optional)"
-msgstr ""
+msgstr "Your name (optional)"
 
 #: templates/single-experience.php:740
 msgid "Your name"
-msgstr ""
+msgstr "Your name"
 
-#: templates/single-experience.php:745
-#: templates/single-experience.php:752
+#: templates/single-experience.php:745 templates/single-experience.php:752
 msgid "Recipient name"
-msgstr ""
+msgstr "Recipient name"
 
 #: templates/single-experience.php:758
 msgid "Recipient email"
-msgstr ""
+msgstr "Recipient email"
 
 #: templates/single-experience.php:765
 msgid "recipient@example.com"
-msgstr ""
+msgstr "recipient@example.com"
 
 #: templates/single-experience.php:770
 msgid "Send date (optional)"
-msgstr ""
+msgstr "Send date (optional)"
 
 #: templates/single-experience.php:777
 msgid "Leave empty to send immediately"
-msgstr ""
+msgstr "Leave empty to send immediately"
 
 #: templates/single-experience.php:782
 msgid "Personal message (optional)"
-msgstr ""
+msgstr "Personal message (optional)"
 
 #: templates/single-experience.php:787
 msgid "Write a personal message..."
-msgstr ""
+msgstr "Write a personal message..."
 
 #: templates/single-experience.php:799
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
-#: templates/single-experience.php:810
-#: templates/voucher-form.php:19
+#: templates/single-experience.php:810 templates/voucher-form.php:19
 msgid "Have a voucher?"
-msgstr ""
+msgstr "Have a voucher?"
 
-#: templates/single-experience.php:817
-#: templates/voucher-form.php:26
+#: templates/single-experience.php:817 templates/voucher-form.php:26
 msgid "Enter voucher code"
-msgstr ""
+msgstr "Enter voucher code"
 
-#: templates/single-experience.php:845
-#: assets/js/booking-widget.js:529
+#: templates/single-experience.php:845 assets/js/booking-widget.js:529
 #: assets/js/frontend.js:663
 msgid "Add to Cart"
-msgstr ""
+msgstr "Add to Cart"
 
 #: templates/single-experience.php:848
 msgid "Select date and participants to continue"
-msgstr ""
+msgstr "Select date and participants to continue"
 
 #: templates/single-experience.php:854
 msgid "Loading availability..."
-msgstr ""
+msgstr "Loading availability..."
 
 #: templates/voucher-form.php:27
 msgid "Voucher code input"
-msgstr ""
+msgstr "Voucher code input"
 
-#: templates/voucher-form.php:53
-#: assets/js/frontend.js:227
-#, php-format,js-format
+#: templates/voucher-form.php:53 assets/js/frontend.js:227
+#, php-format
 msgid "Voucher applied: %s"
-msgstr ""
+msgstr "Voucher applied: %s"
 
 #: assets/js/admin.js:224
 msgid "There was an error while fetching events!"
-msgstr ""
+msgstr "There was an error while fetching events!"
 
 #: assets/js/admin.js:232
 msgid "Customer"
-msgstr ""
+msgstr "Customer"
 
 #: assets/js/admin.js:234
 msgid "adults"
-msgstr ""
+msgstr "adults"
 
 #: assets/js/admin.js:234
 msgid "children"
-msgstr ""
+msgstr "children"
 
-#: assets/js/admin.js:526
-#: assets/js/admin.js:1916
+#: assets/js/admin.js:526 assets/js/admin.js:1916
 msgid "Please fix the following errors:"
-msgstr ""
+msgstr "Please fix the following errors:"
 
 #: assets/js/admin.js:634
-#, js-format
 msgid "No time slots configured yet. Click \"%s\" below to get started."
-msgstr ""
+msgstr "No time slots configured yet. Click \"%s\" below to get started."
 
 #: assets/js/admin.js:661
 msgid "min"
-msgstr ""
+msgstr "min"
 
 #: assets/js/admin.js:663
 msgid "setting"
-msgstr ""
+msgstr "setting"
 
 #: assets/js/admin.js:663
 msgid "settings"
-msgstr ""
+msgstr "settings"
 
 #: assets/js/admin.js:820
 msgid "Error adding time slot. Please try again."
-msgstr ""
+msgstr "Error adding time slot. Please try again."
 
 #: assets/js/admin.js:834
 msgid "Are you sure you want to remove this time slot?"
-msgstr ""
+msgstr "Are you sure you want to remove this time slot?"
 
 #: assets/js/admin.js:841
 msgid "Error removing time slot. Please try again."
-msgstr ""
+msgstr "Error removing time slot. Please try again."
 
 #: assets/js/admin.js:1583
 msgid "Error: Unable to find time slots container. Please refresh the page."
-msgstr ""
+msgstr "Error: Unable to find time slots container. Please refresh the page."
 
 #: assets/js/admin.js:1599
 msgid "Error creating time slot card. Please try again."
-msgstr ""
+msgstr "Error creating time slot card. Please try again."
 
 #: assets/js/admin.js:1846
 msgid "Error: Override container not found. Please refresh the page."
-msgstr ""
+msgstr "Error: Override container not found. Please refresh the page."
 
 #: assets/js/admin.js:1883
 msgid "Error adding override. Please try again."
-msgstr ""
+msgstr "Error adding override. Please try again."
 
-#: assets/js/admin.js:1907
-#: assets/js/admin.js:2169
+#: assets/js/admin.js:1907 assets/js/admin.js:2169
 msgid "Select at least one day of the week"
-msgstr ""
+msgstr "Select at least one day of the week"
 
 #: assets/js/admin.js:1971
 msgid "selected"
-msgstr ""
+msgstr "selected"
 
 #: assets/js/admin.js:1971
 msgid "deselected"
-msgstr ""
+msgstr "deselected"
 
 #: assets/js/admin.js:2095
 msgid "Add Another Time Slot"
-msgstr ""
+msgstr "Add Another Time Slot"
 
 #: assets/js/admin.js:2107
 msgid "1 time slot configured"
-msgstr ""
+msgstr "1 time slot configured"
 
 #: assets/js/admin.js:2107
-#, js-format
 msgid "%d time slots configured"
-msgstr ""
+msgstr "%d time slots configured"
 
 #: assets/js/admin.js:2125
 msgid "Add Another Date Override"
-msgstr ""
+msgstr "Add Another Date Override"
 
 #: assets/js/admin.js:2137
 msgid "1 date override configured"
-msgstr ""
+msgstr "1 date override configured"
 
 #: assets/js/admin.js:2137
-#, js-format
 msgid "%d date overrides configured"
-msgstr ""
+msgstr "%d date overrides configured"
 
 #: assets/js/admin.js:2160
 msgid "Start time is required"
-msgstr ""
+msgstr "Start time is required"
 
 #: assets/js/admin.js:2162
 msgid "Please select a start time"
-msgstr ""
+msgstr "Please select a start time"
 
 #: assets/js/admin.js:2171
 msgid "Please select at least one day"
-msgstr ""
+msgstr "Please select at least one day"
 
 #: assets/js/admin.js:2177
 msgid "Please fix the validation errors in the time slot configuration"
-msgstr ""
+msgstr "Please fix the validation errors in the time slot configuration"
 
 #: assets/js/admin.js:2364
 msgid "Unexpected error occurred"
-msgstr ""
+msgstr "Unexpected error occurred"
 
 #: assets/js/admin.js:2371
 msgid "Promise rejection"
-msgstr ""
+msgstr "Promise rejection"
 
 #: assets/js/admin.js:2414
 msgid "A critical error occurred. Please refresh the page."
-msgstr ""
+msgstr "A critical error occurred. Please refresh the page."
 
 #: assets/js/admin.js:2517
 msgid "Date marked as closed"
-msgstr ""
+msgstr "Date marked as closed"
 
 #: assets/js/admin.js:2521
 msgid "Date reopened for bookings"
-msgstr ""
+msgstr "Date reopened for bookings"
 
 #: assets/js/admin.js:2531
 msgid "Error updating closed status. Please try again."
-msgstr ""
+msgstr "Error updating closed status. Please try again."
 
 #: assets/js/admin.js:2613
 msgid "Processing..."
-msgstr ""
+msgstr "Processing..."
 
 #: assets/js/archive-block.js:15
 msgid "Experience Archive"
-msgstr ""
+msgstr "Experience Archive"
 
 #: assets/js/archive-block.js:16
 msgid "Display a filterable archive of experiences"
-msgstr ""
+msgstr "Display a filterable archive of experiences"
 
 #: assets/js/archive-block.js:20
 msgid "experience"
-msgstr ""
+msgstr "experience"
 
 #: assets/js/archive-block.js:21
 msgid "archive"
-msgstr ""
+msgstr "archive"
 
 #: assets/js/archive-block.js:22
 msgid "filter"
-msgstr ""
+msgstr "filter"
 
 #: assets/js/archive-block.js:81
 msgid "Descending"
-msgstr ""
+msgstr "Descending"
 
 #: assets/js/archive-block.js:82
 msgid "Ascending"
-msgstr ""
+msgstr "Ascending"
 
 #: assets/js/archive-block.js:96
 msgid "Display Settings"
-msgstr ""
+msgstr "Display Settings"
 
 #: assets/js/archive-block.js:100
 msgid "Posts per page"
-msgstr ""
+msgstr "Posts per page"
 
 #: assets/js/archive-block.js:107
 msgid "Columns"
-msgstr ""
+msgstr "Columns"
 
 #: assets/js/archive-block.js:114
 msgid "Order by"
-msgstr ""
+msgstr "Order by"
 
 #: assets/js/archive-block.js:132
 msgid "Enable Language Filter"
-msgstr ""
+msgstr "Enable Language Filter"
 
 #: assets/js/archive-block.js:137
 msgid "Enable Meeting Point Filter"
-msgstr ""
+msgstr "Enable Meeting Point Filter"
 
 #: assets/js/archive-block.js:142
 msgid "Enable Duration Filter"
-msgstr ""
+msgstr "Enable Duration Filter"
 
 #: assets/js/archive-block.js:147
 msgid "Enable Date Availability Filter"
-msgstr ""
+msgstr "Enable Date Availability Filter"
 
 #: assets/js/archive-block.js:172
 msgid "🎯 Experience Archive"
-msgstr ""
+msgstr "🎯 Experience Archive"
 
 #: assets/js/archive-block.js:181
 msgid "Displaying"
-msgstr ""
+msgstr "Displaying"
 
 #: assets/js/archive-block.js:182
 msgid "experiences in"
-msgstr ""
+msgstr "experiences in"
 
 #: assets/js/archive-block.js:183
 msgid "columns"
-msgstr ""
+msgstr "columns"
 
 #: assets/js/archive-block.js:192
 msgid "Order:"
-msgstr ""
+msgstr "Order:"
 
 #: assets/js/archive-block.js:203
 msgid "Active filters:"
-msgstr ""
+msgstr "Active filters:"
 
 #: assets/js/archive-block.js:213
 msgid "This block will display the experience archive on the frontend"
-msgstr ""
+msgstr "This block will display the experience archive on the frontend"
 
 #: assets/js/booking-widget.js:311
-#, js-format
 msgid "%d spots available"
-msgstr ""
+msgstr "%d spots available"
 
 #: assets/js/booking-widget.js:312
 msgid "sold out"
-msgstr ""
+msgstr "sold out"
 
 #: assets/js/booking-widget.js:323
-#, js-format
 msgid "Time slot %1$s to %2$s, %3$s, price from €%4$s"
-msgstr ""
+msgstr "Time slot %1$s to %2$s, %3$s, price from €%4$s"
 
 #: assets/js/booking-widget.js:326
-#, js-format
 msgid "From €%s"
-msgstr ""
+msgstr "From €%s"
 
 #: assets/js/booking-widget.js:347
 msgid "Only 1 spot left!"
-msgstr ""
+msgstr "Only 1 spot left!"
 
 #: assets/js/booking-widget.js:348
-#, js-format
 msgid "Only %d spots left!"
-msgstr ""
+msgstr "Only %d spots left!"
 
 #: assets/js/booking-widget.js:387
 msgid "Adult"
-msgstr ""
+msgstr "Adult"
 
 #: assets/js/booking-widget.js:391
 msgid "Child"
-msgstr ""
+msgstr "Child"
 
 #: assets/js/booking-widget.js:409
 msgid "people"
-msgstr ""
+msgstr "people"
 
 #: assets/js/booking-widget.js:482
 msgid "Ready to book this experience"
-msgstr ""
+msgstr "Ready to book this experience"
 
 #: assets/js/booking-widget.js:484
 msgid "Select a date to continue"
-msgstr ""
+msgstr "Select a date to continue"
 
 #: assets/js/booking-widget.js:486
 msgid "Select a time slot to continue"
-msgstr ""
+msgstr "Select a time slot to continue"
 
 #: assets/js/booking-widget.js:488
 msgid "Select at least one participant"
-msgstr ""
+msgstr "Select at least one participant"
 
 #: assets/js/booking-widget.js:490
 msgid "Complete all required fields"
-msgstr ""
+msgstr "Complete all required fields"
 
-#: assets/js/booking-widget.js:506
-#: assets/js/frontend.js:608
+#: assets/js/booking-widget.js:506 assets/js/frontend.js:608
 msgid "Adding..."
-msgstr ""
+msgstr "Adding..."
 
 #: assets/js/frontend.js:131
 msgid "Applying..."
-msgstr ""
+msgstr "Applying..."
 
-#: assets/js/frontend.js:161
-#: assets/js/frontend.js:202
+#: assets/js/frontend.js:161 assets/js/frontend.js:202
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Something went wrong. Please try again."
 
 #: assets/js/frontend.js:177
 msgid "Removing..."
-msgstr ""
+msgstr "Removing..."
 
 #: assets/js/frontend.js:444
 msgid "Request timed out. Please try again."
-msgstr ""
+msgstr "Request timed out. Please try again."
 
 #: assets/js/frontend.js:446
 msgid "Network error. Please check your connection."
-msgstr ""
+msgstr "Network error. Please check your connection."
 
 #: assets/js/frontend.js:658
 msgid "Failed to add to cart"
-msgstr ""
+msgstr "Failed to add to cart"
 
 #: assets/js/frontend.js:662
 msgid "Failed to add to cart. Please try again."
-msgstr ""
+msgstr "Failed to add to cart. Please try again."

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,5 @@ parameters:
         - '#Function wp_die invoked with 1 parameter#'
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
-    bootstrap: phpstan-bootstrap.php
+    bootstrapFiles:
+        - phpstan-bootstrap.php


### PR DESCRIPTION
## Summary
- Localize frontend, booking widget, and admin scripts with `wp_set_script_translations` and `wp_localize_script`
- Wrap user-facing strings in `wp.i18n.__` across frontend, booking widget, and admin JS
- Regenerate translation template and provide base `en_US` `.po` file
- Ignore compiled `.mo` binaries to keep repository text-based
- Fix phpstan configuration using `bootstrapFiles`

## Testing
- `composer test` *(fails: Child process error: PHPStan process crashed because it reached configured PHP memory limit: 128M)*
- `php -d memory_limit=512M vendor/bin/phpstan analyse` *(fails: Found 4283 errors)*
- `vendor/bin/phpcs --standard=WordPress includes/` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bddbd57108832fa5e582ee95c8d31c