### PR TITLE
Schedule pre-experience reminder with site timezone

### DIFF
--- a/MANUAL_TESTS_INTEGRATIONS.md
+++ b/MANUAL_TESTS_INTEGRATIONS.md
@@ -252,6 +252,21 @@
 - No cross-contamination between tab data
 - Both settings types can coexist
 
+### 13. Pre-Experience Reminder Scheduling
+
+**Objective**: Ensure pre-experience reminders respect the booking date, time, and site timezone.
+
+**Steps**:
+1. Configure the site timezone to a non-UTC value (e.g., Europe/Rome).
+2. Create an experience booking scheduled for **2024-06-10** at **14:00**.
+3. Trigger the booking confirmation flow so the reminder is queued.
+4. Run `wp cron event list fp_send_pre_experience_email` or inspect `wp_next_scheduled( 'fp_send_pre_experience_email', [ $booking_id, $booking_data ] )`.
+
+**Expected Results**:
+- The scheduled timestamp corresponds to **2024-06-09 14:00** in the configured site timezone.
+- No reminder is scheduled if the computed time is already in the past.
+- Only one reminder is scheduled per booking/time combination.
+
 ## Test Results Template
 
 ```

--- a/tests/PluginPushTokenCronTest.php
+++ b/tests/PluginPushTokenCronTest.php
@@ -61,10 +61,20 @@ namespace {
         }
     }
 
-    function wp_next_scheduled($hook)
+    function wp_next_scheduled($hook, $args = [], $timestamp = 0)
     {
         global $scheduled_events;
-        return $scheduled_events[$hook]['timestamp'] ?? false;
+        $scheduled = $scheduled_events[$hook]['timestamp'] ?? false;
+
+        if (!$scheduled) {
+            return false;
+        }
+
+        if (!empty($timestamp) && (int) $timestamp !== (int) $scheduled) {
+            return false;
+        }
+
+        return $scheduled;
     }
 
     function wp_schedule_event($timestamp, $recurrence, $hook): void


### PR DESCRIPTION
## Summary
- schedule the pre-experience reminder using the site timezone, combining booking date and time and skipping past timestamps
- pass the computed timestamp into wp_next_scheduled/wp_schedule_single_event to avoid duplicate reminders
- expand the manual QA checklist with steps validating a 2024-06-10 14:00 booking schedules a 2024-06-09 14:00 reminder in the site timezone
- relax the wp_next_scheduled() test double so it accepts the optional timestamp argument

## Testing
- composer test *(fails: phpstan requires more memory and WordPress stubs in this environment)*
- ./vendor/bin/phpstan analyse --memory-limit=512M *(fails: phpstan expects WordPress/WooCommerce symbols and reports thousands of unrelated issues)*
- ./vendor/bin/phpcs --standard=WordPress includes/Integrations/EmailMarketingManager.php *(fails: pre-existing coding-standard violations across the legacy file)*

------
https://chatgpt.com/codex/tasks/task_e_68d14a281e38832f8c883023dd5a8ad3