### PR TITLE
Adjust add to cart success handling

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -692,12 +692,26 @@
                 return response.json();
             })
             .then(function(response) {
-                if (response && response.success) {
+                var hasFragments = !!(response && response.fragments);
+                var hasErrorFlag = !!(response && response.error);
+                var rawErrorMessage = response?.data?.error
+                    || response?.data?.message
+                    || response?.message
+                    || response?.messages
+                    || (typeof response?.error === 'string' ? response.error : '');
+                var errorMessage = (typeof rawErrorMessage === 'string' && rawErrorMessage.trim().length)
+                    ? rawErrorMessage
+                    : '';
+
+                if (!hasErrorFlag || hasFragments) {
                     window.location.href = cartUrl;
                     return;
                 }
 
-                self.showError(response?.data?.error || defaultErrorMessage);
+                if (errorMessage) {
+                    self.showError(errorMessage);
+                }
+
                 $addToCartButton.prop('disabled', false).text(addToCartText);
             })
             .catch(function() {


### PR DESCRIPTION
## Summary
- update the add to cart response handler to treat WooCommerce fragment responses as successful
- only display the frontend error banner when WooCommerce returns an explicit error message

## Testing
- not run (requires WooCommerce/WP environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc249e955c832fac6ea2dab2303633