### PR TITLE
Hook branding CSS output on frontend

### DIFF
--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -271,9 +271,11 @@ class Plugin {
         new Templates();
         new SEOManager();
         new \FP\Esperienze\Frontend\WidgetCheckoutHandler();
-        
+
         // Hide Experience products from normal WooCommerce shop/catalog
         $this->initShopFiltering();
+
+        add_action('wp_head', [$this, 'outputBrandingCSS'], 90);
     }
 
     /**


### PR DESCRIPTION
## Summary
- hook the branding CSS output into `wp_head` during frontend initialization
- ensure branding colors render on public pages without affecting admin screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbe6c3d9e8832fbe9a4f85c3b9f550