### PR TITLE
Add machine-readable gift meta keys for vouchers

### DIFF
--- a/includes/Booking/Cart_Hooks.php
+++ b/includes/Booking/Cart_Hooks.php
@@ -432,19 +432,25 @@ class Cart_Hooks {
         // Save gift meta data
         if (isset($values['fp_gift']) && $values['fp_gift']['is_gift']) {
             $gift_data = $values['fp_gift'];
-            
+
+            $item->add_meta_data('_fp_is_gift', 'yes');
             $item->add_meta_data(__('Gift Purchase', 'fp-esperienze'), __('Yes', 'fp-esperienze'));
+            $item->add_meta_data('_fp_gift_recipient_name', $gift_data['recipient_name']);
             $item->add_meta_data(__('Recipient Name', 'fp-esperienze'), $gift_data['recipient_name']);
+            $item->add_meta_data('_fp_gift_recipient_email', $gift_data['recipient_email']);
             $item->add_meta_data(__('Recipient Email', 'fp-esperienze'), $gift_data['recipient_email']);
-            
+
             if (!empty($gift_data['sender_name'])) {
+                $item->add_meta_data('_fp_gift_sender_name', $gift_data['sender_name']);
                 $item->add_meta_data(__('Sender Name', 'fp-esperienze'), $gift_data['sender_name']);
             }
-            
+
             if (!empty($gift_data['message'])) {
+                $item->add_meta_data('_fp_gift_message', $gift_data['message']);
                 $item->add_meta_data(__('Gift Message', 'fp-esperienze'), $gift_data['message']);
             }
-            
+
+            $item->add_meta_data('_fp_gift_send_date', $gift_data['send_date']);
             $item->add_meta_data(__('Send Date', 'fp-esperienze'), $gift_data['send_date']);
         }
         


### PR DESCRIPTION
## Summary
- store machine-readable gift metadata on order items alongside the translated labels
- teach the voucher manager to read the new meta keys first and fall back to localized labels for older orders
- add helpers to normalize gift meta values when generating vouchers

## Testing
- composer test *(fails: PHPStan worker hit 128M memory limit)*
- php -d memory_limit=512M vendor/bin/phpstan analyse *(fails: thousands of missing WordPress/WooCommerce symbol errors in existing codebase)*
- vendor/bin/phpcs --standard=WordPress includes/ *(fails: pre-existing widespread style violations in codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd4eab8d8832f8d8de0daaedb6ac6