### PR TITLE
Adjust archive card meta spacing

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -411,6 +411,20 @@ html {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 12px;
+    padding-bottom: 16px;
+    flex-wrap: wrap;
+}
+
+.fp-experience-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    margin-left: auto;
+    margin-inline-start: auto;
+    padding-left: 12px;
+    padding-inline-start: 12px;
+    gap: 8px;
 }
 
 .fp-experience-price {


### PR DESCRIPTION
## Summary
- add flex gap and bottom padding to `.fp-experience-meta` so the price and CTA have breathing room and can wrap cleanly on smaller cards
- update `.fp-experience-actions` to push the button away from the card edge with inline padding and RTL-aware auto margins

## Testing
- browser_container.run_playwright_script (viewport check for 2–4 column archive cards)


------
https://chatgpt.com/codex/tasks/task_e_68d153c2f498832f8408297f0de77f03