### PR TITLE
Run capability setup only on activation

### DIFF
--- a/includes/Core/CapabilityManager.php
+++ b/includes/Core/CapabilityManager.php
@@ -23,8 +23,6 @@ class CapabilityManager {
      * Constructor
      */
     public function __construct() {
-        add_action('wp_loaded', [$this, 'addCapabilitiesToRoles']);
-        
         // Handle capability checks for AJAX and form submissions
         add_action('wp_ajax_fp_esperienze_admin_action', [$this, 'checkAdminCapability']);
         add_action('wp_ajax_nopriv_fp_esperienze_admin_action', [$this, 'denyUnauthorizedAccess']);

--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -26,6 +26,7 @@ class Installer {
     public static function activate() {
         self::createTables();
         self::createDefaultOptions();
+        // Capability setup runs only on activation to avoid redundant role checks
         self::addCapabilities();
         
         // Execute schedule migration if feature flag is enabled


### PR DESCRIPTION
## Summary
- Remove runtime capability setup hook
- Clarify in installer that capabilities are added on activation

## Testing
- `composer test` *(fails: Result is incomplete because of severe errors)*
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*
- `php /tmp/cap_test.php`

------
https://chatgpt.com/codex/tasks/task_e_68c1d32a35b8832f9e775be7e23b920c