### PR TITLE
Ensure Plugin Throwable catches use global interface

### DIFF
--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -41,6 +41,7 @@ use FP\Esperienze\Core\SecurityEnhancer;
 use FP\Esperienze\Core\PerformanceOptimizer;
 use FP\Esperienze\Core\UXEnhancer;
 use FP\Esperienze\Core\FeatureTester;
+use Throwable;
 
 defined('ABSPATH') || exit;
 


### PR DESCRIPTION
## Summary
- import the global `Throwable` interface within the plugin class so catch blocks resolve correctly

## Testing
- php -l includes/Core/Plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68cbba078af8832f8da9e2493d404525