### PR TITLE
Avoid deleting transient options when using external object cache

### DIFF
--- a/includes/Core/CacheManager.php
+++ b/includes/Core/CacheManager.php
@@ -100,7 +100,7 @@ class CacheManager {
 
         self::removeAvailabilityKeysFromIndex($product_id, [$cache_key]);
 
-        if (function_exists('delete_option')) {
+        if (!self::isUsingExternalObjectCache() && function_exists('delete_option')) {
             delete_option('_transient_' . $cache_key);
             delete_option('_transient_timeout_' . $cache_key);
         }

--- a/tests/CacheManagerExternalObjectCacheTest.php
+++ b/tests/CacheManagerExternalObjectCacheTest.php
@@ -146,4 +146,44 @@ if (!empty($transient_option_deletes)) {
     exit(1);
 }
 
+$availability_index = [
+    123 => ['fp_availability_123_2024-01-01'],
+];
+$deleted_options = [];
+$deleted_transients = [];
+$object_cache_enabled = false;
+$wpdb->reset();
+
+CacheManager::invalidateAvailabilityCache(123, '2024-01-01');
+
+$transient_option_deletes = array_values(array_filter(
+    $deleted_options,
+    static fn(string $name): bool => str_starts_with($name, '_transient_')
+));
+
+if (empty($transient_option_deletes)) {
+    echo "Expected transient option deletions when object cache disabled for single invalidation\n";
+    exit(1);
+}
+
+$availability_index = [
+    123 => ['fp_availability_123_2024-01-01'],
+];
+$deleted_options = [];
+$deleted_transients = [];
+$object_cache_enabled = true;
+$wpdb->reset();
+
+CacheManager::invalidateAvailabilityCache(123, '2024-01-01');
+
+$transient_option_deletes = array_values(array_filter(
+    $deleted_options,
+    static fn(string $name): bool => str_starts_with($name, '_transient_')
+));
+
+if (!empty($transient_option_deletes)) {
+    echo "Transient options deleted despite external object cache during single invalidation\n";
+    exit(1);
+}
+
 echo "CacheManager external object cache regression test passed\n";


### PR DESCRIPTION
## Summary
- avoid deleting transient options directly when an external object cache is active
- extend the regression test to cover single availability cache invalidation with and without an external object cache

## Testing
- php tests/CacheManagerExternalObjectCacheTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ad96bbc8832f8cdd03e56a19b383