### PR TITLE
Use WP_Query for mobile experiences pagination

### DIFF
--- a/includes/REST/MobileAPIManager.php
+++ b/includes/REST/MobileAPIManager.php
@@ -391,6 +391,7 @@ class MobileAPIManager {
             'post_status' => 'publish',
             'posts_per_page' => $per_page,
             'paged' => $page,
+            'no_found_rows' => false,
             'meta_query' => [
                 [
                     'key' => '_product_type',
@@ -407,7 +408,8 @@ class MobileAPIManager {
             ];
         }
 
-        $experiences = get_posts($args);
+        $query = new \WP_Query($args);
+        $experiences = $query->posts;
         $mobile_experiences = [];
 
         foreach ($experiences as $experience) {
@@ -436,8 +438,8 @@ class MobileAPIManager {
             'pagination' => [
                 'page' => $page,
                 'per_page' => $per_page,
-                'total' => wp_count_posts('product')->publish,
-                'has_more' => count($experiences) === $per_page
+                'total' => $query->found_posts,
+                'has_more' => $page < $query->max_num_pages
             ]
         ]);
     }


### PR DESCRIPTION
## Summary
- replace get_posts with a WP_Query to gather product experiences and pagination data
- expose accurate total and has_more pagination metadata using WP_Query results

## Testing
- php -l includes/REST/MobileAPIManager.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4d1fcad4832f8100f813d46a31bc