### PR TITLE
Handle zero price in dynamic pricing

### DIFF
--- a/MANUAL_TESTS_DYNAMIC_PRICING.md
+++ b/MANUAL_TESTS_DYNAMIC_PRICING.md
@@ -209,6 +209,20 @@
 - [ ] No conflicts between pricing systems
 - [ ] Final amount is correct
 
+## Test Case 12: Free Product Handling
+
+**Objective**: Ensure no PHP errors occur with free Experience products.
+
+**Steps**:
+1. Create an Experience product with regular price set to `0`.
+2. View the product page on the frontend.
+3. Add the product to the cart.
+
+**Expected Results**:
+- [ ] No PHP warnings or errors are logged.
+- [ ] Product price remains `0` during all steps.
+- [ ] `_price_adjustment` meta is recorded as `0%`.
+
 ## Validation Checklist
 
 After completing all tests:

--- a/includes/AI/AIFeaturesManager.php
+++ b/includes/AI/AIFeaturesManager.php
@@ -71,11 +71,13 @@ class AIFeaturesManager {
         if ($dynamic_price !== $price) {
             update_post_meta($product->get_id(), '_dynamic_price_applied', true);
             update_post_meta($product->get_id(), '_original_price', $price);
-            update_post_meta(
-                $product->get_id(),
-                '_price_adjustment',
-                ($dynamic_price - $price) / $price * 100
-            );
+
+            $adjustment = 0;
+            if ($price > 0) {
+                $adjustment = ($dynamic_price - $price) / $price * 100;
+            }
+
+            update_post_meta($product->get_id(), '_price_adjustment', $adjustment);
 
             return $dynamic_price;
         }


### PR DESCRIPTION
## Summary
- Prevent division by zero in dynamic pricing by checking product price and defaulting adjustment to 0%
- Document manual test for free products to ensure no PHP errors occur

## Testing
- `composer test` (fails: Child process error: PHPStan process crashed because it reached configured PHP memory limit: 128M)
- `./vendor/bin/phpstan analyse --memory-limit=512M` (fails: Found 4790 errors)
- `./vendor/bin/phpcs --standard=WordPress includes/AI/AIFeaturesManager.php` (fails: PHPCBF can fix the 2086 marked sniff violations)


------
https://chatgpt.com/codex/tasks/task_e_68c788acbe08832fb9a9035077c11f8d