### PR TITLE
Refactor offline booking status updates through manager helper

### DIFF
--- a/tests/MobileAPIManagerOfflineActionsTest.php
+++ b/tests/MobileAPIManagerOfflineActionsTest.php
@@ -86,6 +86,13 @@ if (!function_exists('__')) {
     }
 }
 
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value, ...$args)
+    {
+        return $value;
+    }
+}
+
 if (!function_exists('add_action')) {
     function add_action(string $hook, $callback, int $priority = 10, int $accepted_args = 1): void
     {


### PR DESCRIPTION
## Summary
- add a reusable BookingManager::updateBookingStatusById helper with status validation and existing hook payload generation
- ensure triggerBookingStatusHooks can reuse a provided order and expose supported booking statuses
- refactor the offline status update REST handler to resolve the booking/order before delegating to the helper and keep responses consistent
- extend the offline actions test bootstrap to cover the new helper flow and confirm booking hooks fire

## Testing
- php tests/MobileAPIManagerOfflineActionsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d3961d2e90832f8406f7dc6f081a5d