### PR TITLE
Ensure pre-experience reminders reschedule when bookings change

### DIFF
--- a/MANUAL_TESTS_INTEGRATIONS.md
+++ b/MANUAL_TESTS_INTEGRATIONS.md
@@ -260,12 +260,15 @@
 1. Configure the site timezone to a non-UTC value (e.g., Europe/Rome).
 2. Create an experience booking scheduled for **2024-06-10** at **14:00**.
 3. Trigger the booking confirmation flow so the reminder is queued.
-4. Run `wp cron event list fp_send_pre_experience_email` or inspect `wp_next_scheduled( 'fp_send_pre_experience_email', [ $booking_id, $booking_data ] )`.
+4. Run `wp cron event list fp_send_pre_experience_email` or inspect `wp_get_scheduled_event( 'fp_send_pre_experience_email', [ $booking_id, $booking_data ] )` to note the scheduled timestamp.
+5. Reschedule the same booking to **2024-06-11** at **09:30** and retrigger the confirmation flow (or otherwise call the scheduling hook).
+6. Re-run the cron inspection command from step 4.
 
 **Expected Results**:
 - The scheduled timestamp corresponds to **2024-06-09 14:00** in the configured site timezone.
 - No reminder is scheduled if the computed time is already in the past.
 - Only one reminder is scheduled per booking/time combination.
+- After updating the booking time, the scheduled event shifts to **2024-06-10 09:30** without leaving the previous timestamp behind.
 
 ## Test Results Template
 

--- a/includes/Integrations/EmailMarketingManager.php
+++ b/includes/Integrations/EmailMarketingManager.php
@@ -555,7 +555,21 @@ class EmailMarketingManager {
             return;
         }
 
-        if (!wp_next_scheduled('fp_send_pre_experience_email', [$booking_id, $booking_data], $send_timestamp)) {
+        $existing_event = wp_get_scheduled_event(
+            'fp_send_pre_experience_email',
+            [$booking_id, $booking_data]
+        );
+
+        if ($existing_event && isset($existing_event->timestamp) && (int) $existing_event->timestamp !== $send_timestamp) {
+            wp_unschedule_event(
+                $existing_event->timestamp,
+                'fp_send_pre_experience_email',
+                [$booking_id, $booking_data]
+            );
+            $existing_event = null;
+        }
+
+        if (!$existing_event) {
             wp_schedule_single_event($send_timestamp, 'fp_send_pre_experience_email', [$booking_id, $booking_data]);
         }
     }


### PR DESCRIPTION
## Summary
- update the pre-experience reminder scheduler to use `wp_get_scheduled_event` and unschedule outdated timestamps before queuing a new event
- keep the single-event scheduling call after the guard so updated bookings replace their prior reminders
- expand the manual QA steps to cover rescheduling a booking and confirming the cron timestamp moves accordingly

## Testing
- php -l includes/Integrations/EmailMarketingManager.php

------
https://chatgpt.com/codex/tasks/task_e_68d1765b2f14832f89bc3cccc06a11a6