### PR TITLE
Initialize holds cleanup cron on plugin load

### DIFF
--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -244,7 +244,10 @@ class Plugin {
 
         // Initialize WPML hooks for automatic translation jobs
         new WPMLHooks();
-        
+
+        // Initialize holds cleanup cron
+        $this->initHoldsCron();
+
         // Initialize REST API
         add_action('rest_api_init', [$this, 'initREST']);
     }
@@ -768,6 +771,9 @@ class Plugin {
     public function initHoldsCron(): void {
         // Add custom cron interval first
         add_filter('cron_schedules', [$this, 'addHoldsCronInterval']);
+
+        // Register cleanup action
+        add_action('fp_esperienze_cleanup_holds', [$this, 'cleanupExpiredHolds']);
 
         // Schedule the event only after the interval is available
         if (!wp_next_scheduled('fp_esperienze_cleanup_holds')) {


### PR DESCRIPTION
## Summary
- Register the `fp_esperienze_cleanup_holds` action within `initHoldsCron`
- Invoke `initHoldsCron` during component initialization so cleanup scheduling occurs

## Testing
- `./vendor/bin/phpstan analyse --memory-limit=1G` *(fails: Function __ not found, 4788 errors)*
- `./vendor/bin/phpcs --standard=WordPress includes/Core/Plugin.php` *(fails: Expected spaces before closing parenthesis, indentation errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c77fd2a0a8832fae73d4e436160957