### PR TITLE
Add WP-CLI translation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,7 +1324,15 @@ find . -name "*.php" -not -path "./vendor/*" | xargs xgettext \
   --default-domain=fp-esperienze \
   --output=languages/fp-esperienze.pot \
   --add-comments=translators \
-  --force-po
+--force-po
+```
+
+### WP-CLI Translation Command
+
+Queue all plugin content for translation via WP-CLI:
+
+```bash
+wp fp-esperienze translate
 ```
 
 ### JavaScript Localization

--- a/fp-esperienze.php
+++ b/fp-esperienze.php
@@ -75,6 +75,11 @@ if (!$composer_available) {
     require_once $autoloader_path;
 }
 
+// Register WP-CLI commands.
+if (defined('WP_CLI') && WP_CLI) {
+    \WP_CLI::add_command('fp-esperienze', \FP\Esperienze\CLI\TranslateCommand::class);
+}
+
 /**
  * Initialize the plugin
  */

--- a/includes/CLI/TranslateCommand.php
+++ b/includes/CLI/TranslateCommand.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * WP-CLI commands for FP Esperienze.
+ *
+ * @package FP\Esperienze\CLI
+ */
+
+namespace FP\Esperienze\CLI;
+
+use FP\Esperienze\Core\I18nManager;
+use FP\Esperienze\Data\MeetingPointManager;
+use WP_CLI;
+use WP_CLI_Command;
+
+// Exit if accessed directly.
+defined('ABSPATH') || exit;
+
+/**
+ * Translation related commands.
+ */
+class TranslateCommand extends WP_CLI_Command {
+    /**
+     * Queue plugin content for translation.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze translate
+     */
+    public function translate($args, $assoc_args): void {
+        $languages = I18nManager::getAvailableLanguages();
+
+        // Process experience products.
+        $experience_ids = get_posts([
+            'post_type'      => 'product',
+            'post_status'    => 'any',
+            'posts_per_page' => -1,
+            'fields'         => 'ids',
+            'meta_query'     => [
+                [
+                    'key'   => '_product_type',
+                    'value' => 'experience',
+                ],
+            ],
+        ]);
+
+        foreach ($experience_ids as $post_id) {
+            foreach ($languages as $lang) {
+                if (function_exists('wpml_tm_create_post_job')) {
+                    wpml_tm_create_post_job($post_id, $lang);
+                }
+            }
+        }
+
+        // Process meeting points.
+        $meeting_points = MeetingPointManager::getAllMeetingPoints(false);
+        $default_lang   = $languages[0] ?? null;
+        if ($default_lang && function_exists('do_action')) {
+            do_action('wpml_switch_language', $default_lang); // Switch context for translation registration.
+        }
+
+        foreach ($meeting_points as $mp) {
+            I18nManager::translateString($mp->name, 'meeting_point_name_' . $mp->id);
+            I18nManager::translateString($mp->address, 'meeting_point_address_' . $mp->id);
+            if (!empty($mp->note)) {
+                I18nManager::translateString($mp->note, 'meeting_point_note_' . $mp->id);
+            }
+        }
+
+        WP_CLI::success(sprintf(
+            'Processed %d experiences and %d meeting points.',
+            count($experience_ids),
+            count($meeting_points)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- add `fp-esperienze translate` WP-CLI command to queue experience products and meeting points for translation
- register the command during plugin bootstrap
- document CLI translation usage in README

## Testing
- `composer install`
- `composer test` *(fails: Result is incomplete because of severe errors)*
- `composer phpcs` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bde1a882d4832f8afaac1484343b66