### PR TITLE
Clear push token cleanup cron on deactivation

### DIFF
--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -95,6 +95,7 @@ class Installer {
             'fp_esperienze_prebuild_availability',
             'fp_esperienze_retry_webhook',
             'fp_es_process_translation_queue',
+            'fp_cleanup_push_tokens',
         ];
 
         // Clear all scheduled events for the plugin


### PR DESCRIPTION
## Summary
- ensure `fp_cleanup_push_tokens` cron is cleared on plugin deactivation

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Ignored error pattern... Found 4372 errors)*
- `vendor/bin/phpcs --standard=WordPress includes/` *(fails: 525 sniff violations)*
- `wp cron event list --allow-root` *(fails: This does not seem to be a WordPress installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc110ed9c832f9b09177a94eed98d