### PR TITLE
Use central user feedback mechanism for admin errors

### DIFF
--- a/assets/js/admin-modular.js
+++ b/assets/js/admin-modular.js
@@ -135,7 +135,7 @@
             $('form#post').on('submit', function() {
                 if ($('body').hasClass('post-type-product') && $('#product-type').val() !== 'experience') {
                     // Show user-friendly error message
-                    this.showErrorMessage('This product must be of type "Experience"');
+                    self.showErrorMessage('This product must be of type "Experience"');
                     return false;
                 }
             });
@@ -279,7 +279,7 @@
                         };
                     },
                     failure: function() {
-                        FPEsperienze.showErrorMessage('Failed to load bookings');
+                        window.FPEsperienzeAdmin.showErrorMessage('Failed to load bookings');
                     }
                 },
                 eventClick: function(info) {
@@ -373,6 +373,13 @@
             setTimeout(function() {
                 $notice.fadeOut();
             }, duration);
+        },
+
+        /**
+         * Legacy error message helper
+         */
+        showErrorMessage: function(message, duration = 5000) {
+            this.showUserFeedback(message, 'error', duration);
         },
 
         /**


### PR DESCRIPTION
## Summary
- Replace undefined `showErrorMessage` call with `showErrorMessage` helper invoking `showUserFeedback`
- Delegate booking calendar error handling to `FPEsperienzeAdmin.showErrorMessage`
- Add legacy `showErrorMessage` wrapper around existing feedback logic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Result is incomplete because of severe errors. Fix these errors first and then re-run PHPStan to get all reported errors.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0480886c4832fa526560ec4077cb7