### PR TITLE
Enable QueryMonitor in core bootstrap

### DIFF
--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -168,6 +168,11 @@ class Plugin {
             if (class_exists('FP\Esperienze\Core\PerformanceOptimizer')) {
                 PerformanceOptimizer::init();
             }
+
+            // Initialize query monitoring tools when running in debug environments
+            if (class_exists('FP\Esperienze\Core\QueryMonitor')) {
+                QueryMonitor::init();
+            }
             
             // Initialize UX enhancements
             if (class_exists('FP\Esperienze\Core\UXEnhancer')) {


### PR DESCRIPTION
## Summary
- ensure the QueryMonitor subsystem is bootstrapped with the other core utilities when available
- keep the initialization guarded so it only runs when the class exists, matching the existing defensive boot sequence

## Testing
- composer test *(fails: phpstan analyse timed out in this environment; command aborted after prolonged execution)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e726968c832f8a60ad0349d247e9