### PR TITLE
Add resilient translation logger

### DIFF
--- a/includes/Core/TranslationLogger.php
+++ b/includes/Core/TranslationLogger.php
@@ -1,151 +1,308 @@
 <?php
 /**
- * Translation Logger.
+ * Translation Logger utility.
  *
  * @package FP\Esperienze\Core
  */
 
 namespace FP\Esperienze\Core;
 
+use WP_Error;
+
+use function current_time;
+use function error_log;
+use function function_exists;
+use function gmdate;
+use function is_bool;
+use function is_int;
+use function is_string;
+use function is_writable;
+use function json_encode;
+use function trailingslashit;
+use function wp_json_encode;
+use function wp_mkdir_p;
+use function wp_upload_dir;
+use function wp_is_writable;
+use function is_wp_error;
+use function sprintf;
+
 defined('ABSPATH') || exit;
 
 /**
- * Lightweight logger for translation-related events.
+ * Handles structured logging for the translation subsystem.
  */
 class TranslationLogger {
-    /**
-     * Prefix added to each log entry for quick identification.
-     */
-    private const PREFIX = '[FP Esperienze Translation]';
 
     /**
-     * Filter name used to customize translation logging behaviour.
+     * Option flag used to toggle the logger.
      */
-    private const HANDLER_FILTER = 'fp_es_translation_logger_handler';
+    private const OPTION_ENABLE = 'fp_lt_enable_log';
 
     /**
-     * Log a message when debug logging is enabled.
+     * Maximum size in bytes for the log file before rotation.
      *
-     * A custom handler can be supplied using the `fp_es_translation_logger_handler` filter. When
-     * the filter returns a callable it receives the message and context array and bypasses the
-     * default `error_log()` output.
-     *
-     * @param string $message Message to log.
-     * @param array  $context Additional context values that help debugging.
+     * @var int
      */
-    public static function log(string $message, array $context = []): void {
-        $message = trim($message);
+    private const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB.
 
-        if ('' === $message) {
-            return;
+    /**
+     * Relative directory inside the uploads folder used to store logs.
+     */
+    private const LOG_DIRECTORY = 'fp-esperienze/logs';
+
+    /**
+     * Log file name.
+     */
+    private const LOG_FILE = 'translation.log';
+
+    /**
+     * Record a log entry.
+     *
+     * @param string               $message Log message.
+     * @param array<string, mixed> $context Additional contextual information.
+     *
+     * @return bool|WP_Error True on success or WP_Error on failure.
+     */
+    public static function log(string $message, array $context = []) {
+        if (!self::isLoggingEnabled()) {
+            return true;
         }
 
-        $handler = self::getCustomHandler($message, $context);
-
-        if (is_callable($handler)) {
-            try {
-                $handler($message, $context);
-                return;
-            } catch (\Throwable $exception) {
-                self::writeToErrorLog(self::formatMessage('Logger handler error: ' . $exception->getMessage()));
-            }
+        $log_file = self::prepareLogFile();
+        if (is_wp_error($log_file)) {
+            self::fallbackErrorLog($message, $context, $log_file->get_error_message());
+            return $log_file;
         }
 
-        self::writeToErrorLog(self::formatMessage($message, $context));
-    }
+        $formatted = self::formatMessage($message, $context);
 
-    /**
-     * Resolve a custom handler from WordPress filters when available.
-     *
-     * @param string $message Log message.
-     * @param array  $context Context data for the log.
-     *
-     * @return callable|null
-     */
-    private static function getCustomHandler(string $message, array $context): ?callable {
-        if (!function_exists('apply_filters')) {
-            return null;
-        }
-
-        $handler = apply_filters(self::HANDLER_FILTER, null, $message, $context);
-
-        return is_callable($handler) ? $handler : null;
-    }
-
-    /**
-     * Determine whether we can write to the WordPress debug log.
-     *
-     * @return bool
-     */
-    private static function canWriteToDebugLog(): bool {
-        if (!defined('WP_DEBUG_LOG') || !WP_DEBUG_LOG) {
-            return false;
-        }
-
-        if (!defined('WP_DEBUG') || !WP_DEBUG) {
-            return false;
+        $write_result = self::writeToFile($log_file, $formatted);
+        if (is_wp_error($write_result)) {
+            self::fallbackErrorLog($message, $context, $write_result->get_error_message());
+            return $write_result;
         }
 
         return true;
     }
 
     /**
-     * Format a message with the translation prefix and optional context payload.
-     *
-     * @param string $message Log message.
-     * @param array  $context Context data for the log entry.
-     *
-     * @return string
+     * Determine whether logging is enabled.
      */
-    private static function formatMessage(string $message, array $context = []): string {
-        $log_message = sprintf('%s %s', self::PREFIX, $message);
+    private static function isLoggingEnabled(): bool {
+        $enabled = get_option(self::OPTION_ENABLE, '0');
 
-        if (!empty($context)) {
-            $context_string = self::encodeContext($context);
+        if (is_bool($enabled)) {
+            return $enabled;
+        }
 
-            if ('' !== $context_string) {
-                $log_message .= ' | Context: ' . $context_string;
+        if (is_int($enabled)) {
+            return 1 === $enabled;
+        }
+
+        if (is_string($enabled)) {
+            $normalized = strtolower(trim($enabled));
+            return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return false;
+    }
+
+    /**
+     * Ensure the log file exists and is writable.
+     *
+     * @return string|WP_Error Absolute path to the log file or error on failure.
+     */
+    private static function prepareLogFile() {
+        $uploads = wp_upload_dir();
+        $upload_error = $uploads['error'];
+        if (is_string($upload_error) && $upload_error !== '') {
+            return new WP_Error('fp_logger_upload_dir_unavailable', $upload_error);
+        }
+
+        $directory = trailingslashit($uploads['basedir']) . self::LOG_DIRECTORY;
+
+        if (!wp_mkdir_p($directory)) {
+            return new WP_Error('fp_logger_create_directory_failed', sprintf('Unable to create log directory %s', $directory));
+        }
+
+        if (function_exists('wp_is_writable')) {
+            $writable = wp_is_writable($directory);
+        } else {
+            $writable = is_writable($directory);
+        }
+
+        if (!$writable) {
+            return new WP_Error('fp_logger_directory_not_writable', sprintf('Log directory not writable: %s', $directory));
+        }
+
+        $file = trailingslashit($directory) . self::LOG_FILE;
+
+        $rotation_result = self::rotateLogIfNeeded($file);
+        if (is_wp_error($rotation_result)) {
+            return $rotation_result;
+        }
+
+        $filesystem = self::getFilesystem();
+        if (is_wp_error($filesystem)) {
+            return $filesystem;
+        }
+
+        if (!$filesystem->exists($file)) {
+            $chmod = defined('FS_CHMOD_FILE') ? FS_CHMOD_FILE : false;
+
+            if (!$filesystem->put_contents($file, '', $chmod)) {
+                return new WP_Error('fp_logger_file_create_failed', sprintf('Unable to create log file %s', $file));
             }
         }
 
-        return $log_message;
-    }
-
-    /**
-     * Encode the provided context using the best available JSON encoder.
-     *
-     * @param array $context Context data for the log entry.
-     *
-     * @return string
-     */
-    private static function encodeContext(array $context): string {
-        if (function_exists('wp_json_encode')) {
-            $encoded = wp_json_encode($context);
+        if (function_exists('wp_is_writable')) {
+            $file_writable = wp_is_writable($file);
         } else {
-            $encoded = json_encode($context);
+            $file_writable = is_writable($file);
         }
 
-        if (!is_string($encoded) || '' === $encoded || 'null' === $encoded) {
-            return '';
+        if (!$file_writable) {
+            return new WP_Error('fp_logger_file_not_writable', sprintf('Log file not writable: %s', $file));
         }
 
-        return $encoded;
+        return $file;
     }
 
     /**
-     * Write the prepared message to the debug log when enabled.
+     * Rotate the log file when it exceeds the maximum allowed size.
      *
-     * @param string $log_message Final message to send to the debug log.
+     * @param string $file Log file path.
+     *
+     * @return bool|WP_Error
      */
-    private static function writeToErrorLog(string $log_message): void {
-        if ('' === $log_message) {
-            return;
+    private static function rotateLogIfNeeded(string $file) {
+        $filesystem = self::getFilesystem();
+        if (is_wp_error($filesystem)) {
+            return $filesystem;
         }
 
-        if (!self::canWriteToDebugLog()) {
-            return;
+        if (!$filesystem->exists($file)) {
+            return true;
         }
 
-        error_log($log_message); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        $size = $filesystem->size($file);
+        if ($size === false || $size < self::MAX_FILE_SIZE) {
+            return true;
+        }
+
+        $archive = $file . '.' . gmdate('YmdHis');
+        if (!$filesystem->move($file, $archive, true)) {
+            return new WP_Error('fp_logger_rotate_failed', sprintf('Unable to rotate log file %s', $file));
+        }
+
+        return true;
+    }
+
+    /**
+     * Format the message and context into a single log line.
+     *
+     * @param string               $message Log message.
+     * @param array<string, mixed> $context Context array.
+     */
+    private static function formatMessage(string $message, array $context = []): string {
+        $timestamp = function_exists('current_time') ? current_time('mysql') : gmdate('Y-m-d H:i:s');
+        $payload   = [
+            'timestamp' => $timestamp,
+            'message'   => $message,
+        ];
+
+        if ($context !== []) {
+            $payload['context'] = $context;
+        }
+
+        $encoded = wp_json_encode($payload);
+        if (!is_string($encoded)) {
+            $encoded = json_encode($payload);
+        }
+
+        if (!is_string($encoded)) {
+            $encoded = '';
+        }
+
+        return $encoded . PHP_EOL;
+    }
+
+    /**
+     * Append the message to the log file.
+     *
+     * @param string $file     Log file path.
+     * @param string $contents Formatted log line.
+     *
+     * @return bool|WP_Error True on success, WP_Error otherwise.
+     */
+    private static function writeToFile(string $file, string $contents) {
+        $filesystem = self::getFilesystem();
+        if (is_wp_error($filesystem)) {
+            return $filesystem;
+        }
+
+        $existing = '';
+        if ($filesystem->exists($file)) {
+            $existing = $filesystem->get_contents($file);
+            if (!is_string($existing)) {
+                return new WP_Error('fp_logger_read_failed', sprintf('Unable to read log file %s', $file));
+            }
+        }
+
+        $chmod = defined('FS_CHMOD_FILE') ? FS_CHMOD_FILE : false;
+
+        if (!$filesystem->put_contents($file, $existing . $contents, $chmod)) {
+            return new WP_Error('fp_logger_write_failed', sprintf('Unable to write to log file %s', $file));
+        }
+
+        return true;
+    }
+
+    /**
+     * Fallback logging using PHP's error_log when the dedicated log fails.
+     *
+     * @param string               $message Original message.
+     * @param array<string, mixed> $context Context array.
+     * @param string               $error   Error description.
+     */
+    private static function fallbackErrorLog(string $message, array $context, string $error): void {
+        $payload = [
+            'message' => $message,
+            'error'   => $error,
+        ];
+
+        if ($context !== []) {
+            $payload['context'] = $context;
+        }
+
+        $encoded = wp_json_encode($payload);
+        if (!is_string($encoded)) {
+            $encoded = json_encode($payload);
+        }
+
+        if (!is_string($encoded)) {
+            $encoded = '';
+        }
+
+        error_log('FP Esperienze Translation Logger: ' . $encoded);
+    }
+
+    /**
+     * Retrieve an initialized WP_Filesystem instance.
+     *
+     * @return \WP_Filesystem_Base|WP_Error
+     */
+    private static function getFilesystem() {
+        global $wp_filesystem;
+
+        if (!function_exists('WP_Filesystem')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        if (!WP_Filesystem()) {
+            return new WP_Error('fp_logger_filesystem_unavailable', 'Unable to initialize WP_Filesystem for logging.');
+        }
+
+        return $wp_filesystem;
     }
 }


### PR DESCRIPTION
## Summary
- replace the lightweight translation logger with a production-ready implementation that persists logs to wp-content/uploads/fp-esperienze/logs
- ensure logging only runs when explicitly enabled, hardens directory creation, and rotates files over 5MB while falling back to error_log on failure
- rely on WP_Filesystem for writes and surface WP_Error responses when log storage is not writable so callers can react safely

## Testing
- vendor/bin/phpstan analyse includes/Core/TranslationLogger.php --level=5 --memory-limit=-1

------
https://chatgpt.com/codex/tasks/task_e_68d44a178b3c832f8a2fa2302b4c20cb