### PR TITLE
refactor: centralize day pill label styles

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -3098,9 +3098,9 @@ body.fp-reduced-animations .fp-loading::after {
     font-size: 0.75rem;
     font-weight: 600;
     cursor: pointer;
-    transition: background 0.15s ease,
-                transform 0.15s ease,
-                box-shadow 0.15s ease;
+    transition: background 0.2s ease,
+                transform 0.2s ease,
+                box-shadow 0.2s ease;
     margin: 0;
     text-transform: uppercase;
     letter-spacing: 0.5px;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -997,12 +997,6 @@ html {
                 border-color 0.2s ease;
 }
 
-.fp-day-pill-clean label {
-    transition: background 0.15s ease,
-                transform 0.15s ease,
-                box-shadow 0.15s ease;
-}
-
 /* Loading states with optimized animations */
 .fp-loading {
     position: relative;
@@ -3104,7 +3098,9 @@ body.fp-reduced-animations .fp-loading::after {
     font-size: 0.75rem;
     font-weight: 600;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: background 0.15s ease,
+                transform 0.15s ease,
+                box-shadow 0.15s ease;
     margin: 0;
     text-transform: uppercase;
     letter-spacing: 0.5px;


### PR DESCRIPTION
## Summary
- consolidate `.fp-day-pill-clean label` styles into one rule
- remove duplicate transition declarations

## Testing
- `composer install --no-progress --no-interaction`
- `composer test` *(fails: PHPStan process crashed; memory limit 128M)*

------
https://chatgpt.com/codex/tasks/task_e_68c17920ba0c832f91986d0fed422324