### PR TITLE
Enforce rate limiting in bookings and ICS APIs

### DIFF
--- a/MANUAL_TESTS_RATE_LIMITING.md
+++ b/MANUAL_TESTS_RATE_LIMITING.md
@@ -1,0 +1,11 @@
+# Manual Tests – Rate Limiting
+
+## Bookings API
+1. Send 30 quick `GET` requests to `/wp-json/fp-exp/v1/bookings` while authenticated.
+2. Send one additional request and verify it returns HTTP `429` with a `rate_limit_exceeded` message.
+3. Confirm the response includes `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers.
+
+## ICS API
+1. Request `/wp-json/fp-esperienze/v1/ics/product/123?days=1` more than 30 times within a minute.
+2. The 31st request should respond with HTTP `429` and the same rate limit headers.
+3. After waiting one minute, requests should succeed again.

--- a/includes/REST/ICSAPI.php
+++ b/includes/REST/ICSAPI.php
@@ -10,6 +10,7 @@ namespace FP\Esperienze\REST;
 use FP\Esperienze\Data\ICSGenerator;
 use FP\Esperienze\Data\MeetingPointManager;
 use FP\Esperienze\Core\CapabilityManager;
+use FP\Esperienze\Core\RateLimiter;
 
 defined('ABSPATH') || exit;
 
@@ -116,6 +117,10 @@ class ICSAPI {
      * @return \WP_REST_Response|\WP_Error
      */
     public function getProductICS(\WP_REST_Request $request) {
+        if (!RateLimiter::checkRateLimit('ics_product', 30, 60)) {
+            return RateLimiter::createRateLimitResponse();
+        }
+
         $product_id = (int) $request->get_param('product_id');
         $days = (int) $request->get_param('days');
         
@@ -155,7 +160,11 @@ class ICSAPI {
             'Cache-Control' => 'no-cache, must-revalidate',
             'Expires' => gmdate('D, d M Y H:i:s \G\M\T', time() + 3600) // 1 hour cache
         ]);
-        
+
+        foreach (RateLimiter::getRateLimitHeaders('ics_product', 30, 60) as $header => $value) {
+            $response->header($header, $value);
+        }
+
         return $response;
     }
     
@@ -166,6 +175,10 @@ class ICSAPI {
      * @return \WP_REST_Response|\WP_Error
      */
     public function getUserBookingsICS(\WP_REST_Request $request) {
+        if (!RateLimiter::checkRateLimit('ics_user', 30, 60)) {
+            return RateLimiter::createRateLimitResponse();
+        }
+
         $user_id = (int) $request->get_param('user_id');
         
         // Validate user exists
@@ -194,7 +207,11 @@ class ICSAPI {
             'Content-Disposition' => 'attachment; filename="my-bookings.ics"',
             'Cache-Control' => 'no-cache, must-revalidate'
         ]);
-        
+
+        foreach (RateLimiter::getRateLimitHeaders('ics_user', 30, 60) as $header => $value) {
+            $response->header($header, $value);
+        }
+
         return $response;
     }
     
@@ -205,6 +222,10 @@ class ICSAPI {
      * @return \WP_REST_Response|\WP_Error
      */
     public function getBookingICS(\WP_REST_Request $request) {
+        if (!RateLimiter::checkRateLimit('ics_booking', 30, 60)) {
+            return RateLimiter::createRateLimitResponse();
+        }
+
         $booking_id = (int) $request->get_param('booking_id');
         $token = $request->get_param('token');
         
@@ -256,6 +277,10 @@ class ICSAPI {
             'Cache-Control' => 'no-cache, must-revalidate'
         ]);
 
+        foreach (RateLimiter::getRateLimitHeaders('ics_booking', 30, 60) as $header => $value) {
+            $response->header($header, $value);
+        }
+
         return $response;
     }
 
@@ -266,6 +291,10 @@ class ICSAPI {
      * @return \WP_REST_Response|\WP_Error
      */
     public function serveICSFile(\WP_REST_Request $request) {
+        if (!RateLimiter::checkRateLimit('ics_file', 30, 60)) {
+            return RateLimiter::createRateLimitResponse();
+        }
+
         $filename = basename($request->get_param('filename'));
         $token    = (string) $request->get_param('token');
         $base_dir = rtrim(realpath(FP_ESPERIENZE_ICS_DIR), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
@@ -314,6 +343,10 @@ class ICSAPI {
             'Cache-Control' => 'no-cache, must-revalidate'
         ]);
 
+        foreach (RateLimiter::getRateLimitHeaders('ics_file', 30, 60) as $header => $value) {
+            $response->header($header, $value);
+        }
+
         return $response;
     }
     
@@ -324,6 +357,10 @@ class ICSAPI {
      * @return bool|\WP_Error
      */
     public function checkUserPermission(\WP_REST_Request $request) {
+        if (!RateLimiter::checkRateLimit('ics_user_permission', 30, 60)) {
+            return RateLimiter::createRateLimitResponse();
+        }
+
         $user_id = (int) $request->get_param('user_id');
         $current_user = wp_get_current_user();
         


### PR DESCRIPTION
## Summary
- enforce RateLimiter checks in Bookings and ICS REST handlers
- append rate-limit headers to successful responses
- document manual steps for verifying 429 responses

## Testing
- `composer phpstan -- --memory-limit=512M` *(fails: [ERROR] Found 4315 errors)*
- `composer phpcs` *(fails: coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb04726c832f9f0720a7ad5fe126