### PR TITLE
Escape translation outputs in shortcode and admin reports templates

### DIFF
--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -85,7 +85,7 @@ class Shortcodes {
 
             <div class="fp-experience-results" aria-live="polite">
                 <?php if (!$products->have_posts()) : ?>
-                    <p class="fp-no-results"><?php _e('No experiences found.', 'fp-esperienze'); ?></p>
+                    <p class="fp-no-results"><?php esc_html_e('No experiences found.', 'fp-esperienze'); ?></p>
                 <?php else : ?>
                     <div class="fp-experience-grid">
                         <?php while ($products->have_posts()) : $products->the_post(); ?>
@@ -328,9 +328,9 @@ class Shortcodes {
                     
                     <?php if (in_array('mp', $enabled_filters)) : ?>
                         <div class="fp-filter-group">
-                            <label for="fp_mp"><?php _e('Meeting Point', 'fp-esperienze'); ?></label>
+                            <label for="fp_mp"><?php esc_html_e('Meeting Point', 'fp-esperienze'); ?></label>
                             <select name="fp_mp" id="fp_mp" class="fp-filter-select" aria-label="<?php esc_attr_e('Filter by meeting point', 'fp-esperienze'); ?>">
-                                <option value=""><?php _e('All locations', 'fp-esperienze'); ?></option>
+                                <option value=""><?php esc_html_e('All locations', 'fp-esperienze'); ?></option>
                                 <?php
                                 $meeting_points = MeetingPointManager::getAllMeetingPoints();
                                 foreach ($meeting_points as $mp) {
@@ -344,9 +344,9 @@ class Shortcodes {
 
                     <?php if (in_array('lang', $enabled_filters)) : ?>
                         <div class="fp-filter-group">
-                            <label for="fp_lang"><?php _e('Language', 'fp-esperienze'); ?></label>
+                            <label for="fp_lang"><?php esc_html_e('Language', 'fp-esperienze'); ?></label>
                             <select name="fp_lang" id="fp_lang" class="fp-filter-select" aria-label="<?php esc_attr_e('Filter by language', 'fp-esperienze'); ?>">
-                                <option value=""><?php _e('All languages', 'fp-esperienze'); ?></option>
+                                <option value=""><?php esc_html_e('All languages', 'fp-esperienze'); ?></option>
                                 <?php
                                 $languages = $this->getAvailableLanguages();
                                 foreach ($languages as $lang) {
@@ -360,19 +360,19 @@ class Shortcodes {
 
                     <?php if (in_array('duration', $enabled_filters)) : ?>
                         <div class="fp-filter-group">
-                            <label for="fp_duration"><?php _e('Duration', 'fp-esperienze'); ?></label>
+                            <label for="fp_duration"><?php esc_html_e('Duration', 'fp-esperienze'); ?></label>
                             <select name="fp_duration" id="fp_duration" class="fp-filter-select" aria-label="<?php esc_attr_e('Filter by duration', 'fp-esperienze'); ?>">
-                                <option value=""><?php _e('Any duration', 'fp-esperienze'); ?></option>
-                                <option value="<=90" <?php selected(isset($_GET['fp_duration']) ? sanitize_text_field($_GET['fp_duration']) : '', '<=90'); ?>><?php _e('Up to 1.5 hours', 'fp-esperienze'); ?></option>
-                                <option value="91-180" <?php selected(isset($_GET['fp_duration']) ? sanitize_text_field($_GET['fp_duration']) : '', '91-180'); ?>><?php _e('1.5 - 3 hours', 'fp-esperienze'); ?></option>
-                                <option value=">180" <?php selected(isset($_GET['fp_duration']) ? sanitize_text_field($_GET['fp_duration']) : '', '>180'); ?>><?php _e('More than 3 hours', 'fp-esperienze'); ?></option>
+                                <option value=""><?php esc_html_e('Any duration', 'fp-esperienze'); ?></option>
+                                <option value="<=90" <?php selected(isset($_GET['fp_duration']) ? sanitize_text_field($_GET['fp_duration']) : '', '<=90'); ?>><?php esc_html_e('Up to 1.5 hours', 'fp-esperienze'); ?></option>
+                                <option value="91-180" <?php selected(isset($_GET['fp_duration']) ? sanitize_text_field($_GET['fp_duration']) : '', '91-180'); ?>><?php esc_html_e('1.5 - 3 hours', 'fp-esperienze'); ?></option>
+                <option value=">180" <?php selected(isset($_GET['fp_duration']) ? sanitize_text_field($_GET['fp_duration']) : '', '>180'); ?>><?php esc_html_e('More than 3 hours', 'fp-esperienze'); ?></option>
                             </select>
                         </div>
                     <?php endif; ?>
 
                     <?php if (in_array('date', $enabled_filters)) : ?>
                         <div class="fp-filter-group">
-                            <label for="fp_date"><?php _e('Available on', 'fp-esperienze'); ?></label>
+                            <label for="fp_date"><?php esc_html_e('Available on', 'fp-esperienze'); ?></label>
                             <input type="date" name="fp_date" id="fp_date" class="fp-filter-date" 
                                    value="<?php echo esc_attr(isset($_GET['fp_date']) ? sanitize_text_field($_GET['fp_date']) : ''); ?>"
                                    min="<?php echo esc_attr(date('Y-m-d')); ?>"
@@ -384,10 +384,10 @@ class Shortcodes {
                 
                 <div class="fp-filters-actions">
                     <button type="submit" class="fp-btn fp-btn-primary fp-filter-apply">
-                        <?php _e('Apply Filters', 'fp-esperienze'); ?>
+                        <?php esc_html_e('Apply Filters', 'fp-esperienze'); ?>
                     </button>
                     <a href="?" class="fp-btn fp-btn-secondary fp-filter-reset">
-                        <?php _e('Clear', 'fp-esperienze'); ?>
+                        <?php esc_html_e('Clear', 'fp-esperienze'); ?>
                     </a>
                 </div>
 
@@ -466,7 +466,7 @@ class Shortcodes {
                 <?php if ($current_page > 1) : ?>
                     <li class="fp-pagination-item">
                         <a href="<?php echo esc_url($this->getPaginationUrl($current_page - 1)); ?>" class="fp-pagination-link fp-pagination-prev">
-                            <?php _e('Previous', 'fp-esperienze'); ?>
+                            <?php esc_html_e('Previous', 'fp-esperienze'); ?>
                         </a>
                     </li>
                 <?php endif; ?>
@@ -492,7 +492,7 @@ class Shortcodes {
                 <?php if ($current_page < $max_pages) : ?>
                     <li class="fp-pagination-item">
                         <a href="<?php echo esc_url($this->getPaginationUrl($current_page + 1)); ?>" class="fp-pagination-link fp-pagination-next">
-                            <?php _e('Next', 'fp-esperienze'); ?>
+                            <?php esc_html_e('Next', 'fp-esperienze'); ?>
                         </a>
                     </li>
                 <?php endif; ?>
@@ -543,7 +543,7 @@ class Shortcodes {
                 </a>
                 <?php if ($duration) : ?>
                     <div class="fp-experience-duration">
-                        <?php printf(__('%d min', 'fp-esperienze'), intval($duration)); ?>
+                        <?php printf( esc_html__( '%d min', 'fp-esperienze' ), intval( $duration ) ); ?>
                     </div>
                 <?php endif; ?>
             </div>
@@ -573,7 +573,7 @@ class Shortcodes {
                 <div class="fp-experience-meta">
                     <?php if ($adult_price) : ?>
                         <div class="fp-experience-price">
-                            <?php printf(__('From %s', 'fp-esperienze'), wc_price($adult_price)); ?>
+                            <?php printf( esc_html__( 'From %s', 'fp-esperienze' ), wp_kses_post( wc_price( $adult_price ) ) ); ?>
                         </div>
                     <?php endif; ?>
                     
@@ -582,7 +582,7 @@ class Shortcodes {
                            class="fp-btn fp-btn-primary fp-details-btn"
                            data-item-id="<?php echo esc_attr($product_id); ?>"
                            data-item-name="<?php echo esc_attr($product->get_name()); ?>">
-                            <?php _e('Dettagli', 'fp-esperienze'); ?>
+                            <?php esc_html_e('Dettagli', 'fp-esperienze'); ?>
                         </a>
                     </div>
                 </div>

--- a/templates/admin/reports.php
+++ b/templates/admin/reports.php
@@ -9,18 +9,18 @@ defined('ABSPATH') || exit;
 ?>
 
 <div class="wrap">
-    <h1><?php _e('Reports & Analytics', 'fp-esperienze'); ?></h1>
+    <h1><?php esc_html_e('Reports & Analytics', 'fp-esperienze'); ?></h1>
     
     <!-- Filters Section -->
     <div class="fp-reports-filters" style="background: #fff; padding: 20px; margin-bottom: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-        <h2><?php _e('Filters', 'fp-esperienze'); ?></h2>
+        <h2><?php esc_html_e('Filters', 'fp-esperienze'); ?></h2>
         <form id="fp-reports-filters" method="get">
             <input type="hidden" name="page" value="fp-esperienze-reports">
             
             <table class="form-table">
                 <tbody>
                     <tr>
-                        <th scope="row"><?php _e('Date Range', 'fp-esperienze'); ?></th>
+                        <th scope="row"><?php esc_html_e('Date Range', 'fp-esperienze'); ?></th>
                         <td>
                             <input type="date" name="date_from" id="fp-date-from" value="<?php echo date('Y-m-d', strtotime('-30 days')); ?>">
                             <span> - </span>
@@ -28,10 +28,10 @@ defined('ABSPATH') || exit;
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><?php _e('Experience', 'fp-esperienze'); ?></th>
+                        <th scope="row"><?php esc_html_e('Experience', 'fp-esperienze'); ?></th>
                         <td>
                             <select name="product_id" id="fp-product-filter">
-                                <option value=""><?php _e('All Experiences', 'fp-esperienze'); ?></option>
+                                <option value=""><?php esc_html_e('All Experiences', 'fp-esperienze'); ?></option>
                                 <?php foreach ($experience_products as $product) : ?>
                                     <option value="<?php echo esc_attr($product->ID); ?>">
                                         <?php echo esc_html($product->post_title); ?>
@@ -41,10 +41,10 @@ defined('ABSPATH') || exit;
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><?php _e('Meeting Point', 'fp-esperienze'); ?></th>
+                        <th scope="row"><?php esc_html_e('Meeting Point', 'fp-esperienze'); ?></th>
                         <td>
                             <select name="meeting_point_id" id="fp-meeting-point-filter">
-                                <option value=""><?php _e('All Meeting Points', 'fp-esperienze'); ?></option>
+                                <option value=""><?php esc_html_e('All Meeting Points', 'fp-esperienze'); ?></option>
                                 <?php foreach ($meeting_points as $mp) : ?>
                                     <option value="<?php echo esc_attr($mp->id); ?>">
                                         <?php echo esc_html($mp->name); ?>
@@ -54,10 +54,10 @@ defined('ABSPATH') || exit;
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><?php _e('Language', 'fp-esperienze'); ?></th>
+                        <th scope="row"><?php esc_html_e('Language', 'fp-esperienze'); ?></th>
                         <td>
                             <select name="language" id="fp-language-filter">
-                                <option value=""><?php _e('All Languages', 'fp-esperienze'); ?></option>
+                                <option value=""><?php esc_html_e('All Languages', 'fp-esperienze'); ?></option>
                                 <option value="en"><?php echo esc_html( \FP\Esperienze\Core\I18nManager::translateString('English', 'language_english') ); ?></option>
                                 <option value="it"><?php echo esc_html( \FP\Esperienze\Core\I18nManager::translateString('Italiano', 'language_italian') ); ?></option>
                                 <option value="es"><?php echo esc_html( \FP\Esperienze\Core\I18nManager::translateString('Español', 'language_spanish') ); ?></option>
@@ -70,7 +70,7 @@ defined('ABSPATH') || exit;
             
             <p class="submit">
                 <button type="button" id="fp-update-reports" class="button button-primary">
-                    <?php _e('Update Reports', 'fp-esperienze'); ?>
+                    <?php esc_html_e('Update Reports', 'fp-esperienze'); ?>
                 </button>
             </p>
         </form>
@@ -80,30 +80,30 @@ defined('ABSPATH') || exit;
     <div class="fp-kpi-dashboard" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 30px;">
         
         <div class="fp-kpi-card" style="background: #fff; padding: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-            <h3><?php _e('Total Revenue', 'fp-esperienze'); ?></h3>
+            <h3><?php esc_html_e('Total Revenue', 'fp-esperienze'); ?></h3>
             <div class="fp-kpi-value" id="kpi-revenue">
-                <span class="fp-loading"><?php _e('Loading...', 'fp-esperienze'); ?></span>
+                <span class="fp-loading"><?php esc_html_e('Loading...', 'fp-esperienze'); ?></span>
             </div>
         </div>
         
         <div class="fp-kpi-card" style="background: #fff; padding: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-            <h3><?php _e('Seats Sold', 'fp-esperienze'); ?></h3>
+            <h3><?php esc_html_e('Seats Sold', 'fp-esperienze'); ?></h3>
             <div class="fp-kpi-value" id="kpi-seats">
-                <span class="fp-loading"><?php _e('Loading...', 'fp-esperienze'); ?></span>
+                <span class="fp-loading"><?php esc_html_e('Loading...', 'fp-esperienze'); ?></span>
             </div>
         </div>
         
         <div class="fp-kpi-card" style="background: #fff; padding: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-            <h3><?php _e('Total Bookings', 'fp-esperienze'); ?></h3>
+            <h3><?php esc_html_e('Total Bookings', 'fp-esperienze'); ?></h3>
             <div class="fp-kpi-value" id="kpi-bookings">
-                <span class="fp-loading"><?php _e('Loading...', 'fp-esperienze'); ?></span>
+                <span class="fp-loading"><?php esc_html_e('Loading...', 'fp-esperienze'); ?></span>
             </div>
         </div>
         
         <div class="fp-kpi-card" style="background: #fff; padding: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-            <h3><?php _e('Avg Booking Value', 'fp-esperienze'); ?></h3>
+            <h3><?php esc_html_e('Avg Booking Value', 'fp-esperienze'); ?></h3>
             <div class="fp-kpi-value" id="kpi-avg-value">
-                <span class="fp-loading"><?php _e('Loading...', 'fp-esperienze'); ?></span>
+                <span class="fp-loading"><?php esc_html_e('Loading...', 'fp-esperienze'); ?></span>
             </div>
         </div>
         
@@ -114,16 +114,16 @@ defined('ABSPATH') || exit;
         
         <!-- Revenue/Seats Chart -->
         <div class="fp-chart-container" style="background: #fff; padding: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-            <h3><?php _e('Revenue & Seats Trends', 'fp-esperienze'); ?></h3>
+            <h3><?php esc_html_e('Revenue & Seats Trends', 'fp-esperienze'); ?></h3>
             <div class="chart-controls" style="margin-bottom: 15px;">
                 <button type="button" class="button chart-period" data-period="day">
-                    <?php _e('Daily', 'fp-esperienze'); ?>
+                    <?php esc_html_e('Daily', 'fp-esperienze'); ?>
                 </button>
                 <button type="button" class="button chart-period" data-period="week">
-                    <?php _e('Weekly', 'fp-esperienze'); ?>
+                    <?php esc_html_e('Weekly', 'fp-esperienze'); ?>
                 </button>
                 <button type="button" class="button chart-period" data-period="month">
-                    <?php _e('Monthly', 'fp-esperienze'); ?>
+                    <?php esc_html_e('Monthly', 'fp-esperienze'); ?>
                 </button>
             </div>
             <canvas id="fp-revenue-chart" width="400" height="200"></canvas>
@@ -131,9 +131,9 @@ defined('ABSPATH') || exit;
         
         <!-- Top Experiences -->
         <div class="fp-top-experiences" style="background: #fff; padding: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-            <h3><?php _e('Top 10 Experiences', 'fp-esperienze'); ?></h3>
+            <h3><?php esc_html_e('Top 10 Experiences', 'fp-esperienze'); ?></h3>
             <div id="fp-top-experiences-list">
-                <span class="fp-loading"><?php _e('Loading...', 'fp-esperienze'); ?></span>
+                <span class="fp-loading"><?php esc_html_e('Loading...', 'fp-esperienze'); ?></span>
             </div>
         </div>
         
@@ -141,23 +141,23 @@ defined('ABSPATH') || exit;
 
     <!-- UTM Conversions -->
     <div class="fp-utm-section" style="background: #fff; padding: 20px; margin-bottom: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-        <h3><?php _e('Traffic Source Conversions', 'fp-esperienze'); ?></h3>
+        <h3><?php esc_html_e('Traffic Source Conversions', 'fp-esperienze'); ?></h3>
         <div id="fp-utm-conversions">
-            <span class="fp-loading"><?php _e('Loading...', 'fp-esperienze'); ?></span>
+            <span class="fp-loading"><?php esc_html_e('Loading...', 'fp-esperienze'); ?></span>
         </div>
     </div>
 
     <!-- Load Factors -->
     <div class="fp-load-factors" style="background: #fff; padding: 20px; margin-bottom: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-        <h3><?php _e('Load Factors by Experience', 'fp-esperienze'); ?></h3>
+        <h3><?php esc_html_e('Load Factors by Experience', 'fp-esperienze'); ?></h3>
         <div id="fp-load-factors-table">
-            <span class="fp-loading"><?php _e('Loading...', 'fp-esperienze'); ?></span>
+            <span class="fp-loading"><?php esc_html_e('Loading...', 'fp-esperienze'); ?></span>
         </div>
     </div>
 
     <!-- Export Section -->
     <div class="fp-export-section" style="background: #fff; padding: 20px; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
-        <h3><?php _e('Export Report Data', 'fp-esperienze'); ?></h3>
+        <h3><?php esc_html_e('Export Report Data', 'fp-esperienze'); ?></h3>
         <form method="post" id="fp-export-form">
             <?php wp_nonce_field('fp_export_report', 'fp_report_nonce'); ?>
             <input type="hidden" name="action" value="export_report">
@@ -170,15 +170,15 @@ defined('ABSPATH') || exit;
             <table class="form-table">
                 <tbody>
                     <tr>
-                        <th scope="row"><?php _e('Export Format', 'fp-esperienze'); ?></th>
+                        <th scope="row"><?php esc_html_e('Export Format', 'fp-esperienze'); ?></th>
                         <td>
                             <label>
                                 <input type="radio" name="export_format" value="csv" checked>
-                                <?php _e('CSV', 'fp-esperienze'); ?>
+                                <?php esc_html_e('CSV', 'fp-esperienze'); ?>
                             </label>
                             <label style="margin-left: 20px;">
                                 <input type="radio" name="export_format" value="json">
-                                <?php _e('JSON', 'fp-esperienze'); ?>
+                                <?php esc_html_e('JSON', 'fp-esperienze'); ?>
                             </label>
                         </td>
                     </tr>
@@ -187,7 +187,7 @@ defined('ABSPATH') || exit;
             
             <p class="submit">
                 <button type="submit" class="button button-secondary">
-                    <?php _e('Export Data', 'fp-esperienze'); ?>
+                    <?php esc_html_e('Export Data', 'fp-esperienze'); ?>
                 </button>
             </p>
         </form>
@@ -198,7 +198,7 @@ defined('ABSPATH') || exit;
 <div id="fp-reports-loading" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255,255,255,0.8); z-index: 9999;">
     <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">
         <div class="spinner is-active" style="float: none;"></div>
-        <p><?php _e('Loading report data...', 'fp-esperienze'); ?></p>
+        <p><?php esc_html_e('Loading report data...', 'fp-esperienze'); ?></p>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- ensure archive filter labels and pagination strings use escaping helpers
- sanitize translated strings in admin reports template

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=WordPress includes/ handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb752e298832f9ea1a9653339a97a