### PR TITLE
Use wp_safe_redirect for admin redirects

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -183,7 +183,7 @@ class MenuManager {
             // Don't redirect if setup is already complete
             $setup_wizard = new SetupWizard();
             if (!$setup_wizard->isSetupComplete()) {
-                wp_redirect(admin_url('admin.php?page=fp-esperienze-setup-wizard'));
+                wp_safe_redirect(admin_url('admin.php?page=fp-esperienze-setup-wizard'));
                 exit;
             }
         }
@@ -1139,12 +1139,12 @@ class MenuManager {
             });
             
             // Redirect to list view after successful update
-            wp_redirect(admin_url('admin.php?page=fp-esperienze-meeting-points'));
+            wp_safe_redirect(admin_url('admin.php?page=fp-esperienze-meeting-points'));
             exit;
         } else {
             add_action('admin_notices', function() {
-                echo '<div class="notice notice-error is-dismissible"><p>' . 
-                     esc_html__('Failed to update meeting point.', 'fp-esperienze') . 
+                echo '<div class="notice notice-error is-dismissible"><p>' .
+                     esc_html__('Failed to update meeting point.', 'fp-esperienze') .
                      '</p></div>';
             });
         }

--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -175,11 +175,11 @@ class SetupWizard {
 
         // Redirect to next step or finish
         if ($step < $this->total_steps) {
-            wp_redirect(add_query_arg(['step' => $step + 1], admin_url('admin.php?page=fp-esperienze-setup-wizard')));
+            wp_safe_redirect(add_query_arg(['step' => $step + 1], admin_url('admin.php?page=fp-esperienze-setup-wizard')));
+            exit;
         } else {
             $this->finishSetup();
         }
-        exit;
     }
 
     /**
@@ -255,11 +255,11 @@ class SetupWizard {
      */
     private function skipStep(int $step): void {
         if ($step < $this->total_steps) {
-            wp_redirect(add_query_arg(['step' => $step + 1], admin_url('admin.php?page=fp-esperienze-setup-wizard')));
+            wp_safe_redirect(add_query_arg(['step' => $step + 1], admin_url('admin.php?page=fp-esperienze-setup-wizard')));
+            exit;
         } else {
             $this->finishSetup();
         }
-        exit;
     }
 
     /**
@@ -267,7 +267,7 @@ class SetupWizard {
      */
     private function finishSetup(): void {
         update_option('fp_esperienze_setup_complete', 1);
-        wp_redirect(admin_url('admin.php?page=fp-esperienze&setup=complete'));
+        wp_safe_redirect(admin_url('admin.php?page=fp-esperienze&setup=complete'));
         exit;
     }
 

--- a/includes/Admin/SystemStatus.php
+++ b/includes/Admin/SystemStatus.php
@@ -63,7 +63,7 @@ class SystemStatus {
                 break;
             case 'flush_rewrite':
                 flush_rewrite_rules();
-                wp_redirect(admin_url('admin.php?page=fp-esperienze-system-status&fixed=rewrite'));
+                wp_safe_redirect(admin_url('admin.php?page=fp-esperienze-system-status&fixed=rewrite'));
                 exit;
                 break;
         }
@@ -74,7 +74,7 @@ class SystemStatus {
      */
     private function createMissingTables(): void {
         Installer::activate();
-        wp_redirect(admin_url('admin.php?page=fp-esperienze-system-status&fixed=tables'));
+        wp_safe_redirect(admin_url('admin.php?page=fp-esperienze-system-status&fixed=tables'));
         exit;
     }
 

--- a/tools/setup-wizard-diagnostic.php
+++ b/tools/setup-wizard-diagnostic.php
@@ -18,7 +18,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 
 // Check if we're in admin context
 if (!is_admin()) {
-    wp_redirect(admin_url('admin.php?page=fp-esperienze-diagnostic'));
+    wp_safe_redirect(admin_url('admin.php?page=fp-esperienze-diagnostic'));
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Harden setup and admin flows by replacing `wp_redirect` with `wp_safe_redirect`
- Ensure each redirect immediately exits to prevent unintended execution

## Testing
- `composer install`
- `composer test` *(fails: [ERROR] Found 4383 errors)*
- `./vendor/bin/phpcs --standard=WordPress includes/Admin/SetupWizard.php includes/Admin/MenuManager.php includes/Admin/SystemStatus.php tools/setup-wizard-diagnostic.php` *(fails: PHPCBF can fix 362 sniff violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd07f19d0832f8f0a4cdb149e64b4