### PR TITLE
Ensure experience archive cards use white panels

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -263,6 +263,8 @@ html {
     border-radius: 8px;
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
+    background-color: #fff;
+    color: #1a1a1a;
 }
 
 .fp-experience-card:hover {
@@ -301,6 +303,7 @@ html {
 
 .fp-experience-content {
     padding: 20px;
+    background-color: #fff;
 }
 
 .fp-experience-title {
@@ -2175,7 +2178,6 @@ body.admin-bar .fp-booking-widget {
         --fp-text-light-gray: #bbb;
         /* eventuali altri colori */
     }
-    .fp-experience-card,
     .fp-archive-filters {
         background: #1e1e1e;
         border-color: #333;


### PR DESCRIPTION
## Summary
- set a white background and dark text color on experience cards so they remain readable regardless of theme colors
- apply the same background to the content container and stop the dark-mode override from changing card backgrounds

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cabc80eb4c832fbc5306b0432a9dd5