### PR TITLE
Validate translation endpoint and harden remote requests

### DIFF
--- a/MANUAL_TESTS_AUTO_TRANSLATION.md
+++ b/MANUAL_TESTS_AUTO_TRANSLATION.md
@@ -1,0 +1,15 @@
+# Manual Tests – Auto Translation
+
+## Endpoint Validation
+1. Navigate to **Settings > Auto Translation**.
+2. Enter an invalid endpoint like `not-a-url` and save.
+3. Trigger a translation (e.g., translate a booking name).
+4. Confirm the plugin falls back to the default `https://libretranslate.de/translate` and returns a result.
+
+## Fast Failure on Unreachable Endpoint
+1. In **Settings > Auto Translation**, set the endpoint to `https://127.0.0.1:9/translate`.
+2. Trigger a translation request.
+3. Verify the request fails within 10 seconds and the original text is returned.
+4. Check logs for an `AutoTranslator request error` entry.
+
+> Only configure trusted translation endpoints to avoid security risks.

--- a/README.md
+++ b/README.md
@@ -1327,6 +1327,18 @@ find . -name "*.php" -not -path "./vendor/*" | xargs xgettext \
 --force-po
 ```
 
+### Automatic Translation Endpoint
+
+Only configure trusted translation endpoints for the automatic translator. The
+plugin validates the endpoint with `wp_http_validate_url()` and falls back to
+the default LibreTranslate URL if the provided value is invalid. Requests use a
+10 second timeout and limit the response size to 1 MB to avoid hanging on slow
+or malicious hosts.
+
+To confirm fast failure behaviour, test with an unreachable endpoint (for
+example `https://127.0.0.1:9/translate`) and ensure the request fails
+promptly.
+
 ### WP-CLI Translation Command
 
 Queue all plugin content for translation via WP-CLI:

--- a/includes/Core/AutoTranslator.php
+++ b/includes/Core/AutoTranslator.php
@@ -30,8 +30,10 @@ class AutoTranslator {
             return (string) $cached;
         }
 
-        $endpoint = get_option('fp_lt_endpoint', 'https://libretranslate.de/translate');
-        $endpoint = apply_filters('fp_es_auto_translator_endpoint', $endpoint);
+        $default_endpoint = 'https://libretranslate.de/translate';
+        $endpoint         = get_option('fp_lt_endpoint', $default_endpoint);
+        $endpoint         = apply_filters('fp_es_auto_translator_endpoint', $endpoint);
+        $endpoint         = wp_http_validate_url($endpoint) ?: $default_endpoint;
 
         $body = [
             'q'      => $text,
@@ -46,10 +48,12 @@ class AutoTranslator {
         }
 
         $response = wp_remote_post($endpoint, [
-            'headers' => [
+            'headers'            => [
                 'Content-Type' => 'application/json',
             ],
-            'body' => wp_json_encode($body),
+            'body'               => wp_json_encode($body),
+            'timeout'            => 10,
+            'limit_response_size' => 1048576,
         ]);
 
         if (is_wp_error($response)) {


### PR DESCRIPTION
## Summary
- validate auto translation endpoint and fall back to default
- limit remote request time and response size
- document trusted endpoint requirement and add manual tests

## Testing
- `bash tools/dev-tools.sh test` (fails: PHPStan memory limit; PHPCS missing sniff)


------
https://chatgpt.com/codex/tasks/task_e_68bfcc869b60832fbd484b5d187ce9ed