### PR TITLE
Refactor product type error messages to use showUserFeedback

### DIFF
--- a/assets/js/admin-modular.js
+++ b/assets/js/admin-modular.js
@@ -135,7 +135,7 @@
             $('form#post').on('submit', function() {
                 if ($('body').hasClass('post-type-product') && $('#product-type').val() !== 'experience') {
                     // Show user-friendly error message
-                    self.showErrorMessage('This product must be of type "Experience"');
+                    self.showUserFeedback('This product must be of type "Experience"', 'error');
                     return false;
                 }
             });
@@ -279,7 +279,7 @@
                         };
                     },
                     failure: function() {
-                        window.FPEsperienzeAdmin.showErrorMessage('Failed to load bookings');
+                        window.FPEsperienzeAdmin.showUserFeedback('Failed to load bookings', 'error');
                     }
                 },
                 eventClick: function(info) {


### PR DESCRIPTION
## Summary
- use showUserFeedback directly for product type validation
- surface booking calendar load failures via showUserFeedback

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` (fails: Found 4371 errors)
- `vendor/bin/phpcs --standard=WordPress includes/` (fails: coding standard violations)


------
https://chatgpt.com/codex/tasks/task_e_68c049b65404832fb1ac29c94335656f