### PR TITLE
Add cart security nonce to frontend add to cart

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -655,6 +655,10 @@
             formData.append('fp_qty_adult', adultQty);
             formData.append('fp_qty_child', childQty);
             formData.append('fp_extras', JSON.stringify(extras));
+
+            if (typeof wc_add_to_cart_params !== 'undefined' && wc_add_to_cart_params.add_to_cart_nonce) {
+                formData.append('security', wc_add_to_cart_params.add_to_cart_nonce);
+            }
             
             // Add gift data if this is a gift purchase
             if (isGift) {


### PR DESCRIPTION
## Summary
- append WooCommerce add_to_cart nonce to the FormData payload in the frontend add to cart handler
- rely on the shared frontend path so booking widget requests also include the nonce

## Testing
- not run (environment-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cbe44fa288832fa9d475d927072e68