### PR TITLE
Adjust booking insert format placeholders

### DIFF
--- a/includes/Data/HoldManager.php
+++ b/includes/Data/HoldManager.php
@@ -287,7 +287,7 @@ class HoldManager {
             $booking_result = $wpdb->insert(
                 $bookings_table,
                 $booking_data,
-                ['%d', '%d', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s']
+                ['%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s']
             );
             
             if ($booking_result === false) {
@@ -394,7 +394,7 @@ class HoldManager {
             $booking_result = $wpdb->insert(
                 $bookings_table,
                 $booking_data,
-                ['%d', '%d', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s']
+                ['%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s']
             );
             
             if ($booking_result === false) {


### PR DESCRIPTION
## Summary
- update the format placeholder arrays in `HoldManager::convertHoldToBooking()` and `HoldManager::atomicCapacityCheck()` so they match the `$booking_data` order and keep date/time values stored as strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbbc813978832f87f881148ec280ba