### PR TITLE
Guard admin translations against missing wp.i18n

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,7 +5,17 @@
 (function($) {
     'use strict';
 
-    const { __, sprintf } = wp.i18n;
+    let __ = ( text ) => text;
+    let sprintf = ( template, ...args ) => {
+        let i = 0;
+        return template.replace(/%s|%d/g, () => ( i < args.length ? args[i++] : '' ));
+    };
+
+    if ( window.wp && wp.i18n ) {
+        ( { __, sprintf } = wp.i18n );
+    } else {
+        console.warn( 'wp.i18n not found; translations will not be available.' );
+    }
 
     if (typeof fp_esperienze_admin !== 'undefined' && typeof fp_esperienze_admin.banner_offset !== 'undefined') {
         document.documentElement.style.setProperty('--fp-banner-offset', fp_esperienze_admin.banner_offset + 'px');


### PR DESCRIPTION
## Summary
- Add runtime check for `window.wp` and `wp.i18n` in admin script
- Provide no-op translation fallbacks and warning when `wp.i18n` is missing

## Testing
- `composer test` *(fails: Result is incomplete because of severe errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c090b2265c832f8711ca776a6e0f5d