### PR TITLE
Sanitize REMOTE_ADDR for rate limiting

### DIFF
--- a/includes/Core/RateLimiter.php
+++ b/includes/Core/RateLimiter.php
@@ -48,11 +48,16 @@ class RateLimiter {
      *
      * Uses WordPress' {@see wp_get_ip_address()} when available and falls back
      * to processing common proxy headers when behind a trusted proxy.
+     * Falls back to `127.0.0.1` when the remote address is missing or
+     * contains an invalid IP to ensure a stable transient key.
      *
      * @return string Client IP address
      */
     public static function getClientIP(): string {
-        $remote_addr     = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+        $remote_addr = $_SERVER['REMOTE_ADDR'] ?? '';
+
+        // Validate the remote address and use a safe fallback if invalid.
+        $remote_addr     = filter_var( $remote_addr, FILTER_VALIDATE_IP ) ?: '127.0.0.1';
         $trusted_proxies = apply_filters( 'fp_trusted_proxies', [] );
 
         if ( ! empty( $trusted_proxies ) && in_array( $remote_addr, $trusted_proxies, true ) ) {


### PR DESCRIPTION
## Summary
- validate `$_SERVER['REMOTE_ADDR']` before use and fall back to `127.0.0.1`
- document invalid IP fallback in `RateLimiter::getClientIP`

## Testing
- `composer test` (fails: PHPStan memory limit)
- `vendor/bin/phpstan analyse --memory-limit=512M` (fails: missing WordPress functions)
- `vendor/bin/phpcs --standard=WordPress includes/Core/RateLimiter.php` (fails: coding standard violations)


------
https://chatgpt.com/codex/tasks/task_e_68c1d84f3fc8832fa67a052dfa08e5fc