### PR TITLE
Ensure admin scripts depend on jQuery

### DIFF
--- a/assets/js/admin-bookings.js
+++ b/assets/js/admin-bookings.js
@@ -2,6 +2,11 @@
  * FP Esperienze Admin Bookings Calendar
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the admin bookings script.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/assets/js/admin-modular.js
+++ b/assets/js/admin-modular.js
@@ -3,6 +3,11 @@
  * Main entry point that loads and coordinates all modules
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the modular admin script.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -2,6 +2,11 @@
  * FP Esperienze Admin JavaScript
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the admin script.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/assets/js/archive-block.js
+++ b/assets/js/archive-block.js
@@ -2,6 +2,11 @@
  * FP Esperienze Archive Block
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the archive block.');
+    return;
+}
+
 (function() {
     'use strict';
 

--- a/assets/js/modules/accessibility.js
+++ b/assets/js/modules/accessibility.js
@@ -3,6 +3,11 @@
  * Handles accessibility features, ARIA support, and screen reader compatibility
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the accessibility module.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/assets/js/modules/error-handler.js
+++ b/assets/js/modules/error-handler.js
@@ -3,6 +3,11 @@
  * Handles error recovery, reporting, and user feedback
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the error handler module.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/assets/js/modules/performance.js
+++ b/assets/js/modules/performance.js
@@ -3,6 +3,11 @@
  * Handles performance metrics, monitoring, and optimization
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the performance module.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/assets/js/modules/schedule-builder.js
+++ b/assets/js/modules/schedule-builder.js
@@ -3,6 +3,11 @@
  * Handles time slot management and schedule building functionality
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the schedule builder module.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/assets/js/reports.js
+++ b/assets/js/reports.js
@@ -4,6 +4,11 @@
  * @package FP\Esperienze\Assets\JS
  */
 
+if (typeof jQuery === 'undefined') {
+    console.error('FP Esperienze: jQuery is required for the reports script.');
+    return;
+}
+
 (function($) {
     'use strict';
 

--- a/includes/Blocks/ArchiveBlock.php
+++ b/includes/Blocks/ArchiveBlock.php
@@ -124,7 +124,7 @@ class ArchiveBlock {
         wp_enqueue_script(
             'fp-esperienze-archive-block',
             FP_ESPERIENZE_PLUGIN_URL . 'assets/js/archive-block.js',
-            ['wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'],
+            ['jquery', 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'],
             FP_ESPERIENZE_VERSION,
             true
         );

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -522,7 +522,7 @@ class Plugin {
         wp_enqueue_script(
             'fp-esperienze-archive-block',
             $archive_block_url,
-            ['wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'],
+            ['jquery', 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'],
             FP_ESPERIENZE_VERSION,
             true
         );


### PR DESCRIPTION
## Summary
- Add runtime jQuery presence checks across all admin JS modules and controllers
- Require jQuery when enqueueing block editor assets for the archive block

## Testing
- `composer install`
- `./vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Found 4319 errors)*
- `./vendor/bin/phpcs --standard=WordPress includes/` *(fails: filenames should be all lowercase with hyphens as word separators)*

------
https://chatgpt.com/codex/tasks/task_e_68c12670b4c8832faccb781e378fd7af