### PR TITLE
Handle missing or invalid extras data in cart

### DIFF
--- a/includes/Booking/Cart_Hooks.php
+++ b/includes/Booking/Cart_Hooks.php
@@ -66,9 +66,14 @@ class Cart_Hooks {
         $lang = sanitize_text_field(wp_unslash($_POST['fp_lang'] ?? ''));
         $qty_adult = absint(wp_unslash($_POST['fp_qty_adult'] ?? 0));
         $qty_child = absint(wp_unslash($_POST['fp_qty_child'] ?? 0));
-        $extras_data = json_decode(wp_unslash($_POST['fp_extras'] ?? ''), true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            wp_send_json_error(['message' => __('Invalid extras payload', 'fp-esperienze')]);
+        $extras_data = [];
+        $extras_json = wp_unslash($_POST['fp_extras'] ?? '');
+        if (!empty($extras_json)) {
+            $extras_data = json_decode($extras_json, true);
+            if (json_last_error() !== JSON_ERROR_NONE || !is_array($extras_data)) {
+                error_log('Invalid extras payload: ' . $extras_json);
+                $extras_data = [];
+            }
         }
 
         // Get gift data from POST
@@ -81,7 +86,7 @@ class Cart_Hooks {
 
         if ($slot_start) {
             $extras = [];
-            if (is_array($extras_data)) {
+            if (!empty($extras_data)) {
                 foreach ($extras_data as $extra_id => $quantity) {
                     $extras[absint($extra_id)] = absint($quantity);
                 }


### PR DESCRIPTION
## Summary
- Default extras payload to an empty array when not provided
- Log and ignore invalid extras JSON instead of stopping execution
- Skip extras processing when no extras are present

## Testing
- `composer test` *(fails: Result is incomplete because of severe errors)*
- `composer phpcs` *(fails: coding standard violations in unrelated files)*
- `vendor/bin/phpcs --standard=WordPress includes/Booking/Cart_Hooks.php` *(fails: coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ce114d78832f88d7a438a4680afd