### PR TITLE
Limit builder schedules to recurring entries

### DIFF
--- a/includes/Helpers/ScheduleHelper.php
+++ b/includes/Helpers/ScheduleHelper.php
@@ -28,6 +28,9 @@ class ScheduleHelper {
 		$groups     = array();
 
                 foreach ( $schedules as $schedule ) {
+                        if ( isset( $schedule->schedule_type ) && 'recurring' !== $schedule->schedule_type ) {
+                                continue;
+                        }
                         // Skip schedules missing required data
                         if ( $schedule->duration_min === null || $schedule->duration_min === '' ) {
                                 continue;

--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -595,7 +595,7 @@ class Experience {
 	 * @param int $product_id Product ID
 	 */
 	private function renderScheduleBuilder( int $product_id ): void {
-		$schedules      = ScheduleManager::getSchedules( $product_id );
+		$schedules      = ScheduleManager::getRecurringSchedules( $product_id );
 		$meeting_points = $this->getMeetingPoints();
 
                 // Default placeholders when slot values are missing


### PR DESCRIPTION
## Summary
- update the schedule builder to load only recurring schedules for the UI
- skip non-recurring records while aggregating schedules for the builder

## Testing
- php -l includes/ProductType/Experience.php
- php -l includes/Helpers/ScheduleHelper.php

------
https://chatgpt.com/codex/tasks/task_e_68cab66bc528832faa735a0239d46f84