### PR TITLE
Sanitize user agent and validate IP in Meta CAPI events

### DIFF
--- a/includes/Integrations/MetaCAPIManager.php
+++ b/includes/Integrations/MetaCAPIManager.php
@@ -156,11 +156,15 @@ class MetaCAPIManager {
         
         // Add client user agent and IP if available
         if (!empty($_SERVER['HTTP_USER_AGENT'])) {
-            $event_data['user_data']['client_user_agent'] = $_SERVER['HTTP_USER_AGENT'];
+            $event_data['user_data']['client_user_agent'] = sanitize_text_field($_SERVER['HTTP_USER_AGENT']); // Sanitize user agent string
         }
-        
+
         if (!empty($_SERVER['REMOTE_ADDR'])) {
-            $event_data['user_data']['client_ip_address'] = $_SERVER['REMOTE_ADDR'];
+            $client_ip = filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP);
+
+            if ($client_ip) {
+                $event_data['user_data']['client_ip_address'] = $client_ip; // Only send valid IP addresses
+            }
         }
         
         $payload = [


### PR DESCRIPTION
## Summary
- sanitize `$_SERVER['HTTP_USER_AGENT']` in Meta CAPI `sendEvent`
- validate and ignore invalid `$_SERVER['REMOTE_ADDR']`

## Testing
- `composer test` *(fails: Result is incomplete because of severe errors)*
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dca48b54832fb125ae453e13d366