### PR TITLE
Restrict fixed schedules to requested event date

### DIFF
--- a/includes/Data/Availability.php
+++ b/includes/Data/Availability.php
@@ -53,7 +53,7 @@ class Availability {
 		}
 
 		// Get schedules for this day
-		$schedules = ScheduleManager::getSchedulesForDay( $product_id, $day_of_week );
+		$schedules = ScheduleManager::getSchedulesForDay( $product_id, $day_of_week, $date );
 
 		if ( empty( $schedules ) ) {
 			return array();


### PR DESCRIPTION
## Summary
- limit day-level schedule queries so fixed schedules require a matching event_date when provided
- ensure availability lookups request schedules with the selected calendar date so unrelated fixed slots are excluded

## Testing
- php -l includes/Data/ScheduleManager.php
- php -l includes/Data/Availability.php
- composer test *(fails: phpstan not installed before running; after installing dependencies it still exceeds memory / lacks WP stubs)*
- ./vendor/bin/phpstan analyse --memory-limit=512M *(fails: thousands of errors from missing WordPress/WooCommerce symbols in default config)*
- ./vendor/bin/phpcs includes/Data/ScheduleManager.php includes/Data/Availability.php *(fails: referenced sniff "WordPress.PHP.DisallowShortTernary" missing in bundled standard)*

------
https://chatgpt.com/codex/tasks/task_e_68cac345fd18832f93289edfff221c54