### PR TITLE
Replace wp_die Unauthorized with JSON error responses

### DIFF
--- a/includes/AI/AIFeaturesManager.php
+++ b/includes/AI/AIFeaturesManager.php
@@ -140,7 +140,10 @@ class AIFeaturesManager {
      */
     public function ajaxGetAIInsights(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -158,7 +161,10 @@ class AIFeaturesManager {
      */
     public function ajaxGetRecommendations(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -176,7 +182,10 @@ class AIFeaturesManager {
      */
     public function ajaxAnalyzePerformance(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -195,7 +204,10 @@ class AIFeaturesManager {
      */
     public function ajaxUpdateAISettings(): void {
         if (!CapabilityManager::currentUserCan('manage_settings')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');

--- a/includes/Admin/AdvancedAnalytics.php
+++ b/includes/Admin/AdvancedAnalytics.php
@@ -36,7 +36,10 @@ class AdvancedAnalytics {
      */
     public function ajaxGetConversionFunnel(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -54,7 +57,10 @@ class AdvancedAnalytics {
      */
     public function ajaxGetAttributionReport(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -72,7 +78,10 @@ class AdvancedAnalytics {
      */
     public function ajaxGetRoiAnalysis(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -90,7 +99,10 @@ class AdvancedAnalytics {
      */
     public function ajaxExportAnalyticsData(): void {
         if (!CapabilityManager::currentUserCan('export_data')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -108,7 +120,10 @@ class AdvancedAnalytics {
      */
     public function ajaxGetRevenueByChannel(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');
@@ -126,7 +141,10 @@ class AdvancedAnalytics {
      */
     public function ajaxGetCustomerJourney(): void {
         if (!CapabilityManager::currentUserCan('view_reports')) {
-            wp_die('Unauthorized', 403);
+            wp_send_json_error(
+                ['message' => __('Unauthorized', 'fp-esperienze')],
+                403
+            );
         }
 
         check_ajax_referer('fp_esperienze_admin', 'nonce');


### PR DESCRIPTION
## Summary
- Replace `wp_die('Unauthorized', 403)` with `wp_send_json_error()` in AdvancedAnalytics endpoints
- Do the same replacement in AI Features Manager AJAX handlers
- Ensure unauthorized access returns localized JSON error messages

## Testing
- `composer test` (fails: Result is incomplete because of severe errors)
- `vendor/bin/phpcs --standard=WordPress includes/Admin/AdvancedAnalytics.php` (fails: numerous coding standard violations)
- `php /tmp/test_endpoints.php`

------
https://chatgpt.com/codex/tasks/task_e_68bfbc0bce84832fb6fcd5629804035a