### PR TITLE
Sanitize CSV exports to prevent formula injection

### DIFF
--- a/MANUAL_TESTS_CSV_SANITIZATION.md
+++ b/MANUAL_TESTS_CSV_SANITIZATION.md
@@ -1,0 +1,14 @@
+# Manual Test: CSV Export Sanitization
+
+## Objective
+Verify that CSV exports do not allow spreadsheet formula execution by sanitizing fields beginning with `=`, `+`, `-`, or `@`.
+
+## Steps
+1. Create or edit data so that at least one field (e.g., product name or notes) starts with `=2+2`, `+SUM(A1)`, `-1+1`, and `@HYPERLINK(...)`.
+2. From **FP Esperienze → Reports**, export the report as CSV.
+3. From **FP Esperienze → Bookings**, export the bookings list as CSV using the **Export** button.
+4. Open the downloaded CSV files in spreadsheet software.
+
+## Expected Results
+- Cells that started with `=`, `+`, `-`, or `@` appear with a leading apostrophe (`'`).
+- The values are displayed as plain text and are not interpreted as formulas.

--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -4141,7 +4141,25 @@ class MenuManager {
                 break;
         }
     }
-    
+
+    /**
+     * Sanitize CSV row values to prevent formula injection.
+     *
+     * @param array $row Row data.
+     * @return array Sanitized row.
+     */
+    private function sanitizeCsvRow(array $row): array {
+        return array_map(
+            static function ($field) {
+                if (is_string($field) && preg_match('/^[=+\-@]/', $field)) {
+                    return "'" . $field;
+                }
+                return $field;
+            },
+            $row
+        );
+    }
+
     /**
      * Export bookings to CSV
      */
@@ -4172,7 +4190,7 @@ class MenuManager {
         }
 
         // CSV headers
-        fputcsv($output, [
+        fputcsv($output, $this->sanitizeCsvRow([
             __('Booking ID', 'fp-esperienze'),
             __('Order ID', 'fp-esperienze'),
             __('Product', 'fp-esperienze'),
@@ -4186,7 +4204,7 @@ class MenuManager {
             __('Customer Notes', 'fp-esperienze'),
             __('Admin Notes', 'fp-esperienze'),
             __('Created', 'fp-esperienze'),
-        ]);
+        ]));
 
         // CSV data
         foreach ($bookings as $booking) {
@@ -4199,7 +4217,7 @@ class MenuManager {
                 $meeting_point_name = $mp ? $mp->name : __('Not found', 'fp-esperienze');
             }
 
-            fputcsv($output, [
+            fputcsv($output, $this->sanitizeCsvRow([
                 $booking->id,
                 $booking->order_id,
                 $product_name,
@@ -4213,7 +4231,7 @@ class MenuManager {
                 $booking->customer_notes,
                 $booking->admin_notes,
                 $booking->created_at,
-            ]);
+            ]));
         }
 
         rewind($output);

--- a/includes/Admin/ReportsManager.php
+++ b/includes/Admin/ReportsManager.php
@@ -182,6 +182,24 @@ class ReportsManager {
     }
 
     /**
+     * Sanitize CSV row values to prevent formula injection.
+     *
+     * @param array $row Row data.
+     * @return array Sanitized row.
+     */
+    private function sanitizeCsvRow(array $row): array {
+        return array_map(
+            static function ($field) {
+                if (is_string($field) && preg_match('/^[=+\-@]/', $field)) {
+                    return "'" . $field;
+                }
+                return $field;
+            },
+            $row
+        );
+    }
+
+    /**
      * Get chart data for various time periods
      *
      * @param string $period 'day', 'week', or 'month'
@@ -419,38 +437,38 @@ class ReportsManager {
             $output = fopen('php://output', 'w');
             
             // Summary section
-            fputcsv($output, ['FP Esperienze Report Summary']);
-            fputcsv($output, ['Generated', $export_data['generated_at']]);
-            fputcsv($output, ['Date Range', $export_data['date_range']['from'] . ' to ' . $export_data['date_range']['to']]);
-            fputcsv($output, ['Total Revenue', $export_data['kpi_summary']['total_revenue']]);
-            fputcsv($output, ['Total Seats', $export_data['kpi_summary']['total_seats']]);
-            fputcsv($output, ['Total Bookings', $export_data['kpi_summary']['total_bookings']]);
+            fputcsv($output, $this->sanitizeCsvRow(['FP Esperienze Report Summary']));
+            fputcsv($output, $this->sanitizeCsvRow(['Generated', $export_data['generated_at']]));
+            fputcsv($output, $this->sanitizeCsvRow(['Date Range', $export_data['date_range']['from'] . ' to ' . $export_data['date_range']['to']]));
+            fputcsv($output, $this->sanitizeCsvRow(['Total Revenue', $export_data['kpi_summary']['total_revenue']]));
+            fputcsv($output, $this->sanitizeCsvRow(['Total Seats', $export_data['kpi_summary']['total_seats']]));
+            fputcsv($output, $this->sanitizeCsvRow(['Total Bookings', $export_data['kpi_summary']['total_bookings']]));
             fputcsv($output, []);
             
             // Top experiences
-            fputcsv($output, ['Top Experiences']);
-            fputcsv($output, ['Product ID', 'Product Name', 'Bookings', 'Seats Sold', 'Revenue']);
+            fputcsv($output, $this->sanitizeCsvRow(['Top Experiences']));
+            fputcsv($output, $this->sanitizeCsvRow(['Product ID', 'Product Name', 'Bookings', 'Seats Sold', 'Revenue']));
             foreach ($export_data['top_experiences'] as $exp) {
-                fputcsv($output, [
+                fputcsv($output, $this->sanitizeCsvRow([
                     $exp->product_id,
                     $exp->product_name,
                     $exp->total_bookings,
                     $exp->total_seats,
                     $exp->total_revenue
-                ]);
+                ]));
             }
             fputcsv($output, []);
             
             // UTM conversions
-            fputcsv($output, ['UTM Source Conversions']);
-            fputcsv($output, ['Source', 'Orders', 'Revenue', 'Avg Order Value']);
+            fputcsv($output, $this->sanitizeCsvRow(['UTM Source Conversions']));
+            fputcsv($output, $this->sanitizeCsvRow(['Source', 'Orders', 'Revenue', 'Avg Order Value']));
             foreach ($export_data['utm_conversions'] as $utm) {
-                fputcsv($output, [
+                fputcsv($output, $this->sanitizeCsvRow([
                     $utm['source'],
                     $utm['orders'],
                     $utm['revenue'],
                     $utm['avg_order_value']
-                ]);
+                ]));
             }
             
             fclose($output);


### PR DESCRIPTION
## Summary
- sanitize report and booking CSV exports to neutralize leading `=`, `+`, `-`, and `@`
- add helper to sanitize each CSV field
- document manual testing for CSV export sanitization

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` (fails: Function __ not found, 4790 errors)
- `vendor/bin/phpcs --standard=WordPress includes/Admin/ReportsManager.php includes/Admin/MenuManager.php` (fails: coding standard errors)


------
https://chatgpt.com/codex/tasks/task_e_68c780a8f4d4832f875a0674e38098d9