### PR TITLE
Refactor plugin zip build workflow

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,1 +1,34 @@
-tools/
+# Files and directories excluded from the distributable plugin package.
+# The packaging script reads this file and passes it to rsync's --exclude-from flag.
+
+# Version control metadata
+/.git
+/.github
+/.gitignore
+/.gitattributes
+
+# Build and tooling directories
+/build
+/dist
+/node_modules
+/tests
+/tools
+/vendor/bin
+
+# Documentation and local artifacts
+*.md
+*.MD
+*.markdown
+*.html
+MANUAL_TESTS*
+*.zip
+*.tgz
+*.log
+
+# Static analysis and development configs
+phpcs.xml
+phpstan.neon
+phpstan-bootstrap.php
+setup.sh
+composer-backup.json
+composer-dev.json

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     name: Build plugin package
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout repository
@@ -27,6 +30,14 @@ jobs:
             coverage: none
             tools: composer
             extensions: mbstring, intl, json, xml, curl, zip
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache/files
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Validate composer.json / composer.lock
         run: composer validate --no-check-publish
@@ -53,50 +64,22 @@ jobs:
             echo "zip_name=$ZIP_NAME" >> $GITHUB_OUTPUT
             echo "Rilevata versione: $VERSION"
 
-      - name: Prepare build directory
+      - name: Build distributable package
+        id: package
         run: |
-          set -e
-          SLUG="${{ steps.get_version.outputs.slug }}"
-          mkdir build
-          mkdir "build/${SLUG}"
-
-          # Copia file necessari (adatta se hai altre cartelle tipo assets/, languages/, src/, inc/, templates/, ecc.)
-          rsync -av \
-            --exclude=".git" \
-            --exclude=".github" \
-            --exclude="tests" \
-            --exclude="node_modules" \
-            --exclude="*.md" \
-            --exclude="composer.json" \
-            --exclude="composer.lock" \
-            ./ "build/${SLUG}/"
-
-          # MA dobbiamo includere composer.json e lock se ti servono per trasparenza (facoltativo)
-          cp composer.json composer.lock "build/${SLUG}/" || true
-
-          # Assicura che vendor sia presente
-          if [ ! -d vendor ]; then
-            echo "Cartella vendor mancante!"; exit 1;
-          fi
-          # Copia vendor
-          rsync -av vendor "build/${SLUG}/"
-
-          echo "Contenuto finale:"
-          find "build/${SLUG}" -maxdepth 4 -type f | head -50
-
-      - name: Create zip
-        working-directory: build
-        run: |
-          ZIP_NAME="${{ steps.get_version.outputs.zip_name }}"
-          SLUG="${{ steps.get_version.outputs.slug }}"
-          zip -rq "$ZIP_NAME" "$SLUG"
-          ls -lh "$ZIP_NAME"
+          PACKAGE_PATH=$(tools/build-plugin-zip.sh \
+            --slug "${{ steps.get_version.outputs.slug }}" \
+            --version "${{ steps.get_version.outputs.version }}" \
+            --zip-name "${{ steps.get_version.outputs.zip_name }}" \
+            --out-dir "dist")
+          echo "package_path=$PACKAGE_PATH" >> "$GITHUB_OUTPUT"
+          ls -lh "$PACKAGE_PATH"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get_version.outputs.zip_name }}
-          path: build/${{ steps.get_version.outputs.zip_name }}
+          path: ${{ steps.package.outputs.package_path }}
           if-no-files-found: error
           retention-days: 14
 
@@ -104,7 +87,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: build/${{ steps.get_version.outputs.zip_name }}
+          files: ${{ steps.package.outputs.package_path }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/build-plugin-zip.sh
+++ b/tools/build-plugin-zip.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[build-plugin-zip] %s\n' "$1" >&2
+}
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: tools/build-plugin-zip.sh [--slug <slug>] [--version <version>] [--zip-name <name>] [--out-dir <path>]
+
+Creates a distributable WordPress plugin zip by staging the project into an intermediate
+folder and compressing it. Exclusions are driven by the optional .distignore file in the
+repository root in addition to a set of sensible defaults.
+
+Options:
+  --slug <slug>         Plugin directory name inside the archive (default: fp-esperienze)
+  --version <version>   Version string used when generating the zip name if --zip-name is not supplied
+  --zip-name <name>     Explicit zip filename (with or without .zip extension)
+  --out-dir <path>      Directory (relative or absolute) where the build artefacts are written (default: dist)
+  -h, --help            Show this help message and exit
+USAGE
+}
+
+SLUG="fp-esperienze"
+VERSION=""
+ZIP_NAME=""
+OUT_DIR="dist"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --slug)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      SLUG="$2"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --zip-name)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      ZIP_NAME="$2"
+      shift 2
+      ;;
+    --out-dir)
+      [[ $# -ge 2 ]] || { usage; exit 1; }
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v zip >/dev/null 2>&1; then
+  log "zip command not found. Install zip before packaging."
+  exit 1
+fi
+
+if [[ ! -d "${ROOT_DIR}/vendor" ]]; then
+  log "vendor directory missing. Run composer install before packaging."
+  exit 1
+fi
+
+if [[ -z "$ZIP_NAME" ]]; then
+  if [[ -n "$VERSION" ]]; then
+    ZIP_NAME="${SLUG}-v${VERSION}.zip"
+  else
+    ZIP_NAME="${SLUG}.zip"
+  fi
+else
+  [[ "$ZIP_NAME" == *.zip ]] || ZIP_NAME="${ZIP_NAME}.zip"
+fi
+
+if [[ "$OUT_DIR" != /* ]]; then
+  OUT_DIR="${ROOT_DIR}/${OUT_DIR}"
+fi
+
+STAGE_DIR="${OUT_DIR}/${SLUG}"
+ZIP_PATH="${OUT_DIR}/${ZIP_NAME}"
+
+log "Staging plugin into ${STAGE_DIR}"
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+mkdir -p "$OUT_DIR"
+
+RSYNC_ARGS=(
+  -a
+  --delete
+  --prune-empty-dirs
+  --exclude=.git
+  --exclude=.github
+  --exclude=.gitignore
+  --exclude=.gitattributes
+  --exclude=.DS_Store
+  --exclude=.idea
+  --exclude=.vscode
+  --exclude=build
+  --exclude=dist
+  --exclude=.distignore
+)
+
+if [[ -f "${ROOT_DIR}/.distignore" ]]; then
+  RSYNC_ARGS+=("--exclude-from=${ROOT_DIR}/.distignore")
+fi
+
+rsync "${RSYNC_ARGS[@]}" "${ROOT_DIR}/" "$STAGE_DIR/"
+
+log "Creating archive ${ZIP_PATH}"
+rm -f "$ZIP_PATH"
+(
+  cd "$OUT_DIR"
+  zip -rq "$ZIP_NAME" "$SLUG"
+)
+
+log "Created package at ${ZIP_PATH}"
+printf '%s\n' "$ZIP_PATH"


### PR DESCRIPTION
## Summary
- add a repository-level `.distignore` to centralize exclusions for release archives
- create a reusable packaging script that stages the plugin and builds the zip based on the shared ignore list
- update the build workflow to cache composer dependencies and rely on the new script when uploading artifacts or publishing releases

## Testing
- composer install --no-dev --prefer-dist --optimize-autoloader
- tools/build-plugin-zip.sh --version "1.0.0" --zip-name test-package.zip --out-dir dist-test

------
https://chatgpt.com/codex/tasks/task_e_68d53422e744832fa17a9f0ef2eda3a4