### PR TITLE
Update FeatureTester performance cache test

### DIFF
--- a/includes/Core/FeatureTester.php
+++ b/includes/Core/FeatureTester.php
@@ -75,9 +75,17 @@ class FeatureTester {
             
             // Test cache functionality
             try {
-                $cache_result = PerformanceOptimizer::cacheQuery('test_query', 'SELECT 1', 300);
+                $cache_result = PerformanceOptimizer::cacheQuery(
+                    'test_query',
+                    static function () {
+                        global $wpdb;
+
+                        return $wpdb->get_var('SELECT 1');
+                    },
+                    300
+                );
                 $results['cache_test'] = true;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $results['cache_test'] = false;
                 $results['cache_error'] = $e->getMessage();
             }


### PR DESCRIPTION
## Summary
- adjust the FeatureTester performance cache test to run a real callback against $wpdb
- expand the catch block to handle any throwable errors during cache testing

## Testing
- php -l includes/Core/FeatureTester.php

------
https://chatgpt.com/codex/tasks/task_e_68cc2430777c832fa9caa676ccb53b00