### PR TITLE
Ensure staff attendance table exists and handle missing table errors

### DIFF
--- a/fp-esperienze.php
+++ b/fp-esperienze.php
@@ -271,6 +271,13 @@ function fp_esperienze_init() {
             error_log('FP Esperienze: Failed to load text domain for localization');
         }
         
+        if (class_exists('FP\Esperienze\Core\Installer')) {
+            $staff_attendance_result = FP\Esperienze\Core\Installer::maybeCreateStaffAttendanceTable();
+            if (is_wp_error($staff_attendance_result) && defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('FP Esperienze: ' . $staff_attendance_result->get_error_message());
+            }
+        }
+        
         // Initialize main plugin class with error handling
         if (class_exists('FP\Esperienze\Core\Plugin')) {
             FP\Esperienze\Core\Plugin::getInstance();


### PR DESCRIPTION
## Summary
- add the fp_staff_attendance table definition to the installer and expose an upgrade helper to rebuild it when absent
- invoke the new helper during runtime bootstrap so upgrades can restore the attendance table automatically
- enhance the mobile attendance endpoint to recreate the table when it is missing and return clearer error messages

## Testing
- php -l includes/Core/Installer.php
- php -l includes/REST/MobileAPIManager.php
- php -l fp-esperienze.php

------
https://chatgpt.com/codex/tasks/task_e_68cc71991558832fa292f5c693635e64