### PR TITLE
Use esc_url for meeting point map URLs

### DIFF
--- a/templates/single-experience.php
+++ b/templates/single-experience.php
@@ -290,7 +290,7 @@ jQuery(document).ready(function($) {
                             
                             <?php if ($meeting_point->lat && $meeting_point->lng) : ?>
                                 <div class="fp-meeting-point-actions">
-                                    <a href="https://www.google.com/maps?q=<?php echo esc_attr($meeting_point->lat . ',' . $meeting_point->lng); ?>" 
+                                    <a href="https://www.google.com/maps?q=<?php echo esc_url($meeting_point->lat . ',' . $meeting_point->lng); ?>"
                                        target="_blank" 
                                        rel="noopener"
                                        class="fp-maps-link"
@@ -306,7 +306,7 @@ jQuery(document).ready(function($) {
                                 <!-- Interactive Google Maps embed using basic iframe (no API key required) -->
                                 <div class="fp-map-container" aria-label="<?php _e('Map showing meeting point location', 'fp-esperienze'); ?>">
                                     <iframe 
-                                        src="https://maps.google.com/maps?q=<?php echo esc_attr($meeting_point->lat . ',' . $meeting_point->lng); ?>&amp;z=15&amp;output=embed"
+                                        src="https://maps.google.com/maps?q=<?php echo esc_url($meeting_point->lat . ',' . $meeting_point->lng); ?>&amp;z=15&amp;output=embed"
                                         width="100%" 
                                         height="200" 
                                         style="border:0;" 


### PR DESCRIPTION
## Summary
- sanitize Google Maps link and embed URL with `esc_url`

## Testing
- `composer test` (fails: Result is incomplete because of severe errors)
- `composer phpcs` (fails: code style violations)
- `curl -I "https://www.google.com/maps?q=41.9028,12.4964"`
- `curl -L -A "Mozilla/5.0" "https://maps.google.com/maps?q=41.9028,12.4964&z=15&output=embed" -o /tmp/curl_iframe.html`


------
https://chatgpt.com/codex/tasks/task_e_68c7873a30e4832f8a6727c91cfa4d6a