### PR TITLE
Add pagination support to bookings REST API

### DIFF
--- a/includes/Booking/BookingManager.php
+++ b/includes/Booking/BookingManager.php
@@ -292,51 +292,96 @@ class BookingManager {
      * @param array $filters Filters array
      * @return array Bookings
      */
-    public static function getBookings(array $filters = []): array {
+    public static function getBookings(array $filters = [], int $limit = 0, int $offset = 0): array {
         global $wpdb;
-        
+
         $table_name = $wpdb->prefix . 'fp_bookings';
-        
+
         $where_clauses = ['1=1'];
         $where_values = [];
-        
+
         // Apply filters
         if (!empty($filters['status'])) {
             $where_clauses[] = 'status = %s';
             $where_values[] = $filters['status'];
         }
-        
+
         if (!empty($filters['product_id'])) {
             $where_clauses[] = 'product_id = %d';
             $where_values[] = $filters['product_id'];
         }
-        
+
         if (!empty($filters['date_from'])) {
             $where_clauses[] = 'booking_date >= %s';
             $where_values[] = $filters['date_from'];
         }
-        
+
         if (!empty($filters['date_to'])) {
             $where_clauses[] = 'booking_date <= %s';
             $where_values[] = $filters['date_to'];
         }
-        
+
         // Build query
         $where_sql = implode(' AND ', $where_clauses);
         $order_by = 'ORDER BY booking_date DESC, booking_time DESC';
-        $limit = '';
-        
-        if (!empty($filters['limit'])) {
-            $limit = $wpdb->prepare('LIMIT %d', $filters['limit']);
+
+        $sql = "SELECT * FROM {$table_name} WHERE {$where_sql} {$order_by}";
+
+        if ($limit > 0) {
+            $sql .= ' LIMIT %d OFFSET %d';
+            $where_values[] = $limit;
+            $where_values[] = $offset;
         }
-        
-        $sql = "SELECT * FROM {$table_name} WHERE {$where_sql} {$order_by} {$limit}";
-        
+
         if (!empty($where_values)) {
             $sql = $wpdb->prepare($sql, $where_values);
         }
-        
+
         return $wpdb->get_results($sql);
+    }
+
+    /**
+     * Count bookings with optional filters
+     *
+     * @param array $filters Filters array
+     * @return int Total number of bookings
+     */
+    public static function countBookings(array $filters = []): int {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'fp_bookings';
+
+        $where_clauses = ['1=1'];
+        $where_values = [];
+
+        if (!empty($filters['status'])) {
+            $where_clauses[] = 'status = %s';
+            $where_values[] = $filters['status'];
+        }
+
+        if (!empty($filters['product_id'])) {
+            $where_clauses[] = 'product_id = %d';
+            $where_values[] = $filters['product_id'];
+        }
+
+        if (!empty($filters['date_from'])) {
+            $where_clauses[] = 'booking_date >= %s';
+            $where_values[] = $filters['date_from'];
+        }
+
+        if (!empty($filters['date_to'])) {
+            $where_clauses[] = 'booking_date <= %s';
+            $where_values[] = $filters['date_to'];
+        }
+
+        $where_sql = implode(' AND ', $where_clauses);
+        $sql = "SELECT COUNT(*) FROM {$table_name} WHERE {$where_sql}";
+
+        if (!empty($where_values)) {
+            $sql = $wpdb->prepare($sql, $where_values);
+        }
+
+        return (int) $wpdb->get_var($sql);
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow page and per_page params on bookings endpoints
- paginate DB queries with limit/offset and expose pagination meta
- add countBookings helper for totals

## Testing
- `composer test` *(fails: PHPStan process crashed: memory limit 128M)*
- `composer phpcs` *(fails: coding standard violations across project)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d07115f4832fa8f4a609a8e31312