### PR TITLE
Load WordPress file library before using WP_Filesystem

### DIFF
--- a/includes/Core/AssetOptimizer.php
+++ b/includes/Core/AssetOptimizer.php
@@ -227,6 +227,7 @@ class AssetOptimizer {
         }
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'FP Assets: WP_Filesystem initialization failed.';
             error_log($msg);
@@ -304,6 +305,7 @@ class AssetOptimizer {
         $minified_path = self::$assets_dir . "{$asset_type}/{$group}.min.{$asset_type}";
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             error_log('FP Assets: WP_Filesystem initialization failed.');
             return false;
@@ -327,6 +329,7 @@ class AssetOptimizer {
         $frontend_js = self::$assets_dir . 'js/frontend.min.js';
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             error_log('FP Assets: WP_Filesystem initialization failed.');
             return false;
@@ -347,6 +350,7 @@ class AssetOptimizer {
         ];
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'FP Assets: WP_Filesystem initialization failed.';
             error_log($msg);

--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -54,6 +54,7 @@ class Installer {
         }
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'Installer: WP_Filesystem initialization failed during activation.';
             error_log($msg);
@@ -164,6 +165,7 @@ class Installer {
         // Remove ICS directory and files
         $ics_dir = FP_ESPERIENZE_ICS_DIR;
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'Installer: WP_Filesystem initialization failed during deactivation.';
             error_log($msg);

--- a/includes/Core/TranslationLogger.php
+++ b/includes/Core/TranslationLogger.php
@@ -37,6 +37,7 @@ class TranslationLogger {
         $entry = sprintf('[%s] %s%s', current_time('mysql'), $message, PHP_EOL);
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'TranslationLogger: WP_Filesystem initialization failed.';
             error_log($msg);

--- a/includes/Data/ICSGenerator.php
+++ b/includes/Data/ICSGenerator.php
@@ -288,6 +288,7 @@ class ICSGenerator {
         $ics_dir = FP_ESPERIENZE_ICS_DIR;
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'ICSGenerator: WP_Filesystem initialization failed.';
             error_log($msg);

--- a/includes/PDF/Qr.php
+++ b/includes/PDF/Qr.php
@@ -55,6 +55,7 @@ class Qr {
         $qr_dir     = $base_dir . 'fp-esperienze/voucher/qr/';
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'Qr: WP_Filesystem initialization failed.';
             error_log($msg);

--- a/includes/PDF/Voucher_Pdf.php
+++ b/includes/PDF/Voucher_Pdf.php
@@ -59,6 +59,7 @@ class Voucher_Pdf {
         $voucher_dir = $base_dir . 'fp-esperienze/voucher/';
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'Voucher_Pdf: WP_Filesystem initialization failed.';
             error_log($msg);
@@ -114,6 +115,7 @@ class Voucher_Pdf {
         $voucher_dir = $base_dir . 'fp-esperienze/voucher/';
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'Voucher_Pdf: WP_Filesystem initialization failed.';
             error_log($msg);
@@ -355,6 +357,7 @@ Options -Indexes
         $htaccess_path = $directory . '.htaccess';
 
         global $wp_filesystem;
+        require_once ABSPATH . 'wp-admin/includes/file.php';
         if (!WP_Filesystem()) {
             $msg = 'Voucher_Pdf: WP_Filesystem initialization failed.';
             error_log($msg);


### PR DESCRIPTION
## Summary
- require `wp-admin/includes/file.php` before any `WP_Filesystem()` calls in Installer, AssetOptimizer, ICSGenerator, TranslationLogger, and PDF helpers

## Testing
- `composer test` *(fails: result incomplete due to phpstan errors)*
- `php /tmp/test-wp-filesystem.php`

------
https://chatgpt.com/codex/tasks/task_e_68bfd62af51c832fbfd6fa26847b523a