### PR TITLE
Use :focus-visible for keyboard-driven outline

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -3122,7 +3122,7 @@ body.fp-reduced-animations .fp-loading::after {
     border-color: #2271b1;
 }
 
-.fp-day-pill-clean input[type="checkbox"]:focus + label {
+.fp-day-pill-clean input[type="checkbox"]:focus-visible + label {
     outline: 2px solid #2271b1;
     outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- restrict day pill checkbox outline to keyboard focus using :focus-visible

## Testing
- `./vendor/bin/phpstan analyse --memory-limit=1G` *(fails: 4219 errors)*
- `./vendor/bin/phpcs --standard=WordPress includes/` *(fails: sniff violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c177a5c2a8832f8dcacba9905cffbc