### PR TITLE
Fix day pill width to avoid layout shift

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -3097,7 +3097,9 @@ body.fp-reduced-animations .fp-loading::after {
 
 .fp-day-pill-clean label {
     display: inline-block;
-    padding: 8px 14px;
+    width: 40px;
+    padding: 8px 0;
+    text-align: center;
     background-color: #f7f7f7;
     border: 1px solid #ccd0d4;
     border-radius: 3px;
@@ -3117,6 +3119,8 @@ body.fp-reduced-animations .fp-loading::after {
 }
 
 .fp-day-pill-clean input[type="checkbox"]:checked + label {
+    width: 40px;
+    text-align: center;
     background-color: #2271b1;
     color: #fff;
     border-color: #2271b1;


### PR DESCRIPTION
## Summary
- Set a fixed width and centered text for day pill labels
- Apply same width when checked to prevent layout shift

## Testing
- `composer test` *(fails: Result is incomplete because of severe errors)*
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68c173e88cd0832fb288cfe23498f039