### PR TITLE
Import Exception class for explicit catch handling

### DIFF
--- a/includes/AI/AIFeaturesManager.php
+++ b/includes/AI/AIFeaturesManager.php
@@ -10,6 +10,7 @@
 
 namespace FP\Esperienze\AI;
 
+use Exception;
 use FP\Esperienze\Core\CapabilityManager;
 
 defined('ABSPATH') || exit;

--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\Admin;
 
+use Exception;
 use FP\Esperienze\Data\OverrideManager;
 use FP\Esperienze\Data\MeetingPointManager;
 use FP\Esperienze\Data\ExtraManager;

--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\Core;
 
+use Exception;
 use FP\Esperienze\Core\CapabilityManager;
 use FP\Esperienze\Core\TranslationQueue;
 

--- a/includes/Core/QueryMonitor.php
+++ b/includes/Core/QueryMonitor.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\Core;
 
+use Exception;
 defined('ABSPATH') || exit;
 
 /**

--- a/includes/Data/VoucherManager.php
+++ b/includes/Data/VoucherManager.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\Data;
 
+use Exception;
 use FP\Esperienze\PDF\Voucher_Pdf;
 use FP\Esperienze\PDF\Qr;
 

--- a/templates/single-experience.php
+++ b/templates/single-experience.php
@@ -7,6 +7,7 @@
 
 defined('ABSPATH') || exit;
 
+use Exception;
 use FP\Esperienze\Data\MeetingPointManager;
 use FP\Esperienze\Data\ExtraManager;
 use FP\Esperienze\Integrations\GooglePlacesManager;


### PR DESCRIPTION
## Summary
- Import the base `Exception` class across admin, AI, data, core, and template files so that existing `catch (Exception $e)` blocks resolve unambiguously
- Ensures runtime errors are trapped via exception testing

## Testing
- `composer test` *(fails: Result is incomplete because of severe errors)*
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*
- `php /tmp/exception_test.php`

------
https://chatgpt.com/codex/tasks/task_e_68bfd8b55990832fba44cf03af1972a2