### PR TITLE
Prevent schedule builder auto changes from toggling unsaved warning

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -258,12 +258,15 @@
         bindEvents: function() {
             // Schedule management
             this.bindScheduleEvents();
-            
+
             // Event schedule management
             this.bindEventScheduleEvents();
-            
+
             // Modern schedule and override management - REFACTORED
             this.initModernScheduleBuilder();
+
+            // Reset unsaved changes after automatic builder setup
+            this.clearUnsavedChanges();
         },
         
         /**
@@ -759,8 +762,8 @@
             });
             
             // Auto-save functionality for better UX
-            $(document).on('change', '#fp-time-slots-container input, #fp-time-slots-container select', function() {
-                self.markAsChanged();
+            $(document).on('change', '#fp-time-slots-container input, #fp-time-slots-container select', function(event) {
+                self.markAsChanged(event);
             });
         },
         
@@ -833,7 +836,11 @@
         /**
          * Mark form as changed for unsaved changes warning
          */
-        markAsChanged: function() {
+        markAsChanged: function(event) {
+            if (!event || !event.originalEvent) {
+                return;
+            }
+
             if (!this.hasUnsavedChanges) {
                 this.hasUnsavedChanges = true;
                 this.showUnsavedChangesWarning();


### PR DESCRIPTION
## Summary
- ignore synthetic schedule builder change events before marking the form as dirty
- reset the unsaved changes flag after initializing the modern builder so automatic updates stay silent

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbde56ed44832f8024f404c52b6a9f