### PR TITLE
Add Throwable import for installer activation handling

### DIFF
--- a/includes/Core/Installer.php
+++ b/includes/Core/Installer.php
@@ -8,6 +8,7 @@
 namespace FP\Esperienze\Core;
 
 use Exception;
+use Throwable;
 use FP\Esperienze\Core\CapabilityManager;
 use FP\Esperienze\Core\TranslationQueue;
 use FP\Esperienze\Core\PerformanceOptimizer;


### PR DESCRIPTION
## Summary
- import the global `Throwable` interface in the installer so activation exceptions are handled without fatal errors

## Testing
- php -l includes/Core/Installer.php
- php /tmp/test_activation.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb638ba30832fa27290c21b6b999c