### PR TITLE
Queue Meta CAPI events asynchronously

### DIFF
--- a/MANUAL_TESTS_COMPLETE_TRACKING.md
+++ b/MANUAL_TESTS_COMPLETE_TRACKING.md
@@ -182,10 +182,12 @@ Console should show tracking events in this order:
 ### Steps:
 1. Enable Meta Conversions API with valid credentials
 2. Place a test order with experience products
-3. Check WordPress error logs or debug logs
-4. Verify in Meta Events Manager (if access available)
+3. Confirm the checkout completes without waiting for the Meta HTTP request
+4. Check WordPress error logs or debug logs
+5. Verify in Meta Events Manager (if access available)
 
 ### Expected Results:
+- Checkout flow is not delayed by the Meta API call
 - Server-side purchase event should be sent to Meta
 - Log should show "Meta CAPI Success" message
 - Event should include hashed customer data


### PR DESCRIPTION
## Summary
- queue Meta purchase events and process them via `fp_send_meta_event`
- add `processQueuedEvent` handler and register its hook
- update Meta CAPI manual test to ensure checkout isn't blocked by API calls

## Testing
- `php -l includes/Integrations/MetaCAPIManager.php`
- `composer test` *(phpstan: memory limit 128M)*
- `vendor/bin/phpcs` *(missing sniff `WordPress.PHP.DisallowShortTernary`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1db7f26fc832f934ed858666ee75f