### PR TITLE
Align schedule builder with core WP styles

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -335,31 +335,6 @@ html {
     margin-bottom: 4px;
 }
 
-.fp-primary-button {
-    background: var(--fp-brand-primary);
-    color: #fff;
-    border: none;
-    padding: 12px 24px;
-    border-radius: 6px;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    transition: all 0.2s ease;
-    text-decoration: none;
-}
-
-.fp-primary-button:hover {
-    background: #135e96;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(34, 113, 177, 0.3);
-}
-
-.fp-primary-button .dashicons {
-    font-size: 1rem;
-}
 
 /* Enhanced summary table */
 .fp-slots-summary {
@@ -886,55 +861,46 @@ html {
 
 /* Add override button */
 .fp-add-override {
-    background: var(--fp-brand-primary);
-    color: #fff;
-    border: none;
-    padding: 10px 16px;
-    border-radius: 4px;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: inline-flex;
     align-items: center;
+    background: #d63638;
+    border: 1px solid #d63638;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
     gap: 6px;
-}
-
-.fp-add-override:hover {
-    background: #135e96;
-    transform: translateY(-1px);
-}
-
-.fp-add-override .dashicons {
-    font-size: 1rem;
-}
-
-/* Enhanced add override button */
-.fp-add-override {
-    background: #d63638 !important;
-    border: none !important;
-    color: #fff !important;
-    padding: 12px 20px !important;
-    border-radius: 6px !important;
-    font-size: 0.875rem !important;
-    font-weight: 500 !important;
-    cursor: pointer !important;
-    display: inline-flex !important;
-    align-items: center !important;
-    gap: 8px !important;
-    transition: all 0.2s ease !important;
-    text-decoration: none !important;
+    justify-content: center;
+    line-height: 1.5;
     margin-top: 15px;
+    padding: 12px 16px;
+    text-decoration: none;
+    transition: none;
 }
 
-.fp-add-override:hover {
-    background: #b32d2e !important;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(214,54,56,0.2);
+.fp-add-override:hover,
+.fp-add-override:focus {
+    background: #b32d2e;
+    border-color: #b32d2e;
+    color: #fff;
+}
+
+.fp-add-override:focus {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.fp-add-override:active {
+    background: #861d1f;
+    border-color: #861d1f;
+    color: #fff;
 }
 
 .fp-add-override .dashicons {
-    font-size: 1rem;
+    font-size: 16px;
 }
 
 /* WordPress standard responsive styles */
@@ -958,7 +924,6 @@ html {
 
 /* Focus states for accessibility */
 .fp-override-input:focus-visible,
-.fp-primary-button:focus-visible,
 .fp-override-remove:focus-visible {
     outline: 2px solid var(--fp-brand-primary);
     outline-offset: 2px;
@@ -990,23 +955,7 @@ html {
    ======================================== */
 
 /* Hardware acceleration for smooth animations */
-.fp-time-slot-card-clean,
-.fp-override-card-clean,
-.fp-day-pill-clean label,
-.fp-remove-time-slot-clean,
-.fp-override-remove-clean,
-#fp-add-time-slot,
-#fp-add-override {
-    transform: translateZ(0);
-    will-change: transform, opacity;
-}
-
-/* Optimized transitions with GPU acceleration */
-.fp-time-slot-card-clean {
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-                box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-                border-color 0.2s ease;
-}
+/* Hardware acceleration utilities removed to align with core WordPress styles */
 
 /* Loading states with optimized animations */
 .fp-loading {
@@ -1477,31 +1426,41 @@ html {
 
 .fp-day-pill label:hover {
     border-color: #8c8f94;
-    transform: translateY(-1px);
 }
 
 /* Remove time slot button */
 .fp-remove-time-slot {
-    background: #fff;
-    border: 1px solid #d63638;
-    color: #d63638;
-    padding: 8px 12px;
-    border-radius: 4px;
-    font-size: 0.75rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
     align-items: center;
+    background: transparent;
+    border: 1px solid #d63638;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #d63638;
+    cursor: pointer;
+    display: flex;
     gap: 4px;
+    line-height: 1.5;
+    padding: 8px 12px;
+    text-decoration: none;
+    transition: none;
     white-space: nowrap;
-    height: fit-content;
 }
 
 .fp-remove-time-slot:hover {
     background: #d63638;
+    border-color: #d63638;
     color: #fff;
-    transform: translateY(-1px);
+}
+
+.fp-remove-time-slot:focus {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.fp-remove-time-slot:active {
+    background: #861d1f;
+    border-color: #861d1f;
+    color: #fff;
 }
 
 .fp-remove-time-slot .dashicons {
@@ -1601,28 +1560,46 @@ html {
 
 /* Add time slot button */
 .fp-add-time-slot {
-    background: var(--fp-brand-primary);
+    background: #2271b1;
+    border: 1px solid #2271b1;
+    border-radius: 4px;
+    box-shadow: none;
     color: #fff;
-    border: none;
-    padding: 12px 20px;
-    border-radius: 6px;
-    font-size: 0.875rem;
-    font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s ease;
     display: inline-flex;
     align-items: center;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
     gap: 8px;
+    justify-content: center;
+    line-height: 1.5;
+    padding: 12px 16px;
+    text-decoration: none;
+    transition: none;
+    width: 100%;
 }
 
-.fp-add-time-slot:hover {
+.fp-add-time-slot:hover,
+.fp-add-time-slot:focus {
     background: #135e96;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(34, 113, 177, 0.3);
+    border-color: #135e96;
+    color: #fff;
+}
+
+.fp-add-time-slot:focus {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.fp-add-time-slot:active {
+    background: #0c4a6e;
+    border-color: #0c4a6e;
+    color: #fff;
 }
 
 .fp-add-time-slot .dashicons {
-    font-size: 1rem;
+    font-size: 16px;
 }
 
 /* ========================================
@@ -1727,12 +1704,8 @@ html {
 }
 
 .fp-time-field .dashicons {
+    color: #2271b1;
     font-size: 1.125rem;
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    filter: drop-shadow(0 1px 2px rgba(102,126,234,0.2));
 }
 
 .fp-time-field input[type="time"] {
@@ -1743,17 +1716,15 @@ html {
     font-size: 0.9375rem !important;
     font-weight: 500 !important;
     box-sizing: border-box !important;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
-    background: linear-gradient(145deg, #ffffff 0%, #f8f9fa 100%) !important;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.02), inset 0 2px 4px rgba(0,0,0,0.02);
+    transition: none !important;
+    background: #fff !important;
+    box-shadow: none;
 }
 
 .fp-time-field input[type="time"]:focus {
-    border-color: #667eea !important;
-    box-shadow: 0 0 0 3px rgba(102,126,234,0.1), 0 4px 12px rgba(102,126,234,0.15) !important;
-    outline: none !important;
-    background: #ffffff !important;
-    transform: translateY(-1px);
+    border-color: #2271b1 !important;
+    outline: 2px solid #72aee6 !important;
+    outline-offset: 2px !important;
 }
 
 .fp-time-field input[type="time"]:hover {
@@ -1774,35 +1745,33 @@ html {
 }
 
 .fp-days-field .dashicons {
+    color: #2271b1;
     font-size: 1.125rem;
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    filter: drop-shadow(0 1px 2px rgba(102,126,234,0.2));
 }
 
 /* Standard remove time slot button */
 .fp-remove-time-slot {
-    background: #fff !important;
-    border: 1px solid #d63638 !important;
-    color: #d63638 !important;
-    padding: 6px 10px !important;
-    border-radius: 4px !important;
-    cursor: pointer !important;
-    font-size: 0.8125rem !important;
-    font-weight: 500 !important;
-    display: flex !important;
     align-items: center !important;
+    background: transparent !important;
+    border: 1px solid #d63638 !important;
+    border-radius: 4px !important;
+    box-shadow: none !important;
+    color: #d63638 !important;
+    cursor: pointer !important;
+    display: flex !important;
     gap: 4px !important;
+    line-height: 1.5 !important;
     margin-top: 15px;
+    padding: 8px 12px !important;
+    text-decoration: none !important;
+    transition: none !important;
 }
 
 .fp-remove-time-slot:hover {
     background: #d63638 !important;
+    border-color: #d63638 !important;
     color: #fff !important;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(214,54,56,0.2);
+    box-shadow: none !important;
 }
 
 .fp-remove-time-slot .dashicons {
@@ -1957,7 +1926,7 @@ html {
 }
 
 .fp-summary-table th {
-    background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+    background: #f6f7f7;
     font-weight: 700;
     color: #2d3748;
     border-bottom: 2px solid #e2e8f0;
@@ -1967,7 +1936,7 @@ html {
 }
 
 .fp-summary-table tr:hover {
-    background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
+    background: #f0f0f1;
 }
 
 .fp-summary-table .fp-days-summary {
@@ -1977,12 +1946,12 @@ html {
 }
 
 .fp-summary-table .fp-day-badge {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: #fff;
-    padding: 4px 8px;
+    background: #2271b1;
     border-radius: 12px;
+    color: #fff;
     font-size: 0.6875rem;
     font-weight: 600;
+    padding: 4px 8px;
 }
 
 .fp-summary-table .fp-time-badge {
@@ -2002,34 +1971,80 @@ html {
 
 /* WordPress standard add time slot button */
 .fp-add-time-slot {
-    background: #0073aa;
-    border: none;
+    background: #2271b1;
+    border: 1px solid #2271b1;
+    border-radius: 4px;
     color: #fff;
-    padding: 6px 10px;
-    font-size: 0.8125rem;
     cursor: pointer;
-    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    gap: 8px;
+    justify-content: center;
+    line-height: 1.5;
     margin-top: 10px;
+    padding: 10px 16px;
+    text-decoration: none;
+    transition: none;
 }
 
-.fp-add-time-slot:hover {
-    background: #005a87;
+.fp-add-time-slot:hover,
+.fp-add-time-slot:focus {
+    background: #135e96;
+    border-color: #135e96;
+    color: #fff;
+}
+
+.fp-add-time-slot:focus {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.fp-add-time-slot:active {
+    background: #0c4a6e;
+    border-color: #0c4a6e;
+    color: #fff;
 }
 
 /* WordPress standard add override button */
 .fp-add-override {
     background: #d63638;
-    border: none;
+    border: 1px solid #d63638;
+    border-radius: 4px;
     color: #fff;
-    padding: 6px 10px;
-    font-size: 0.8125rem;
     cursor: pointer;
-    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    gap: 8px;
+    justify-content: center;
+    line-height: 1.5;
     margin-top: 10px;
+    padding: 10px 16px;
+    text-decoration: none;
+    transition: none;
 }
 
-.fp-add-override:hover {
+.fp-add-override:hover,
+.fp-add-override:focus {
     background: #b32d2e;
+    border-color: #b32d2e;
+    color: #fff;
+}
+
+.fp-add-override:focus {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.fp-add-override:active {
+    background: #861d1f;
+    border-color: #861d1f;
+    color: #fff;
 }
 
 .fp-remove-time-slot {
@@ -2096,19 +2111,15 @@ html {
 
 /* Focus management */
 .fp-time-slot-card-clean.fp-focused {
-    border-color: #72aee6;
-    box-shadow: 0 0 0 2px rgba(114, 174, 230, 0.2);
+    border-color: #2271b1;
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
 }
 
 /* New card highlight effect */
 .fp-time-slot-card-clean.fp-newly-added {
+    background: #f4fff8;
     border-color: #00a32a;
-    box-shadow: 0 0 0 2px rgba(0, 163, 42, 0.2);
-}
-
-.fp-time-slot-card-clean.fp-newly-added::before {
-    opacity: 1;
-    background: linear-gradient(90deg, #00a32a 0%, #046b2f 100%);
 }
 
 /* Container state indicators */
@@ -2140,7 +2151,8 @@ html {
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%);
+    margin-left: -9px;
+    margin-top: -9px;
 }
 
 /* Validation states */
@@ -2156,19 +2168,18 @@ html {
     box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.2) !important;
 }
 
-/* Card state animations */
-.fp-time-slot-card-clean.fp-error-shake {
-    animation: fp-error-shake 0.4s ease-in-out;
-}
-
+/* Card error state */
+.fp-time-slot-card-clean.fp-error-shake,
 .fp-override-card-clean.fp-error-shake {
-    animation: fp-error-shake 0.4s ease-in-out;
+    animation: none;
+    border-color: #d63638;
 }
 
 /* Improved hover states with performance */
 .fp-time-slot-card-clean:hover,
 .fp-override-card-clean:hover {
-    transform: translateY(-2px);
+    background: #f0f6fc;
+    border-color: #135e96;
 }
 
 /* Better focus indicators for accessibility */
@@ -2181,11 +2192,6 @@ html {
 
 /* High contrast improvements */
 @media (prefers-contrast: high) {
-    .fp-time-slot-card-clean::before,
-    .fp-override-card-clean::before {
-        height: 5px;
-    }
-    
     .fp-day-pill-clean input:checked + label {
         border: 3px solid #000;
     }
@@ -2235,126 +2241,97 @@ body.fp-reduced-animations .fp-loading::after {
    ENHANCED MAIN ACTION BUTTONS
    ======================================== */
 
-/* Time slot button with premium styling */
+/* Schedule builder action buttons aligned with WordPress core styles */
 #fp-add-time-slot,
 .fp-add-time-slot {
-    background: linear-gradient(135deg, var(--fp-brand-primary) 0%, #135e96 100%);
-    color: #fff;
-    border: none;
-    padding: 16px 24px;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 600;
-    text-decoration: none;
-    display: inline-flex;
     align-items: center;
+    background: #2271b1;
+    border: 1px solid #2271b1;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    gap: 8px;
     justify-content: center;
-    gap: 10px;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 3px 8px rgba(34, 113, 177, 0.3);
-    width: 100%;
+    line-height: 1.5;
     margin-top: 20px;
+    padding: 12px 20px;
     position: relative;
-    overflow: hidden;
-}
-
-#fp-add-time-slot::before,
-.fp-add-time-slot::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
+    text-decoration: none;
+    transition: none;
     width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
-    transition: left 0.5s ease;
 }
 
 #fp-add-time-slot:hover,
-.fp-add-time-slot:hover {
-    background: linear-gradient(135deg, #135e96 0%, #0f4c75 100%);
-    transform: translateY(-3px);
-    box-shadow: 0 8px 16px rgba(34, 113, 177, 0.4);
-}
-
-#fp-add-time-slot:hover::before,
-.fp-add-time-slot:hover::before {
-    left: 100%;
+#fp-add-time-slot:focus,
+.fp-add-time-slot:hover,
+.fp-add-time-slot:focus {
+    background: #135e96;
+    border-color: #135e96;
+    color: #fff;
 }
 
 #fp-add-time-slot:focus,
 .fp-add-time-slot:focus {
-    outline: 3px solid #72aee6;
+    outline: 2px solid #72aee6;
     outline-offset: 2px;
-    background: linear-gradient(135deg, #135e96 0%, #0f4c75 100%);
 }
 
 #fp-add-time-slot:active,
 .fp-add-time-slot:active {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(34, 113, 177, 0.5);
+    background: #0c4a6e;
+    border-color: #0c4a6e;
+    color: #fff;
 }
 
-/* Override button with distinct styling */
 #fp-add-override,
 .fp-add-override {
-    background: linear-gradient(135deg, #d63638 0%, #b32d2e 100%);
-    color: #fff;
-    border: none;
-    padding: 16px 24px;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 600;
-    text-decoration: none;
-    display: inline-flex;
     align-items: center;
+    background: #d63638;
+    border: 1px solid #d63638;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    gap: 8px;
     justify-content: center;
-    gap: 10px;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 3px 8px rgba(214, 54, 56, 0.3);
-    width: 100%;
+    line-height: 1.5;
     margin-top: 20px;
+    padding: 12px 20px;
     position: relative;
-    overflow: hidden;
-}
-
-#fp-add-override::before,
-.fp-add-override::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
+    text-decoration: none;
+    transition: none;
     width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
-    transition: left 0.5s ease;
 }
 
 #fp-add-override:hover,
-.fp-add-override:hover {
-    background: linear-gradient(135deg, #b32d2e 0%, #941a1c 100%);
-    transform: translateY(-3px);
-    box-shadow: 0 8px 16px rgba(214, 54, 56, 0.4);
-}
-
-#fp-add-override:hover::before,
-.fp-add-override:hover::before {
-    left: 100%;
+#fp-add-override:focus,
+.fp-add-override:hover,
+.fp-add-override:focus {
+    background: #b32d2e;
+    border-color: #b32d2e;
+    color: #fff;
 }
 
 #fp-add-override:focus,
 .fp-add-override:focus {
-    outline: 3px solid #d63638;
+    outline: 2px solid #72aee6;
     outline-offset: 2px;
-    background: linear-gradient(135deg, #b32d2e 0%, #941a1c 100%);
 }
 
 #fp-add-override:active,
 .fp-add-override:active {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(214, 54, 56, 0.5);
+    background: #861d1f;
+    border-color: #861d1f;
+    color: #fff;
 }
 
 /* Loading states for buttons */
@@ -2983,7 +2960,7 @@ body.fp-reduced-animations .fp-loading::after {
 .fp-empty-slots-message {
     text-align: center;
     padding: 50px 30px;
-    background: linear-gradient(135deg, #f8f9fa 0%, #f1f3f4 100%);
+    background: #f6f7f7;
     border: 2px dashed #c3c4c7;
     border-radius: 12px;
     color: #50575e;
@@ -3010,35 +2987,13 @@ body.fp-reduced-animations .fp-loading::after {
 /* Time slot card clean */
 .fp-time-slot-card-clean {
     background: #fff;
-    border: 1px solid #e1e5e9;
-    border-radius: 12px;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    box-shadow: none;
     margin-bottom: 20px;
     overflow: hidden;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     position: relative;
-}
-
-.fp-time-slot-card-clean::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: linear-gradient(90deg, #0073aa 0%, #135e96 100%);
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-.fp-time-slot-card-clean:hover {
-    border-color: #0073aa;
-    box-shadow: 0 8px 25px rgba(0, 115, 170, 0.15);
-    transform: translateY(-2px);
-}
-
-.fp-time-slot-card-clean:hover::before {
-    opacity: 1;
+    transition: none;
 }
 
 .fp-time-slot-content-clean {
@@ -3046,7 +3001,7 @@ body.fp-reduced-animations .fp-loading::after {
 }
 
 .fp-time-slot-header-clean {
-    background: linear-gradient(135deg, #f8f9fa 0%, #f1f3f4 100%);
+    background: #f6f7f7;
     padding: 20px;
     border-bottom: 1px solid #e5e5e5;
     display: grid;
@@ -3139,27 +3094,40 @@ body.fp-reduced-animations .fp-loading::after {
 }
 
 .fp-slot-actions-clean .fp-remove-time-slot-clean {
-    background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
-    color: #fff;
-    border: none;
-    padding: 10px 16px;
-    border-radius: 6px;
+    align-items: center;
+    background: transparent;
+    border: 1px solid #d63638;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #d63638;
     cursor: pointer;
-    font-size: 0.8125rem;
+    display: inline-flex;
+    font-family: inherit;
+    font-size: 13px;
     font-weight: 600;
-    transition: all 0.2s ease;
-    box-shadow: 0 2px 4px rgba(220, 53, 69, 0.2);
+    gap: 6px;
+    justify-content: center;
+    line-height: 1.5;
+    padding: 8px 12px;
+    text-decoration: none;
+    transition: none;
 }
 
 .fp-slot-actions-clean .fp-remove-time-slot-clean:hover {
-    background: linear-gradient(135deg, #c82333 0%, #bd2130 100%);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(220, 53, 69, 0.3);
+    background: #d63638;
+    border-color: #d63638;
+    color: #fff;
 }
 
 .fp-slot-actions-clean .fp-remove-time-slot-clean:focus {
-    outline: 2px solid #dc3545;
+    outline: 2px solid #72aee6;
     outline-offset: 2px;
+}
+
+.fp-slot-actions-clean .fp-remove-time-slot-clean:active {
+    background: #861d1f;
+    border-color: #861d1f;
+    color: #fff;
 }
 
 .fp-slot-actions-clean .fp-remove-time-slot-clean:active {
@@ -3236,7 +3204,7 @@ body.fp-reduced-animations .fp-loading::after {
 .fp-overrides-empty-clean {
     text-align: center;
     padding: 50px 30px;
-    background: linear-gradient(135deg, #fff5f5 0%, #fef2f2 100%);
+    background: #fef2f2;
     border: 2px dashed #f5c6cb;
     border-radius: 12px;
     color: #721c24;
@@ -3263,35 +3231,17 @@ body.fp-reduced-animations .fp-loading::after {
 /* Override card clean */
 .fp-override-card-clean {
     background: #fff;
-    border: 1px solid #e1e5e9;
-    border-radius: 12px;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    box-shadow: none;
     margin-bottom: 20px;
     overflow: hidden;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     position: relative;
-}
-
-.fp-override-card-clean::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: linear-gradient(90deg, #d63638 0%, #b32d2e 100%);
-    opacity: 0;
-    transition: opacity 0.3s ease;
+    transition: none;
 }
 
 .fp-override-card-clean:hover {
     border-color: #d63638;
-    box-shadow: 0 8px 25px rgba(214, 54, 56, 0.15);
-    transform: translateY(-2px);
-}
-
-.fp-override-card-clean:hover::before {
-    opacity: 1;
 }
 
 .fp-override-card-clean.is-closed {
@@ -3299,12 +3249,8 @@ body.fp-reduced-animations .fp-loading::after {
     background: #fff5f5;
 }
 
-.fp-override-card-clean.is-closed::before {
-    opacity: 1;
-}
-
 .fp-override-header-clean {
-    background: linear-gradient(135deg, #f8f9fa 0%, #f1f3f4 100%);
+    background: #f6f7f7;
     padding: 18px 20px;
     border-bottom: 1px solid #e5e5e5;
     display: grid;
@@ -3359,32 +3305,40 @@ body.fp-reduced-animations .fp-loading::after {
 }
 
 .fp-override-remove-clean {
-    background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
-    color: #fff;
-    border: none;
-    padding: 10px 16px;
-    border-radius: 6px;
+    align-items: center;
+    background: transparent;
+    border: 1px solid #d63638;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #d63638;
     cursor: pointer;
-    font-size: 0.8125rem;
+    display: inline-flex;
+    font-family: inherit;
+    font-size: 13px;
     font-weight: 600;
-    transition: all 0.2s ease;
-    box-shadow: 0 2px 4px rgba(220, 53, 69, 0.2);
+    gap: 6px;
+    justify-content: center;
+    line-height: 1.5;
+    padding: 8px 12px;
+    text-decoration: none;
+    transition: none;
 }
 
 .fp-override-remove-clean:hover {
-    background: linear-gradient(135deg, #c82333 0%, #bd2130 100%);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(220, 53, 69, 0.3);
+    background: #d63638;
+    border-color: #d63638;
+    color: #fff;
 }
 
 .fp-override-remove-clean:focus {
-    outline: 2px solid #dc3545;
+    outline: 2px solid #72aee6;
     outline-offset: 2px;
 }
 
 .fp-override-remove-clean:active {
-    transform: translateY(0);
-    box-shadow: 0 1px 2px rgba(220, 53, 69, 0.4);
+    background: #861d1f;
+    border-color: #861d1f;
+    color: #fff;
 }
 
 .fp-override-fields-clean {
@@ -3439,15 +3393,15 @@ body.fp-reduced-animations .fp-loading::after {
 }
 
 .fp-override-toggle-clean {
-    background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+    background: #f6f7f7;
     padding: 16px 20px;
     border-bottom: 1px solid #e5e5e5;
     margin: 0;
-    transition: all 0.2s ease;
+    transition: none;
 }
 
 .fp-override-toggle-clean:hover {
-    background: linear-gradient(135deg, #f1f3f4 0%, #e1e5e9 100%);
+    background: #f0f0f1;
 }
 
 .fp-override-toggle-clean label {
@@ -3575,7 +3529,7 @@ body.fp-reduced-animations .fp-loading::after {
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #007cba 0%, #00a0d2 100%);
+    background: #2271b1;
     transition: width 0.3s ease;
     border-radius: 4px;
 }
@@ -3759,25 +3713,69 @@ body.admin-bar .fp-notification {
 }
 
 .fp-add-event-timeslot {
-    background: var(--fp-brand-primary);
-    color: white;
-    border: none;
+    align-items: center;
+    background: #2271b1;
+    border: 1px solid #2271b1;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 6px;
+    line-height: 1.5;
+    padding: 6px 12px;
+    text-decoration: none;
+    transition: none;
 }
 
 .fp-add-event-timeslot:hover {
-    background: #e55a2b;
-    color: white;
+    background: #135e96;
+    border-color: #135e96;
+    color: #fff;
+}
+
+.fp-add-event-timeslot:focus {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.fp-add-event-timeslot:active {
+    background: #0c4a6e;
+    border-color: #0c4a6e;
+    color: #fff;
 }
 
 .fp-remove-event-date {
-    background: #dc3545;
-    color: white;
-    border: none;
+    align-items: center;
+    background: transparent;
+    border: 1px solid #d63638;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #d63638;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 6px;
+    line-height: 1.5;
+    padding: 6px 12px;
+    text-decoration: none;
+    transition: none;
 }
 
 .fp-remove-event-date:hover {
-    background: #c82333;
-    color: white;
+    background: #d63638;
+    border-color: #d63638;
+    color: #fff;
+}
+
+.fp-remove-event-date:focus {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.fp-remove-event-date:active {
+    background: #861d1f;
+    border-color: #861d1f;
+    color: #fff;
 }
 
 /* Event timeslots */

--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -376,10 +376,10 @@ class Experience {
 						<?php $this->renderEventScheduleBuilder( $post->ID ); ?>
 					</div>
 					
-					<button type="button" class="button fp-primary-button" id="fp-add-event-schedule">
-						<span class="dashicons dashicons-plus-alt"></span>
-						<?php _e( 'Add Event Date', 'fp-esperienze' ); ?>
-					</button>
+                                        <button type="button" class="button button-primary" id="fp-add-event-schedule">
+                                                <span class="dashicons dashicons-plus-alt"></span>
+                                                <?php _e( 'Add Event Date', 'fp-esperienze' ); ?>
+                                        </button>
 				</div>
 			</fieldset>
 			
@@ -394,10 +394,10 @@ class Experience {
 					<div id="fp-overrides-container">
 						<?php $this->renderOverridesSection( $post->ID ); ?>
 					</div>
-					<button type="button" class="button fp-primary-button fp-add-override" id="fp-add-override">
-						<span class="dashicons dashicons-plus-alt"></span>
-						<?php _e( 'Add Date Override', 'fp-esperienze' ); ?>
-					</button>
+                                        <button type="button" class="button button-primary fp-add-override" id="fp-add-override">
+                                                <span class="dashicons dashicons-plus-alt"></span>
+                                                <?php _e( 'Add Date Override', 'fp-esperienze' ); ?>
+                                        </button>
 				</div>
 			</fieldset>
 			
@@ -571,11 +571,11 @@ class Experience {
 				</div>
 			</div>
 			
-			<div style="text-align: right;">
-				<button type="button" class="button fp-remove-schedule" style="color: #dc3545;">
-					<span class="dashicons dashicons-trash" style="vertical-align: middle;"></span>
-					<?php _e( 'Remove Schedule', 'fp-esperienze' ); ?>
-				</button>
+                        <div style="text-align: right;">
+                                <button type="button" class="button button-link-delete fp-remove-schedule">
+                                        <span class="dashicons dashicons-trash" style="vertical-align: middle;"></span>
+                                        <?php _e( 'Remove Schedule', 'fp-esperienze' ); ?>
+                                </button>
 			</div>
 		</div>
 		<?php
@@ -631,10 +631,10 @@ class Experience {
 				<?php endif; ?>
 			</div>
 			
-			<button type="button" class="button fp-add-time-slot" id="fp-add-time-slot">
-				<span class="dashicons dashicons-plus-alt"></span>
-				<?php _e( 'Add Time Slot', 'fp-esperienze' ); ?>
-			</button>
+                        <button type="button" class="button button-primary fp-add-time-slot" id="fp-add-time-slot">
+                                <span class="dashicons dashicons-plus-alt"></span>
+                                <?php _e( 'Add Time Slot', 'fp-esperienze' ); ?>
+                        </button>
 		</div>
 		
 		<!-- Hidden container for generated schedule inputs -->
@@ -683,11 +683,11 @@ class Experience {
 					</div>
 				</div>
 				
-				<div class="fp-slot-actions-clean">
-					<button type="button" class="fp-remove-time-slot-clean button">
-						<span class="dashicons dashicons-trash"></span>
-						<?php _e( 'Remove', 'fp-esperienze' ); ?>
-					</button>
+                                <div class="fp-slot-actions-clean">
+                                        <button type="button" class="button button-link-delete fp-remove-time-slot-clean">
+                                                <span class="dashicons dashicons-trash"></span>
+                                                <?php _e( 'Remove', 'fp-esperienze' ); ?>
+                                        </button>
 				</div>
 			</div>
 			
@@ -812,11 +812,11 @@ class Experience {
 					</div>
 				</div>
 				
-				<div>
-					<button type="button" class="fp-remove-time-slot">
-						<span class="dashicons dashicons-trash"></span>
-						<?php _e( 'Remove', 'fp-esperienze' ); ?>
-					</button>
+                                <div>
+                                        <button type="button" class="button button-link-delete fp-remove-time-slot">
+                                                <span class="dashicons dashicons-trash"></span>
+                                                <?php _e( 'Remove', 'fp-esperienze' ); ?>
+                                        </button>
 				</div>
 			</div>
 			
@@ -1049,14 +1049,14 @@ class Experience {
 				<span class="fp-event-date-meta"><?php printf( _n( '%d time slot', '%d time slots', count( $schedules ), 'fp-esperienze' ), count( $schedules ) ); ?></span>
 			</div>
 			<div class="fp-event-date-actions">
-				<button type="button" class="button fp-add-event-timeslot" data-date="<?php echo esc_attr( $date ); ?>">
-					<span class="dashicons dashicons-clock"></span>
-					<?php _e( 'Add Time Slot', 'fp-esperienze' ); ?>
-				</button>
-				<button type="button" class="button fp-remove-event-date" data-date="<?php echo esc_attr( $date ); ?>">
-					<span class="dashicons dashicons-trash"></span>
-					<?php _e( 'Remove Date', 'fp-esperienze' ); ?>
-				</button>
+                                <button type="button" class="button button-primary fp-add-event-timeslot" data-date="<?php echo esc_attr( $date ); ?>">
+                                        <span class="dashicons dashicons-clock"></span>
+                                        <?php _e( 'Add Time Slot', 'fp-esperienze' ); ?>
+                                </button>
+                                <button type="button" class="button button-link-delete fp-remove-event-date" data-date="<?php echo esc_attr( $date ); ?>">
+                                        <span class="dashicons dashicons-trash"></span>
+                                        <?php _e( 'Remove Date', 'fp-esperienze' ); ?>
+                                </button>
 			</div>
 		</div>
 		
@@ -1148,11 +1148,11 @@ class Experience {
 							min="0" step="0.01" required>
 				</div>
 				
-				<div class="fp-timeslot-actions">
-					<button type="button" class="button fp-remove-event-timeslot">
-						<span class="dashicons dashicons-trash"></span>
-						<?php _e( 'Remove', 'fp-esperienze' ); ?>
-					</button>
+                                <div class="fp-timeslot-actions">
+                                        <button type="button" class="button button-link-delete fp-remove-event-timeslot">
+                                                <span class="dashicons dashicons-trash"></span>
+                                                <?php _e( 'Remove', 'fp-esperienze' ); ?>
+                                        </button>
 				</div>
 			</div>
 		</div>
@@ -1233,10 +1233,10 @@ class Experience {
 						<label for="override-closed-<?php echo esc_attr( $index ); ?>"><?php _e( 'Closed', 'fp-esperienze' ); ?></label>
 					</div>
 					
-					<button type="button" class="fp-override-remove-clean button">
-						<span class="dashicons dashicons-trash"></span>
-						<?php _e( 'Remove', 'fp-esperienze' ); ?>
-					</button>
+                                        <button type="button" class="button button-link-delete fp-override-remove-clean">
+                                                <span class="dashicons dashicons-trash"></span>
+                                                <?php _e( 'Remove', 'fp-esperienze' ); ?>
+                                        </button>
 				</div>
 			</div>
 			
@@ -1334,10 +1334,10 @@ class Experience {
 								data-original-checked="<?php echo $is_closed ? '1' : '0'; ?>">
 						<label for="override-closed-<?php echo esc_attr( $index ); ?>"><?php _e( 'Closed', 'fp-esperienze' ); ?></label>
 					</div>
-					<button type="button" class="fp-override-remove" aria-label="<?php esc_attr_e( 'Remove this override', 'fp-esperienze' ); ?>">
-						<span class="dashicons dashicons-trash"></span>
-						<?php _e( 'Remove', 'fp-esperienze' ); ?>
-					</button>
+                                        <button type="button" class="button button-link-delete fp-override-remove" aria-label="<?php esc_attr_e( 'Remove this override', 'fp-esperienze' ); ?>">
+                                                <span class="dashicons dashicons-trash"></span>
+                                                <?php _e( 'Remove', 'fp-esperienze' ); ?>
+                                        </button>
 				</div>
 			</div>
 			
@@ -1498,10 +1498,10 @@ class Experience {
 		</td>
 		
 		<td>
-			<button type="button" class="fp-override-remove" aria-label="<?php esc_attr_e( 'Remove this override', 'fp-esperienze' ); ?>">
-				<span class="dashicons dashicons-trash"></span>
-				<?php _e( 'Remove', 'fp-esperienze' ); ?>
-			</button>
+                   <button type="button" class="button button-link-delete fp-override-remove" aria-label="<?php esc_attr_e( 'Remove this override', 'fp-esperienze' ); ?>">
+                            <span class="dashicons dashicons-trash"></span>
+                            <?php _e( 'Remove', 'fp-esperienze' ); ?>
+                   </button>
 		</td>
 		<?php
 	}
@@ -1594,10 +1594,10 @@ class Experience {
 					aria-label="<?php esc_attr_e( 'Reason for this override', 'fp-esperienze' ); ?>"
 					data-original-value="<?php echo esc_attr( $override->reason ?? '' ); ?>">
 			
-			<button type="button" class="fp-override-remove" aria-label="<?php esc_attr_e( 'Remove this override', 'fp-esperienze' ); ?>">
-				<span class="dashicons dashicons-trash"></span>
-				<?php _e( 'Remove', 'fp-esperienze' ); ?>
-			</button>
+                   <button type="button" class="button button-link-delete fp-override-remove" aria-label="<?php esc_attr_e( 'Remove this override', 'fp-esperienze' ); ?>">
+                            <span class="dashicons dashicons-trash"></span>
+                            <?php _e( 'Remove', 'fp-esperienze' ); ?>
+                   </button>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
## Summary
- restyled schedule builder action buttons to use the WordPress admin color palette and accessible focus states while removing custom gradients, shadows, and transforms
- simplified time slot and override card visuals to match core cards and removed bespoke animation hooks for a calmer experience
- updated removal and event controls plus PHP markup to rely on core `button` classes for consistent WordPress typography and semantics

## Testing
- php -l includes/ProductType/Experience.php

------
https://chatgpt.com/codex/tasks/task_e_68cb28b4a94c832fa3efec1e8ea0cc84