### PR TITLE
Use product_type_selector hook for experience product

### DIFF
--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -31,7 +31,7 @@ class Experience {
 		// Register product type filter IMMEDIATELY if WooCommerce is available
 		// This fixes the timing issue where the filter was registered too late
 		if ( function_exists( 'wc_get_product_types' ) ) {
-			add_filter( 'woocommerce_product_type_selector', array( $this, 'addProductType' ), 10 );
+                       add_filter( 'product_type_selector', array( $this, 'addProductType' ), 10 );
 			
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				error_log( 'FP Esperienze: Experience product type filter registered immediately' );
@@ -87,7 +87,7 @@ class Experience {
 		}
 
 		// Register the product type selector filter
-		add_filter( 'woocommerce_product_type_selector', array( $this, 'addProductType' ), 10 );
+               add_filter( 'product_type_selector', array( $this, 'addProductType' ), 10 );
 		
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( 'FP Esperienze: Experience product type filter registered on init hook' );


### PR DESCRIPTION
## Summary
- update the Experience product type registration to use the `product_type_selector` hook both on construction and init fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caad139acc832fa7bc356b6f5f225c