### PR TITLE
Ensure experience products are purchasable

### DIFF
--- a/includes/ProductType/WC_Product_Experience.php
+++ b/includes/ProductType/WC_Product_Experience.php
@@ -24,6 +24,15 @@ class WC_Product_Experience extends \WC_Product {
     protected $product_type = 'experience';
 
     /**
+     * Supported features for the experience product type.
+     *
+     * @var array<string>
+     */
+    protected $supports = [
+        'ajax_add_to_cart',
+    ];
+
+    /**
      * Constructor
      *
      * @param mixed $product Product ID or WC_Product
@@ -57,6 +66,22 @@ class WC_Product_Experience extends \WC_Product {
      */
     public function is_downloadable() {
         return false;
+    }
+
+    /**
+     * Check if product can be purchased.
+     *
+     * @return bool
+     */
+    public function is_purchasable() {
+        $purchasable = $this->exists() && $this->get_status() === 'publish';
+
+        if ($purchasable) {
+            $schedules = ScheduleManager::getSchedules($this->get_id());
+            $purchasable = !empty($schedules);
+        }
+
+        return apply_filters('woocommerce_is_purchasable', $purchasable, $this);
     }
 
     /**


### PR DESCRIPTION
## Summary
- declare AJAX add-to-cart support for the custom experience product wrapper
- ensure experiences report themselves as purchasable when published with active schedules so WooCommerce allows cart operations while still honouring the core filter

## Testing
- composer test *(fails: phpstan crashes at 128M memory limit before analysing due to configuration warnings)*
- vendor/bin/phpstan analyse --memory-limit=512M *(fails: thousands of pre-existing errors caused by missing WordPress stubs and legacy code issues outside the touched file)*
- vendor/bin/phpcs --standard=WordPress includes/ProductType/WC_Product_Experience.php *(fails: longstanding coding-standard violations across the file that predate this change)*
- php -l includes/ProductType/WC_Product_Experience.php

------
https://chatgpt.com/codex/tasks/task_e_68cbdcbce8bc832fa644fed9c3c9fda5