### PR TITLE
Restrict diagnostic scripts to admins and replace exec

### DIFF
--- a/MANUAL_TESTING_GUIDE.md
+++ b/MANUAL_TESTING_GUIDE.md
@@ -85,19 +85,31 @@ echo get_class($product); // Should output: FP\Esperienze\ProductType\WC_Product
 
 ## Automated Testing Scripts
 
+> **Security Requirement:** All utility scripts must run inside a WordPress context with an authenticated administrator. Use WP-CLI with the `--user=<admin>` flag or access the file from the browser while logged in as an administrator.
+
+### Status Report
+- **Location:** `wp-content/plugins/fp-esperienze/status-report.php`
+- **WP-CLI:**
+  ```bash
+  wp eval-file wp-content/plugins/fp-esperienze/status-report.php --user=<admin>
+  ```
+- **Notes:** Requires the OPcache extension to perform inline syntax linting. If OPcache is unavailable, lint critical files manually with `php -l`.
+
 ### PHP Syntax Test
-Run this to check PHP syntax without WordPress:
+- **Location:** `wp-content/plugins/fp-esperienze/test-php-syntax.php`
+- **WP-CLI:**
+  ```bash
+  wp eval-file wp-content/plugins/fp-esperienze/test-php-syntax.php --user=<admin>
+  ```
+- **Notes:** Uses OPcache to validate syntax without executing the files. When OPcache is disabled, manually lint files (e.g. `php -l wp-content/plugins/fp-esperienze/fp-esperienze.php`).
+
+### Full Functionality Test
+Run this in WordPress via WP-CLI or the browser:
 ```bash
-php test-php-syntax.php
+wp eval-file wp-content/plugins/fp-esperienze/test-experience-functionality.php --user=<admin>
 ```
 
-### Full Functionality Test  
-Run this in WordPress environment (WP-CLI or browser):
-```bash
-wp eval-file test-experience-functionality.php
-```
-
-Or access via browser: `/test-experience-functionality.php` (admin login required)
+Or access via browser: `/wp-content/plugins/fp-esperienze/test-experience-functionality.php` (admin login required).
 
 ### WordPress Diagnostic Script
 Run this for detailed diagnostics:

--- a/tools/README.md
+++ b/tools/README.md
@@ -23,9 +23,12 @@ This directory contains diagnostic tools to help identify and resolve plugin act
 **Purpose**: Comprehensive command-line diagnostic tool.
 
 **Usage**:
-- Run from WordPress admin or include in scripts
-- Provides detailed analysis of all potential failure points
-- Generates detailed reports
+- Run via WP-CLI with an administrator context:
+  ```bash
+  wp eval-file wp-content/plugins/fp-esperienze/tools/activation-diagnostic.php --user=<admin>
+  ```
+- Or access the file from the browser while logged in as an administrator
+- Anonymous access is blocked for security reasons
 
 **What it tests**:
 - All environment requirements
@@ -34,6 +37,10 @@ This directory contains diagnostic tools to help identify and resolve plugin act
 - PHP extension availability
 - Plugin conflicts
 - Debug settings
+
+**Notes**:
+- OPcache is used for passive syntax checks. When OPcache is disabled, lint the reported file manually with `php -l`.
+- Additional standalone tools (`status-report.php`, `test-php-syntax.php`) live in the plugin root and follow the same administrator-only access rules.
 
 ## Common Issues and Solutions
 


### PR DESCRIPTION
## Summary
- enforce administrator-only access for status-report.php, test-php-syntax.php, and tools/activation-diagnostic.php by bootstrapping WordPress and validating capabilities
- replace exec()-based syntax checks with an OPcache-powered lint helper and warning flow when linting isn’t available
- document secure WP-CLI usage for the diagnostic utilities and the need for manual php -l linting when OPcache is disabled

## Testing
- php -l status-report.php
- php -l test-php-syntax.php
- php -l tools/activation-diagnostic.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c581fef0832f9318ce4a06b1e123