### PR TITLE
feat: add target languages option for auto translations

### DIFF
--- a/includes/Admin/Settings/TranslationHelp.php
+++ b/includes/Admin/Settings/TranslationHelp.php
@@ -71,6 +71,9 @@ class TranslationHelp {
                     );
                     ?>
                 </li>
+                <li>
+                    <?php esc_html_e('Choose the target languages for automatic translation in the Auto Translation settings.', 'fp-esperienze'); ?>
+                </li>
             </ol>
             <p>
                 <?php

--- a/includes/CLI/TranslateCommand.php
+++ b/includes/CLI/TranslateCommand.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\CLI;
 
+use FP\Esperienze\Admin\Settings\AutoTranslateSettings;
 use FP\Esperienze\Core\I18nManager;
 use FP\Esperienze\Data\MeetingPointManager;
 use WP_CLI;
@@ -27,7 +28,9 @@ class TranslateCommand extends WP_CLI_Command {
      *     wp fp-esperienze translate
      */
     public function translate($args, $assoc_args): void {
-        $languages = I18nManager::getAvailableLanguages();
+        $available = I18nManager::getAvailableLanguages();
+        $selected  = (array) get_option(AutoTranslateSettings::OPTION_TARGET_LANGUAGES, []);
+        $languages = !empty($selected) ? array_values(array_intersect($available, $selected)) : $available;
 
         // Process experience products.
         $experience_ids = get_posts([

--- a/includes/Core/TranslationQueue.php
+++ b/includes/Core/TranslationQueue.php
@@ -9,6 +9,8 @@
 
 namespace FP\Esperienze\Core;
 
+use FP\Esperienze\Admin\Settings\AutoTranslateSettings;
+
 defined('ABSPATH') || exit;
 
 /**
@@ -183,7 +185,10 @@ class TranslationQueue {
             return;
         }
 
-        $languages = I18nManager::getAvailableLanguages();
+        $available       = I18nManager::getAvailableLanguages();
+        $target_langs    = (array) get_option(AutoTranslateSettings::OPTION_TARGET_LANGUAGES, []);
+        $languages       = !empty($target_langs) ? array_values(array_intersect($available, $target_langs)) : $available;
+
         foreach ($languages as $lang) {
             if (function_exists('wpml_tm_create_post_job')) {
                 wpml_tm_create_post_job($post_id, $lang);

--- a/includes/Data/WPMLHooks.php
+++ b/includes/Data/WPMLHooks.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\Data;
 
+use FP\Esperienze\Admin\Settings\AutoTranslateSettings;
 use FP\Esperienze\Core\I18nManager;
 
 defined('ABSPATH') || exit;
@@ -43,7 +44,9 @@ class WPMLHooks {
         }
 
         // Determine available languages.
-        $languages = I18nManager::getAvailableLanguages();
+        $available = I18nManager::getAvailableLanguages();
+        $selected  = (array) get_option(AutoTranslateSettings::OPTION_TARGET_LANGUAGES, []);
+        $languages = !empty($selected) ? array_values(array_intersect($available, $selected)) : $available;
         if (empty($languages)) {
             return;
         }

--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\Frontend;
 
+use FP\Esperienze\Admin\Settings\AutoTranslateSettings;
 use FP\Esperienze\Data\Availability;
 use FP\Esperienze\Data\MeetingPointManager;
 use FP\Esperienze\Core\I18nManager;
@@ -411,6 +412,10 @@ class Shortcodes {
         // Use multilingual plugin languages if available
         if (I18nManager::isMultilingualActive()) {
             $available_languages = I18nManager::getAvailableLanguages();
+            $selected            = (array) get_option(AutoTranslateSettings::OPTION_TARGET_LANGUAGES, []);
+            if (!empty($selected)) {
+                $available_languages = array_values(array_intersect($available_languages, $selected));
+            }
             if (!empty($available_languages)) {
                 return $available_languages;
             }
@@ -435,7 +440,12 @@ class Shortcodes {
             $languages = array_merge($languages, $langs);
         }
 
-        return array_unique(array_filter($languages));
+        $languages = array_unique(array_filter($languages));
+        $selected  = (array) get_option(AutoTranslateSettings::OPTION_TARGET_LANGUAGES, []);
+        if (!empty($selected)) {
+            $languages = array_values(array_intersect($languages, $selected));
+        }
+        return $languages;
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow selecting target languages for automatic translation
- limit translation jobs and commands to chosen languages
- document how to choose auto-translation languages

## Testing
- `composer test` *(fails: Result is incomplete because of severe errors)*
- `composer phpcs` *(fails: WordPress coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bde4c9bd5c832f85b30e4f1f3c2236