### PR TITLE
Normalize schedule start time handling

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -500,14 +500,15 @@
                     $slot.find('input[name*="[start_time]"]').css('border-color', '#d63638');
                     errorMessages.push('All time slots must have a start time.');
                 } else {
-                    // Validate time format on frontend too
-                    var timePattern = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
+                    // Validate time format on frontend too (allow optional seconds)
+                    var timePattern = /^([01]?[0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9])?$/;
                     if (!timePattern.test(startTime)) {
                         hasErrors = true;
                         $slot.find('input[name*="[start_time]"]').css('border-color', '#d63638');
                         errorMessages.push('Time "' + startTime + '" has invalid format. Use HH:MM format.');
                     } else {
-                        $slot.find('input[name*="[start_time]"]').css('border-color', '');
+                        startTime = startTime.substring(0,5);
+                        $slot.find('input[name*="[start_time]"]').val(startTime).css('border-color', '');
                     }
                 }
                 

--- a/includes/Helpers/ScheduleHelper.php
+++ b/includes/Helpers/ScheduleHelper.php
@@ -119,11 +119,14 @@ class ScheduleHelper {
         
         foreach ($schedules as $schedule) {
             $hydrated = self::hydrateEffectiveValues($schedule, $product_id);
-            
+
+            // Normalize start time to HH:MM for grouping
+            $start_time = substr($schedule->start_time, 0, 5);
+
             // Create grouping key based on schedule attributes (excluding day and ID)
             $key = sprintf(
                 '%s_%d_%d_%s_%s_%.2f_%.2f',
-                $schedule->start_time,
+                $start_time,
                 $hydrated->effective->duration_min,
                 $hydrated->effective->capacity,
                 $hydrated->effective->lang,
@@ -131,10 +134,10 @@ class ScheduleHelper {
                 $hydrated->effective->price_adult,
                 $hydrated->effective->price_child
             );
-            
+
             if (!isset($groups[$key])) {
                 $groups[$key] = [
-                    'start_time' => $schedule->start_time,
+                    'start_time' => $start_time,
                     'duration_min' => $hydrated->effective->duration_min,
                     'capacity' => $hydrated->effective->capacity,
                     'lang' => $hydrated->effective->lang,
@@ -146,7 +149,7 @@ class ScheduleHelper {
                     'can_aggregate' => true
                 ];
             }
-            
+
             $groups[$key]['days'][] = (int) $schedule->day_of_week;
             $groups[$key]['schedule_ids'][] = $schedule->id;
         }

--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -1764,25 +1764,18 @@ class Experience {
                 continue;
             }
             
-            // Sanitize time before validation
+            // Sanitize and validate time (allow optional seconds)
             $start_time = trim($slot_data['start_time']);
-            
-            // Handle common time format variations (convert to HH:MM)
-            if (preg_match('/^(\d{1,2}):(\d{2})$/', $start_time, $matches)) {
-                $hours = str_pad($matches[1], 2, '0', STR_PAD_LEFT);
-                $minutes = $matches[2];
-                $start_time = $hours . ':' . $minutes;
-            }
-            
-            // Validate time format - enhanced validation with better error reporting
-            if (!preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $start_time)) {
+            if (preg_match('/^(\d{1,2}):(\d{2})(?::\d{2})?$/', $start_time, $m)) {
+                $start_time = sprintf('%02d:%02d', $m[1], $m[2]);
+            } else {
                 // Add debug information if logging is enabled
                 if (apply_filters('fp_esperienze_debug_validation', false)) {
                     error_log("FP Esperienze: Invalid time format for slot {$slot_index}: '{$start_time}' (original: '{$slot_data['start_time']}')");
                 }
-                
+
                 $validation_errors[] = sprintf(
-                    __('Time slot %d: Invalid time format "%s". Use HH:MM format (e.g., 09:30).', 'fp-esperienze'), 
+                    __('Time slot %d: Invalid time format "%s". Use HH:MM format (e.g., 09:30).', 'fp-esperienze'),
                     $slot_index + 1,
                     esc_html($slot_data['start_time']) // Show original for user feedback
                 );


### PR DESCRIPTION
## Summary
- Trim seconds from schedule start times during aggregation
- Allow client-side time slot validation to accept seconds, storing only HH:MM
- Accept seconds on server-side builder slots and normalize to HH:MM

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` (fails: Found 4370 errors)
- `composer phpcs` (fails: multiple coding standards errors)


------
https://chatgpt.com/codex/tasks/task_e_68c048e8fb00832f868abad1baed44e7