### PR TITLE
Improve proxy IP resolution in rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A WordPress + WooCommerce plugin for experience booking management by Francesco 
 
 ### Trusted Proxy Configuration
 
-If your WordPress installation sits behind a reverse proxy or load balancer, add its IP address to the list of trusted proxies so the rate limiter can read the original client address from `X-Forwarded-*` headers.
+If your WordPress installation sits behind a reverse proxy or load balancer, add its IP address to the list of trusted proxies so the rate limiter can read the original client address from `Client-IP`, `X-Real-IP`, `Forwarded`, `Forwarded-For`, and `X-Forwarded-*` headers.
 
 ```php
 // In wp-config.php or a custom plugin.
@@ -44,7 +44,7 @@ add_filter( 'fp_trusted_proxies', function() {
 } );
 ```
 
-Only requests that originate from a trusted proxy will have their `X-Forwarded-*` headers processed. Otherwise the plugin falls back to `$_SERVER['REMOTE_ADDR']`.
+Only requests that originate from a trusted proxy will have their forwarding headers processed. Otherwise the plugin falls back to `$_SERVER['REMOTE_ADDR']` (or `wp_get_ip_address()` when available).
 
 ## Uninstall
 


### PR DESCRIPTION
## Summary
- Extend `RateLimiter::getClientIP()` to parse `Client-IP`, `X-Real-IP`, `Forwarded`, `Forwarded-For`, and `X-Forwarded-*` headers and prefer WordPress' `wp_get_ip_address()` when available
- Update trusted proxy documentation to reflect additional headers and WordPress IP helper

## Testing
- `php /tmp/test_ip.php`
- `php /tmp/test_ip_wp.php`
- `php /tmp/test_ip_forwarded.php`
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Function __ not found, 4372 errors)*
- `vendor/bin/phpcs --standard=WordPress includes/Core/RateLimiter.php` *(fails: FOUND 181 ERRORS AND 5 WARNINGS)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbf2c09f0832f8561f3208f6f3f32