### PR TITLE
Prevent duplicate mobile endpoint registration

### DIFF
--- a/includes/REST/MobileAPIManager.php
+++ b/includes/REST/MobileAPIManager.php
@@ -30,9 +30,22 @@ class MobileAPIManager {
     private const API_NAMESPACE = 'fp-esperienze/v2';
 
     /**
+     * Tracks whether the mobile endpoints have already been registered.
+     *
+     * @var bool
+     */
+    private static $endpointsRegistered = false;
+
+    /**
      * Constructor
      */
     public function __construct() {
+        if (did_action('rest_api_init')) {
+            $this->registerMobileEndpoints();
+
+            return;
+        }
+
         add_action('rest_api_init', [$this, 'registerMobileEndpoints']);
     }
 
@@ -40,6 +53,12 @@ class MobileAPIManager {
      * Register mobile-specific REST endpoints
      */
     public function registerMobileEndpoints(): void {
+        if (self::$endpointsRegistered) {
+            return;
+        }
+
+        self::$endpointsRegistered = true;
+
         // Authentication endpoints
         register_rest_route(self::API_NAMESPACE, '/mobile/auth/login', [
             'methods' => 'POST',


### PR DESCRIPTION
## Summary
- register mobile endpoints immediately when the REST API is already initialized
- guard against duplicate registrations with a static flag

## Testing
- php -l includes/REST/MobileAPIManager.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4ac3df8c832faf9da456a3b8916e