### PR TITLE
Fix Experience product type registration hook

### DIFF
--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -31,11 +31,7 @@ class Experience {
 		// Register product type filter IMMEDIATELY if WooCommerce is available
 		// This fixes the timing issue where the filter was registered too late
 		if ( function_exists( 'wc_get_product_types' ) ) {
-                       add_filter( 'product_type_selector', array( $this, 'addProductType' ), 10 );
-			
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				error_log( 'FP Esperienze: Experience product type filter registered immediately' );
-			}
+                       add_filter( 'woocommerce_product_type_selector', array( $this, 'addProductType' ), 10 );
 		} else {
 			// Fallback: register on init hook if WooCommerce isn't ready yet
 			add_action( 'init', array( $this, 'registerProductType' ), 5 );
@@ -87,11 +83,7 @@ class Experience {
 		}
 
 		// Register the product type selector filter
-               add_filter( 'product_type_selector', array( $this, 'addProductType' ), 10 );
-		
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			error_log( 'FP Esperienze: Experience product type filter registered on init hook' );
-		}
+               add_filter( 'woocommerce_product_type_selector', array( $this, 'addProductType' ), 10 );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- register the Experience product type selector with the WooCommerce-specific `woocommerce_product_type_selector` hook
- remove temporary debugging logs tied to the outdated hook registration

## Testing
- php -l includes/ProductType/Experience.php

------
https://chatgpt.com/codex/tasks/task_e_68cac6137804832f9b75183371970ac1