### PR TITLE
Sync slot pricing state across booking widgets

### DIFF
--- a/assets/js/booking-widget.js
+++ b/assets/js/booking-widget.js
@@ -197,7 +197,10 @@
             $(document).on('click', '.fp-time-slot:not(.unavailable)', function() {
                 $('.fp-time-slot').removeClass('selected').attr('aria-checked', 'false');
                 $(this).addClass('selected').attr('aria-checked', 'true');
-                
+
+                self.adultPrice = parseFloat($(this).data('adult-price')) || 0;
+                self.childPrice = parseFloat($(this).data('child-price')) || 0;
+
                 self.selectedSlot = {
                     start_time: $(this).data('start-time'),
                     adult_price: $(this).data('adult-price'),
@@ -375,7 +378,10 @@
             
             $('#fp-time-slots').html(html);
             this.selectedSlot = null;
+            this.adultPrice = 0;
+            this.childPrice = 0;
             $('#fp-selected-slot').val('');
+            this.updateTotal();
             this.validateForm();
         },
 

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -331,7 +331,10 @@
             $(document).on('click', '.fp-time-slot:not(.unavailable)', function() {
                 $('.fp-time-slot').removeClass('selected');
                 $(this).addClass('selected');
-                
+
+                self.adultPrice = parseFloat($(this).data('adult-price')) || 0;
+                self.childPrice = parseFloat($(this).data('child-price')) || 0;
+
                 self.selectedSlot = {
                     start_time: $(this).data('start-time'),
                     adult_price: $(this).data('adult-price'),
@@ -486,7 +489,10 @@
             
             $('#fp-time-slots').html(html);
             this.selectedSlot = null;
+            this.adultPrice = 0;
+            this.childPrice = 0;
             $('#fp-selected-slot').val('');
+            this.updateTotal();
             this.validateForm();
         },
 


### PR DESCRIPTION
## Summary
- update both legacy and modern booking widget time-slot handlers to pull per-slot adult and child prices into widget state before recalculating totals
- reset cached slot prices when refreshed time slots clear the selected slot so totals return to zero until a new slot is chosen

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cad41d0230832fb75e8a32a5c39d60