### PR TITLE
Improve proxy IP resolution in rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A WordPress + WooCommerce plugin for experience booking management by Francesco 
 
 ### Trusted Proxy Configuration
 
-If your WordPress installation sits behind a reverse proxy or load balancer, add its IP address to the list of trusted proxies so the rate limiter can read the original client address from `Client-IP`, `X-Real-IP`, `Forwarded`, `Forwarded-For`, and `X-Forwarded-*` headers.
+If your WordPress installation sits behind a reverse proxy or load balancer, add its IP address to the list of trusted proxies so the rate limiter can read the original client address from trusted headers. When a request originates from a proxy contained in this list FP Esperienze, by default, inspects the following headers in order: `CF-Connecting-IP`, `Client-IP`, `X-Cluster-Client-IP`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded`, `Forwarded-For`, and `Forwarded`.
 
 ```php
 // In wp-config.php or a custom plugin.
@@ -52,6 +52,8 @@ add_filter( 'fp_trusted_proxies', function() {
     return [ '203.0.113.1', '198.51.100.0' ];
 } );
 ```
+
+You can customize the header preference order with the `fp_trusted_proxy_headers` filter or adjust the final resolved address with `fp_resolved_client_ip` should your infrastructure use bespoke headers.
 
 Only requests that originate from a trusted proxy will have their forwarding headers processed. Otherwise the plugin falls back to `$_SERVER['REMOTE_ADDR']` (or `wp_get_ip_address()` when available).
 

--- a/includes/Core/RateLimiter.php
+++ b/includes/Core/RateLimiter.php
@@ -54,80 +54,230 @@ class RateLimiter {
      * @return string Client IP address
      */
     public static function getClientIP(): string {
-        $remote_addr = $_SERVER['REMOTE_ADDR'] ?? '';
+        $remote_addr_raw = $_SERVER['REMOTE_ADDR'] ?? '';
+        $remote_addr     = filter_var($remote_addr_raw, FILTER_VALIDATE_IP);
+        if (!is_string($remote_addr)) {
+            $remote_addr = '127.0.0.1';
+        }
 
-        // Validate the remote address and use a safe fallback if invalid.
-        $remote_addr     = filter_var( $remote_addr, FILTER_VALIDATE_IP ) ?: '127.0.0.1';
-        $trusted_proxies = apply_filters( 'fp_trusted_proxies', [] );
+        $trusted_proxies = self::normalizeTrustedProxies(apply_filters('fp_trusted_proxies', []));
 
-        if ( ! empty( $trusted_proxies ) && in_array( $remote_addr, $trusted_proxies, true ) ) {
-            if ( function_exists( 'wp_get_ip_address' ) ) {
-                $ip = wp_get_ip_address();
-                if ( $ip ) {
-                    return $ip;
+        if ($trusted_proxies !== [] && in_array($remote_addr, $trusted_proxies, true)) {
+            if (function_exists('wp_get_ip_address')) {
+                $wp_ip_raw = wp_get_ip_address();
+                if (is_string($wp_ip_raw)) {
+                    $wp_ip = filter_var($wp_ip_raw, FILTER_VALIDATE_IP);
+                    if (is_string($wp_ip)) {
+                        return apply_filters('fp_resolved_client_ip', $wp_ip, $remote_addr);
+                    }
                 }
             }
 
-            $forwarded_headers = [
-                'HTTP_CLIENT_IP',
-                'HTTP_X_REAL_IP',
-                'HTTP_X_FORWARDED_FOR',
-                'HTTP_X_FORWARDED',
-                'HTTP_FORWARDED_FOR',
-                'HTTP_FORWARDED',
-            ];
+            $header_order = apply_filters(
+                'fp_trusted_proxy_headers',
+                [
+                    'HTTP_CF_CONNECTING_IP',
+                    'HTTP_CLIENT_IP',
+                    'HTTP_X_CLUSTER_CLIENT_IP',
+                    'HTTP_X_REAL_IP',
+                    'HTTP_X_FORWARDED_FOR',
+                    'HTTP_X_FORWARDED',
+                    'HTTP_FORWARDED_FOR',
+                    'HTTP_FORWARDED',
+                ]
+            );
 
-            foreach ( $forwarded_headers as $header ) {
-                if ( empty( $_SERVER[ $header ] ) ) {
+            foreach (is_array($header_order) ? $header_order : (array) $header_order as $header) {
+                if (!is_string($header) || $header === '') {
                     continue;
                 }
 
-                $ips = [];
-                if ( 'HTTP_FORWARDED' === $header || 'HTTP_FORWARDED_FOR' === $header ) {
-                    $parts = explode( ',', $_SERVER[ $header ] );
-                    foreach ( $parts as $part ) {
-                        if ( preg_match( '/for=([^;]+)/', $part, $matches ) ) {
-                            $ips[] = trim( $matches[1], " \"[]" );
-                        } else {
-                            $ips[] = trim( $part );
-                        }
-                    }
-                } else {
-                    $ips = explode( ',', $_SERVER[ $header ] );
+                if (!array_key_exists($header, $_SERVER)) {
+                    continue;
                 }
 
-                foreach ( $ips as $ip ) {
-                    $ip = trim( $ip );
+                $raw_header_value = (string) $_SERVER[$header];
+                if ($raw_header_value === '') {
+                    continue;
+                }
 
-                    if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
-                        return $ip;
-                    }
+                $candidate = self::extractIpFromHeader($header, $raw_header_value);
+                if ($candidate !== null && $candidate !== '') {
+                    return apply_filters('fp_resolved_client_ip', $candidate, $remote_addr);
                 }
             }
         }
 
-        return $remote_addr;
+        return apply_filters('fp_resolved_client_ip', $remote_addr, $remote_addr);
+    }
+
+    /**
+     * Normalize the list of trusted proxies returned by the filter.
+     *
+     * @param mixed $proxies Raw list provided by filter consumers.
+     * @return array<int, string>
+     */
+    private static function normalizeTrustedProxies($proxies): array {
+        if (!is_array($proxies)) {
+            $proxies = [$proxies];
+        }
+
+        $normalized = [];
+
+        foreach ($proxies as $proxy) {
+            $candidate = is_string($proxy) ? trim($proxy) : '';
+            $validated = filter_var($candidate, FILTER_VALIDATE_IP);
+            if (is_string($validated)) {
+                $normalized[] = $validated;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * Extract a valid client IP from a forwarded header.
+     *
+     * @param string $header Header name.
+     * @param string $value  Header value.
+     * @return string|null
+     */
+    private static function extractIpFromHeader(string $header, string $value): ?string {
+        $value = trim($value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        $candidates = self::normalizeHeaderCandidates($header, $value);
+        $private_candidate = null;
+
+        foreach ($candidates as $candidate) {
+            $candidate = self::sanitizeIpCandidate($candidate);
+
+            if ($candidate === null || $candidate === '') {
+                continue;
+            }
+
+            $public_candidate = filter_var($candidate, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+            if (is_string($public_candidate)) {
+                return $public_candidate;
+            }
+
+            if ($private_candidate === null) {
+                $validated = filter_var($candidate, FILTER_VALIDATE_IP);
+                if (is_string($validated)) {
+                    $private_candidate = $validated;
+                }
+            }
+        }
+
+        return $private_candidate;
+    }
+
+    /**
+     * Convert the forwarded header value into a list of raw candidates.
+     *
+     * @param string $header Header name.
+     * @param string $value  Header value.
+     * @return array<int, string>
+     */
+    private static function normalizeHeaderCandidates(string $header, string $value): array {
+        $header = strtoupper($header);
+
+        switch ($header) {
+            case 'HTTP_FORWARDED':
+                $parts = preg_split('/\s*,\s*/', $value);
+                if ($parts === false) {
+                    return [];
+                }
+
+                $candidates = [];
+                foreach ($parts as $part) {
+                    if (preg_match('/for=([^;]+)/i', $part, $matches) > 0) {
+                        $candidates[] = $matches[1];
+                    }
+                }
+
+                return $candidates;
+
+            case 'HTTP_X_FORWARDED_FOR':
+            case 'HTTP_X_FORWARDED':
+            case 'HTTP_FORWARDED_FOR':
+                $parts = preg_split('/\s*,\s*/', $value);
+                if ($parts === false) {
+                    return [];
+                }
+
+                return $parts;
+
+            default:
+                return [$value];
+        }
+    }
+
+    /**
+     * Sanitize a potential IP value extracted from a header.
+     *
+     * @param string $candidate Raw candidate string.
+     * @return string|null
+     */
+    private static function sanitizeIpCandidate(string $candidate): ?string {
+        $candidate = trim($candidate);
+
+        if ($candidate === '' || strtolower($candidate) === 'unknown') {
+            return null;
+        }
+
+        if (stripos($candidate, 'for=') === 0) {
+            $candidate = substr($candidate, 4);
+        }
+
+        $candidate = trim($candidate, " \"'");
+
+        if (preg_match('/^\[([^\]]+)\](?::\d+)?$/', $candidate, $matches) > 0) {
+            $candidate = $matches[1];
+        }
+
+        if (preg_match('/^\d{1,3}(?:\.\d{1,3}){3}:\d+$/', $candidate) > 0) {
+            $candidate = explode(':', $candidate, 2)[0];
+        }
+
+        if ($candidate === '') {
+            return null;
+        }
+
+        return $candidate;
     }
 
     /**
      * Get rate limit headers for response
      *
      * @param string $endpoint Endpoint identifier
-     * @param int $limit Request limit per window
-     * @param int $window Time window in seconds
-     * @return array Headers array
+     * @param int    $limit    Request limit per window
+     * @param int    $window   Time window in seconds
+     * @return array<string, int> Headers array
      */
     public static function getRateLimitHeaders(string $endpoint, int $limit = 30, int $window = 60): array {
         $client_ip = self::getClientIP();
-        $key = 'fp_rate_limit_' . md5($endpoint . '_' . $client_ip);
-        
-        $current_count = get_transient($key) ?: 0;
-        $remaining = max(0, $limit - $current_count);
-        
+        $key       = 'fp_rate_limit_' . md5($endpoint . '_' . $client_ip);
+
+        $current_count = get_transient($key);
+        if ($current_count === false) {
+            $current_count = 0;
+        } else {
+            $current_count = (int) $current_count;
+        }
+
+        $remaining = $limit - $current_count;
+        if ($remaining < 0) {
+            $remaining = 0;
+        }
+
         return [
-            'X-RateLimit-Limit' => $limit,
+            'X-RateLimit-Limit'     => $limit,
             'X-RateLimit-Remaining' => $remaining,
-            'X-RateLimit-Window' => $window
+            'X-RateLimit-Window'    => $window,
         ];
     }
 


### PR DESCRIPTION
## Summary
- harden `RateLimiter::getClientIP()` by validating trusted proxy lists, examining a wider set of forwarding headers (including Cloudflare/X-Cluster) and sanitising forwarded values before use
- add helper utilities for parsing/sanitising forwarded headers and tighten rate-limit header generation with explicit value typing
- document the expanded trusted header handling and new filters in the README trusted proxy guidance

## Testing
- `vendor/bin/phpstan analyse includes/Core/RateLimiter.php --memory-limit=-1`
- `composer phpcs` *(fails: repository-wide pre-existing WPCS spacing/style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d43bbc6e18832fba584f0c810c6897