### PR TITLE
Fix conversion funnel caching and add regression test

### DIFF
--- a/includes/Admin/AdvancedAnalytics.php
+++ b/includes/Admin/AdvancedAnalytics.php
@@ -202,8 +202,9 @@ class AdvancedAnalytics {
 
         // Get completed purchases
         $purchases = $this->getCompletedPurchases($date_from, $date_to);
+        $total_revenue = $this->getTotalRevenue($date_from, $date_to);
 
-        return [
+        $funnel_data = [
             'funnel_steps' => [
                 [
                     'step' => 'Website Visits',
@@ -237,8 +238,8 @@ class AdvancedAnalytics {
                 ]
             ],
             'overall_conversion_rate' => $visits > 0 ? round(($purchases / $visits) * 100, 2) : 0,
-            'total_revenue' => $this->getTotalRevenue($date_from, $date_to),
-            'average_order_value' => $purchases > 0 ? round($this->getTotalRevenue($date_from, $date_to) / $purchases, 2) : 0
+            'total_revenue' => $total_revenue,
+            'average_order_value' => $purchases > 0 ? round($total_revenue / $purchases, 2) : 0
         ];
 
         // Cache for 1 hour

--- a/tests/AdvancedAnalyticsFunnelCacheTest.php
+++ b/tests/AdvancedAnalyticsFunnelCacheTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+use FP\Esperienze\Admin\AdvancedAnalytics;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error {}
+}
+
+if (!class_exists('WP_REST_Response')) {
+    class WP_REST_Response {
+        public function __construct($data = null) {}
+        public function header($name, $value) {}
+        public function get_headers() {
+            return [];
+        }
+        public function get_data() {
+            return null;
+        }
+    }
+}
+
+require_once __DIR__ . '/../includes/Admin/AdvancedAnalytics.php';
+
+$transients = [];
+$transient_stats = [
+    'get' => 0,
+    'hit' => 0,
+];
+
+function get_transient(string $key) {
+    global $transients, $transient_stats;
+
+    $transient_stats['get']++;
+
+    if (array_key_exists($key, $transients)) {
+        $transient_stats['hit']++;
+        return $transients[$key];
+    }
+
+    return false;
+}
+
+function set_transient(string $key, $value, int $ttl) {
+    global $transients;
+
+    $transients[$key] = $value;
+
+    return true;
+}
+
+class WPDBStub {
+    public string $prefix = 'wp_';
+    public int $prepare_calls = 0;
+    public int $get_var_calls = 0;
+
+    /**
+     * @return array{0: string, 1: array}
+     */
+    public function prepare(string $query, ...$args): array {
+        $this->prepare_calls++;
+
+        return [$query, $args];
+    }
+
+    public function get_var($prepared) {
+        $this->get_var_calls++;
+
+        return $this->get_var_calls === 1 ? 12 : 3456.78;
+    }
+}
+
+$wpdb = new WPDBStub();
+$GLOBALS['wpdb'] = $wpdb;
+
+$reflection = new ReflectionClass(AdvancedAnalytics::class);
+/** @var AdvancedAnalytics $analytics */
+$analytics = $reflection->newInstanceWithoutConstructor();
+
+$method = $reflection->getMethod('getConversionFunnelData');
+$method->setAccessible(true);
+
+$first_result = $method->invoke($analytics, '2024-01-01', '2024-01-31');
+$first_db_calls = $wpdb->get_var_calls;
+
+$second_result = $method->invoke($analytics, '2024-01-01', '2024-01-31');
+$second_db_calls = $wpdb->get_var_calls;
+
+if ($first_result !== $second_result) {
+    echo "Cached funnel data mismatch\n";
+    exit(1);
+}
+
+if ($second_db_calls !== $first_db_calls) {
+    echo "Conversion funnel cache miss\n";
+    exit(1);
+}
+
+if ($transient_stats['hit'] < 1) {
+    echo "Transient cache was not hit\n";
+    exit(1);
+}
+
+echo "Conversion funnel cache test passed\n";


### PR DESCRIPTION
## Summary
- ensure the conversion funnel analytics data is assigned to a variable for reuse and caching
- cache the computed funnel data before returning to callers
- add a regression test that verifies repeated calls hit the transient cache instead of recomputing

## Testing
- php tests/AdvancedAnalyticsFunnelCacheTest.php
- php tests/AutoTranslatorCacheKeyTest.php
- php tests/CartHooksCutoffTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb22affdc832fb7b60959e8b29605