### PR TITLE
Adjust experience editing UI and gallery display

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -281,37 +281,36 @@ html {
 /* Enhanced section styling with semantic structure */
 .fp-schedules-section,
 .fp-overrides-section-wrapper {
-    border: 1px solid #c3c4c7;
-    border-radius: 6px;
-    background: #fff;
+    border: none;
+    border-radius: 0;
+    background: transparent;
     margin-bottom: 20px;
+    box-shadow: none;
 }
 
 .fp-schedules-section > h4,
 .fp-overrides-section-wrapper > h4 {
-    background: #f6f7f7;
-    border-bottom: 1px solid #c3c4c7;
-    margin: 0;
-    padding: 15px 20px;
-    font-size: 0.875rem;
+    background: transparent;
+    border-bottom: none;
+    margin: 0 0 12px 0;
+    padding: 0;
+    font-size: 0.95rem;
     font-weight: 600;
     color: #1d2327;
-    border-radius: 6px 6px 0 0;
 }
 
 .fp-section-content {
-    padding: 20px;
+    padding: 0;
 }
 
 .fp-section-description {
-    background: #f0f6fc;
-    border-left: 4px solid var(--fp-brand-primary);
-    padding: 12px 16px;
-    margin-bottom: 20px;
-    font-size: 0.8125rem;
+    background: transparent;
+    border-left: none;
+    padding: 0 0 16px;
+    margin-bottom: 16px;
+    font-size: 0.875rem;
     line-height: 1.5;
-    color: #1d2327;
-    border-radius: 0 4px 4px 0;
+    color: #50575e;
 }
 
 /* Empty state styling for time slots */
@@ -682,23 +681,23 @@ html {
 
 /* Override container and wrapper */
 .fp-overrides-section-wrapper {
-    background: #fff;
-    border: 1px solid #c3c4c7;
-    border-radius: 4px;
-    overflow: hidden;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    overflow: visible;
     margin-bottom: 20px;
 }
 
 .fp-overrides-section-wrapper .fp-section-content {
-    padding: 20px;
+    padding: 0;
 }
 
 .fp-section-description {
-    background: #f6f7f7;
-    border-left: 4px solid var(--fp-brand-primary);
-    padding: 12px 16px;
-    margin-bottom: 20px;
-    font-size: 0.8125rem;
+    background: transparent;
+    border-left: none;
+    padding: 0 0 16px;
+    margin-bottom: 16px;
+    font-size: 0.875rem;
     line-height: 1.5;
     color: #50575e;
 }
@@ -1269,41 +1268,35 @@ html {
 
 /* Standard WordPress section styling */
 .fp-schedules-section {
-    background: #fff;
-    border: 1px solid #c3c4c7;
-    border-radius: 4px;
+    background: transparent;
+    border: none;
+    border-radius: 0;
     padding: 0;
     margin-bottom: 20px;
-    box-shadow: 0 1px 1px rgba(0,0,0,0.04);
+    box-shadow: none;
 }
 
 .fp-schedules-section h4 {
-    margin: 0 0 20px 0;
-    padding: 20px 20px 15px;
-    border-bottom: 1px solid #c3c4c7;
+    margin: 0 0 12px 0;
+    padding: 0;
+    border-bottom: none;
     font-size: 1rem;
     font-weight: 600;
     color: #1d2327;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    background: #fff;
+    display: block;
+    background: transparent;
 }
 
 .fp-schedules-section h4::before {
-    content: "\f507"; /* dashicons-clock */
-    font-family: "dashicons";
-    font-size: 1.125rem;
-    color: #646970;
+    display: none;
 }
 
 .fp-schedules-section .fp-section-description {
-    margin: 0 20px 20px;
-    background: #f0f6fc;
-    border-left: 4px solid var(--fp-brand-primary);
-    padding: 15px 20px;
-    border-radius: 0 4px 4px 0;
-    font-size: 0.8125rem;
+    margin: 0 0 16px;
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: 0.875rem;
     color: #50575e;
     line-height: 1.6;
 }
@@ -1311,7 +1304,7 @@ html {
 /* Add padding to section content */
 .fp-schedules-section .fp-section-content,
 .fp-overrides-section-wrapper .fp-section-content {
-    padding: 0 20px 20px;
+    padding: 0;
 }
 
 /* ========================================

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -228,6 +228,7 @@
             var $overridesSection = $('#fp-overrides-section');
             var $recurringHeading = $recurringSchedules.find('.hndle span');
             var $eventHeading = $eventSchedules.find('.hndle span');
+            var $overridesHeading = $overridesSection.find('.hndle span');
 
             if (experienceType === 'event') {
                 // Show event sections, hide experience sections
@@ -239,7 +240,7 @@
 
                 // Update section descriptions
                 if ($eventHeading.length) {
-                    $eventHeading.text(fp_esperienze_admin.strings.event_schedules || 'Event Dates & Times');
+                    $eventHeading.text(fp_esperienze_admin.strings.event_schedules || 'Event dates & times');
                 }
 
             } else {
@@ -250,10 +251,14 @@
 
                 // Restore section descriptions
                 if ($recurringHeading.length) {
-                    $recurringHeading.text(fp_esperienze_admin.strings.recurring_schedules || 'Recurring Time Slots');
+                    $recurringHeading.text(fp_esperienze_admin.strings.recurring_schedules || 'Recurring schedule');
                 }
             }
-            
+
+            if ($overridesHeading.length) {
+                $overridesHeading.text(fp_esperienze_admin.strings.schedule_overrides || 'Schedule exceptions');
+            }
+
             // Add body class for CSS targeting
             $('body').removeClass('fp-experience-type-experience fp-experience-type-event')
                      .addClass('fp-experience-type-' + (experienceType || 'experience'));

--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -254,7 +254,7 @@ class Experience {
 
                                         $this->renderExperienceMetabox(
                                                 'fp-recurring-schedules',
-                                                __( 'Recurring time slots', 'fp-esperienze' ),
+                                                __( 'Recurring schedule', 'fp-esperienze' ),
                                                 function () use ( $post ) {
                                                         $this->renderExperienceSchedulesSection( $post->ID );
                                                 },
@@ -277,7 +277,7 @@ class Experience {
 
                                         $this->renderExperienceMetabox(
                                                 'fp-overrides-section',
-                                                __( 'Date-specific overrides', 'fp-esperienze' ),
+                                                __( 'Schedule exceptions', 'fp-esperienze' ),
                                                 function () use ( $post ) {
                                                         $this->renderExperienceOverridesSection( $post->ID );
                                                 },
@@ -341,13 +341,13 @@ class Experience {
                 woocommerce_wp_select(
                         array(
                                 'id'          => '_fp_experience_type',
-                                'label'       => __( 'Type', 'fp-esperienze' ),
+                                'label'       => __( 'Scheduling mode', 'fp-esperienze' ),
                                 'options'     => array(
-                                        'experience' => __( 'Experience (Recurring Schedule)', 'fp-esperienze' ),
-                                        'event'      => __( 'Event (Fixed Date)', 'fp-esperienze' ),
+                                        'experience' => __( 'Recurring schedule', 'fp-esperienze' ),
+                                        'event'      => __( 'Fixed date event', 'fp-esperienze' ),
                                 ),
                                 'desc_tip'    => true,
-                                'description' => __( 'Choose whether this is a recurring experience or a fixed-date event', 'fp-esperienze' ),
+                                'description' => __( 'Pick how customers can book this product: a repeating weekly schedule or individual fixed dates.', 'fp-esperienze' ),
                                 'value'       => get_post_meta( $post->ID, '_fp_experience_type', true ) ?: 'experience',
                         )
                 );
@@ -532,7 +532,7 @@ class Experience {
          */
         private function renderExperienceSchedulesSection( int $product_id ): void {
                 ?>
-                <p class="description"><?php _e( 'Configure weekly recurring time slots for your experience. Each slot can run on multiple days and can have custom settings that override the default product values above.', 'fp-esperienze' ); ?></p>
+                <p class="description"><?php _e( 'Create the weekly pattern for this experience. Add the start time, days and availability for each repeating slot below.', 'fp-esperienze' ); ?></p>
 
                 <div id="fp-schedule-builder-container" class="fp-schedule-builder-wrapper">
                         <?php $this->renderScheduleBuilder( $product_id ); ?>
@@ -583,7 +583,7 @@ class Experience {
          */
         private function renderExperienceOverridesSection( int $product_id ): void {
                 ?>
-                <p class="description"><?php _e( 'Add exceptions for specific dates: close the experience, change capacity, or modify prices for particular days.', 'fp-esperienze' ); ?></p>
+                <p class="description"><?php _e( 'Handle special dates here — close sales, tweak capacity or adjust pricing for single days without touching your recurring plan.', 'fp-esperienze' ); ?></p>
 
                 <div id="fp-overrides-container">
                         <?php $this->renderOverridesSection( $product_id ); ?>
@@ -3147,8 +3147,9 @@ class Experience {
 			'loading'                   => __( 'Loading...', 'fp-esperienze' ),
 			'unsaved_changes'           => __( 'You have unsaved changes. Are you sure you want to leave?', 'fp-esperienze' ),
 			'validation_error'          => __( 'Please fix the validation errors before saving.', 'fp-esperienze' ),
-			'event_schedules'           => __( 'Event Dates & Times', 'fp-esperienze' ),
-			'recurring_schedules'       => __( 'Recurring Time Slots', 'fp-esperienze' ),
+                        'event_schedules'           => __( 'Event dates & times', 'fp-esperienze' ),
+                        'recurring_schedules'       => __( 'Recurring schedule', 'fp-esperienze' ),
+                        'schedule_overrides'        => __( 'Schedule exceptions', 'fp-esperienze' ),
 			'confirm_remove_event_date' => __( 'Are you sure you want to remove this event date and all its time slots?', 'fp-esperienze' ),
 			'event_date_exists'         => __( 'This event date already exists.', 'fp-esperienze' ),
 			'add_time_slot'             => __( 'Add Time Slot', 'fp-esperienze' ),

--- a/templates/single-experience.php
+++ b/templates/single-experience.php
@@ -105,20 +105,13 @@ foreach ($gallery_meta as $attachment_id) {
     ];
 }
 
-// Merge hero image with additional gallery items so the main slider always cycles through every asset.
-if (!empty($additional_gallery)) {
-    if (!empty($hero_gallery)) {
-        $hero_gallery = array_merge($hero_gallery, $additional_gallery);
-    } else {
-        $hero_gallery = $additional_gallery;
-    }
+// If there is no featured image fall back to the first gallery asset for the hero.
+if (empty($hero_gallery) && !empty($additional_gallery)) {
+    $hero_gallery[] = array_shift($additional_gallery);
 }
 
-// Build secondary gallery (omit the first slide because it already appears in the hero slider).
-$experience_gallery = [];
-if (count($hero_gallery) > 1) {
-    $experience_gallery = array_slice($hero_gallery, 1);
-}
+// The Experience Gallery section should only render additional media items.
+$experience_gallery = $additional_gallery;
 
 // Meta data derived from schedules
 $schedules = ScheduleManager::getSchedules($product_id);
@@ -496,7 +489,7 @@ jQuery(document).ready(function($) {
                     <section class="fp-experience-secondary-gallery">
                         <h2><?php _e('Experience Gallery', 'fp-esperienze'); ?></h2>
                         <div class="fp-secondary-gallery">
-                            <div class="fp-experience-gallery" tabindex="0">
+                            <div class="fp-experience-gallery" tabindex="0" data-autoplay-interval="3000">
                                 <div class="fp-experience-gallery__stage" role="region" aria-label="<?php esc_attr_e('Additional experience images', 'fp-esperienze'); ?>">
                                     <?php foreach ($experience_gallery as $index => $item) : ?>
                                         <figure class="fp-experience-gallery__slide<?php echo $index === 0 ? ' is-active' : ''; ?>" data-gallery-index="<?php echo esc_attr($index); ?>" aria-hidden="<?php echo $index === 0 ? 'false' : 'true'; ?>">


### PR DESCRIPTION
## Summary
- rename the scheduling dropdown and section headings so the product editor no longer repeats the product-type wording and copy is clearer
- simplify the recurring schedules and date override admin blocks with flatter styling and copy updates
- ensure the single experience header only shows the featured image while the Experience Gallery slider rotates additional images every three seconds
- keep the experience admin toggles in sync with the simplified “Recurring schedule”, “Event dates & times”, and “Schedule exceptions” labels

## Testing
- `composer test` *(phpstan still stalls at 0/77 even after installing dependencies; the run was cancelled after hanging without progress)*

------
https://chatgpt.com/codex/tasks/task_e_68d54d1598a0832fb2dc2f7a1721879e