### PR TITLE
Add error recovery initializer for admin interface

### DIFF
--- a/assets/js/modules/error-handler.js
+++ b/assets/js/modules/error-handler.js
@@ -104,6 +104,20 @@
         },
 
         /**
+         * Initialize error recovery state
+         */
+        initErrorRecovery: function() {
+            // Azzerare i contatori di errore e ripulire eventuali timer
+            this.criticalErrors = 0;
+            this.recoveryAttempts = 0;
+            if (this.recoveryTimeout) {
+                clearTimeout(this.recoveryTimeout);
+                this.recoveryTimeout = null;
+            }
+            // (Eventuale log o hook aggiuntivo)
+        },
+
+        /**
          * Handle global JavaScript errors
          */
         handleGlobalError: function(errorInfo) {


### PR DESCRIPTION
## Summary
- add `initErrorRecovery` to reset counters and clear recovery timer

## Testing
- `bash tools/dev-tools.sh js-check`
- `bash tools/dev-tools.sh minify`
- `bash tools/dev-tools.sh test` *(fails: PHPStan memory limit and PHPCS sniff issue)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b00b490832f9d5019ad977cc2de