### PR TITLE
Restore brand button color token

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -7,6 +7,7 @@ html {
 /* CSS Custom Properties for consistent colors and accessibility */
 :root {
     --fp-brand-primary: #ff6b35; /* Brand primary color for backgrounds and borders */
+    --fp-brand-orange: var(--fp-brand-primary); /* Legacy alias for components still using the orange token */
     --fp-brand-secondary: #2c3e50; /* Brand secondary color - updated via branding settings */
     --fp-text-gray: #555; /* Improved from #666 for better contrast */
     --fp-text-light-gray: #666; /* Improved from #999 for better contrast */

--- a/assets/js/archive-block.js
+++ b/assets/js/archive-block.js
@@ -200,7 +200,7 @@ if (typeof jQuery === 'undefined') {
                     activeFilters.length > 0 && createElement('div', {
                         style: {
                             fontSize: '12px',
-                            color: 'var(--fp-brand-orange, #ff6b35)',
+                            color: 'var(--fp-brand-primary, #ff6b35)',
                             marginTop: '10px',
                             fontWeight: '500'
                         }


### PR DESCRIPTION
## Summary
- restore the legacy `--fp-brand-orange` CSS custom property by mapping it to `--fp-brand-primary` so existing button styles pick up the correct brand color
- point the archive block preview styles at the supported brand variable to keep the editor preview in sync

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cbdb10584c832fa6895654e0cc87a1