### PR TITLE
Add onboarding reminder notice with snooze controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ verify-experience-fix.php
 vendor/
 *.php
 !tests/*.php
-!includes/Core/TranslationCompiler.php
+!includes/**/*.php

--- a/INTEGRATION_TOOLKIT.md
+++ b/INTEGRATION_TOOLKIT.md
@@ -1,0 +1,32 @@
+# Integration Toolkit
+
+The **FP Esperienze → Integration Toolkit** admin page centralises the snippets needed to embed the booking widget on partner websites, landing pages, and headless front-ends.
+
+## Sections
+
+### Quick Embed
+- Copy an iframe wrapper with the correct REST endpoint for your site (pre-filled with the newest experience ID when available).
+- Paste into WordPress, Webflow, Squarespace, HubSpot, or any CMS that accepts raw HTML.
+- Append `?theme=dark` or `?return_url=https://partner.com/thanks` to control theming and post-booking redirects.
+
+### Auto-Height Integration
+- Provides the `postMessage` listener used by the widget to announce its height.
+- Keeps embeds responsive when content expands (e.g., extras or translated text).
+- Emits events:
+  - `fp_widget_ready`
+  - `fp_widget_height_change`
+  - `fp_widget_checkout`
+  - `fp_widget_booking_success`
+
+### Theme Tokens
+- Copy CSS variables (`--fp-esperienze-widget-*`) to align partner pages with your brand.
+- Drop them into a global stylesheet or CMS design settings.
+
+## Copy Buttons
+
+Each snippet includes a "Copy" button powered by the `assets/js/integration-toolkit.js` helper. The script supports both the Clipboard API and a fallback method, ensuring the buttons work on older browsers used inside admin panels.
+
+## Related Resources
+
+- Full recipes live in [`WIDGET_INTEGRATION_GUIDE.md`](WIDGET_INTEGRATION_GUIDE.md) for teams that prefer documentation-first workflows.
+- For automated smoke tests and digest monitoring combine the Integration Toolkit with the WP-CLI commands documented in [`ONBOARDING_AUTOMATION.md`](ONBOARDING_AUTOMATION.md) and the new `wp fp-esperienze operations health-check` task.

--- a/MARKETING_SEO_PLAYBOOK.md
+++ b/MARKETING_SEO_PLAYBOOK.md
@@ -1,0 +1,75 @@
+# FP Esperienze Marketing & SEO Playbook
+
+This playbook helps marketing teams get the most out of FP Esperienze without touching code. It turns the built-in schema, tracking, and social metadata into ready-to-run campaigns.
+
+## 1. Launch Checklist per Experience
+
+| Task | Owner | Notes |
+|------|-------|-------|
+| Add hero images (1200×800+) to the Experience gallery | Content | Surfaces in OpenGraph tags and the widget carousel |
+| Populate “What’s included / excluded” fields | Content | Powers FAQ markup and enriches search snippets |
+| Assign the correct meeting point | Ops | Required for Event/Trip structured data and Google Maps deep links |
+| Enable at least one payment method | Ops | Checklist item must be ✅ to publish |
+| Configure Google Analytics 4 ID in Setup Wizard | Marketing | Enables funnel events & conversions |
+| Add campaign UTM defaults (`?utm_source=` etc.) | Marketing | Use WooCommerce > Settings > Tracking tab |
+
+## 2. Seasonal Campaign Recipes
+
+### Flash Tour Drop (48 hours)
+- Duplicate the experience, switch the product status to “Scheduled”, and add a fixed-date schedule via the Schedule Builder.
+- Enable Brevo integration and select a dedicated contact list for the flash sale.
+- Use the new CLI report to confirm daily conversions:
+  ```bash
+  wp fp-esperienze onboarding daily-report --days=2
+  ```
+- Update the widget embed on partner sites with `?theme=dark` to visually differentiate the limited offer.
+
+### Evergreen SEO Refresh (Quarterly)
+1. Export reviews from the Reports screen to capture fresh testimonial quotes.
+2. Refresh the long description and “What’s Included” bullet points.
+3. Verify Event schema is still valid using the `SEO` admin tab → Rich Results checker shortcut.
+4. Regenerate social preview (Admin → SEO → Social Cards) to align with the updated copy.
+
+## 3. Structured Data Game Plan
+
+| Scenario | Schema Type | Action |
+|----------|-------------|--------|
+| Recurring departures | `Event` | Ensure schedules are active and capacity set; schema renders automatically |
+| Open-dated voucher | `Product` + `Offer` | Highlight gift experience content and attach default price |
+| Multi-day trip | `Trip` | Tag the product with `multi-day` category to force Trip schema |
+
+Use [Google Rich Results Test](https://search.google.com/test/rich-results) weekly on your top 5 experiences. No manual JSON-LD editing is required—the plugin assembles the graph using meeting points, schedules, and pricing.
+
+## 4. Conversion Tracking Toolkit
+
+| Metric | Where to Find | Tips |
+|--------|---------------|------|
+| Booking revenue by day | `wp fp-esperienze onboarding daily-report --days=7` | Pipe output into Slack via scheduled cron |
+| Funnel analytics | Google Analytics 4 (Enhanced eCommerce) | Events: `view_item`, `add_to_cart`, `purchase` are automatically tagged |
+| Paid media performance | Google Ads + Meta Pixel integrations | Configure in Setup Wizard step 2 |
+| Email engagement | Brevo lists | Use the “Flash Tour” automation template for time-boxed drops |
+
+## 5. Partner / OTA Enablement Kit
+
+Share these assets with distribution partners:
+
+- **Widget Embed Snippets** – see `WIDGET_INTEGRATION_GUIDE.md` for iframe templates with auto-resize and return URLs.
+- **Style Tokens** – override CSS variables from the widget using a parent stylesheet (`--fp-color-primary`, `--fp-font-family`).
+- **Messaging Hooks** – listen for `fp_widget_booking_success` events to trigger thank-you modals or upsell flows on partner sites.
+
+## 6. Reporting Cadence
+
+| Frequency | Action |
+|-----------|--------|
+| Daily | `wp fp-esperienze onboarding daily-report` to monitor bookings & revenue |
+| Weekly | Review “Reports → Availability Heatmap” for load factor anomalies |
+| Monthly | Export “Reports → Conversion Breakdown” and share with finance |
+| Quarterly | Run the Guided Onboarding checklist to ensure new staff followed all prerequisites |
+
+## 7. Asset Templates
+
+- **Thank-you Page Copy:** “Grazie per aver prenotato *{experience_name}*. Riceverai un’email con i dettagli del punto d’incontro in {booking_language}.”
+- **Social Caption Framework:** `[{city}] {experience_type} · {duration} · {price}` + CTA “Prenota ora → {widget_url}``
+- **Email Reminder Subject:** `Domani alle {slot_time}: ci vediamo per {experience_name}!`
+
+Keep this playbook in your internal knowledge base and adapt it per market. The new onboarding CLI commands allow you to automate data pulls, while the wizard’s checklist guarantees operations and marketing stay aligned.

--- a/ONBOARDING_AUTOMATION.md
+++ b/ONBOARDING_AUTOMATION.md
@@ -1,0 +1,97 @@
+# FP Esperienze Onboarding Automation Guide
+
+Use these recipes to validate FP Esperienze installations and keep critical workflows monitored without manual testing.
+
+## 0.1. In-app reminders for pending setup
+
+Administrators with the `manage_woocommerce` capability now see a persistent FP Esperienze onboarding notice on the WordPress dashboard and plugin pages whenever checklist items remain unfinished. Use the buttons to relaunch the setup wizard or jump to the dashboard widget, or click **Remind me later** to snooze the alert for a week while you finish other tasks.
+
+## 0. Built-in Operational Alerts
+
+1. Navigate to **FP Esperienze → Operational Alerts** in the WordPress admin.
+2. Enable the email digest and/or provide a Slack webhook URL.
+3. Set the booking threshold, lookback window, and preferred send hour (site timezone).
+4. Save the form and click **Send digest now** to confirm delivery.
+
+The plugin automatically schedules a daily event based on the selected hour. Digests include booking totals, participant counts, revenue, and a warning when the minimum booking threshold is not met.
+
+## 1. Daily Booking Digest (Cron)
+
+```bash
+# /etc/cron.d/fp-esperienze
+0 7 * * * www-data cd /var/www/html && wp fp-esperienze onboarding send-digest --channel=all --days=1
+```
+
+The digest honours the configured channels. If neither email nor Slack is enabled the command exits with a warning so your scheduler can flag the issue.
+
+## 2. CI Smoke Test Before Deploying Themes
+
+```yaml
+# .github/workflows/fp-onboarding.yml
+name: FP Esperienze onboarding audit
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'wp-content/themes/**'
+
+jobs:
+  checklist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+      - name: Install WP-CLI
+        run: curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x wp-cli.phar && sudo mv wp-cli.phar /usr/local/bin/wp
+      - name: Run onboarding checklist
+        run: wp fp-esperienze onboarding checklist --format=json
+```
+
+Parse the JSON output to enforce minimum completion thresholds (e.g., fail the pipeline if payment gateways are disabled).
+
+## 3. Demo Content Refresh for Training Environments
+
+```bash
+wp site empty --yes
+wp fp-esperienze onboarding seed-data
+wp option update fp_esperienze_notifications '{"staff_notifications_enabled":1,"staff_emails":"academy@example.com"}'
+```
+
+Pair this with `wp theme activate` commands to rehydrate a sandbox for onboarding new staff.
+
+## 4. Slack Notification on Drops
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+REPORT=$(wp fp-esperienze onboarding daily-report --days=1 --format=json)
+BOOKINGS=$(echo "$REPORT" | jq '.overall.total_bookings')
+if [ "$BOOKINGS" -lt 1 ]; then
+  curl -X POST -H 'Content-type: application/json' \
+    --data "{\"text\":\"⚠️ Nessuna prenotazione registrata nelle ultime 24h. Verificare campagne e disponibilità.\"}" \
+    https://hooks.slack.com/services/T0000/B0000/XXXX
+fi
+```
+
+Automate this via cron to catch regressions or payment issues early.
+
+## 5. QA Shortcuts
+
+- `wp fp-esperienze onboarding checklist` before shipping new product data.
+- `wp fp-esperienze onboarding seed-data` on staging to populate the Schedule Builder with realistic content.
+- `wp fp-esperienze production-check` to confirm system prerequisites are still satisfied.
+- `wp fp-esperienze operations health-check` to capture digest status, cron readiness, and pending onboarding tasks.
+
+Combine these commands with your existing deployment scripts to replace repetitive manual smoke tests from the legacy checklist documents.
+
+## 6. Operations Health Monitor
+
+```bash
+# Collect a JSON report for dashboards or alerting
+wp fp-esperienze operations health-check --format=json > /var/log/fp-esperienze-health.json
+```
+
+Parse the summary counters to trigger alerts (for example, fail the job when `fail` > 0 or notify the support team when `warn` increases between runs).

--- a/QA_AUTOMATION.md
+++ b/QA_AUTOMATION.md
@@ -1,0 +1,58 @@
+# FP Esperienze QA Automation
+
+The `wp fp-esperienze qa` command turns the manual smoke tests into repeatable
+checks that can run after deployments, inside CI pipelines, or on staging sites
+before stakeholders sign off.
+
+## Available Checks
+
+| ID                       | Description |
+|--------------------------|-------------|
+| `experience_product_type` | Verifies WooCommerce has the `experience` product type registered so booking creation works. |
+| `onboarding_checklist`    | Ensures the onboarding helper reports that core prerequisites (meeting points, products, schedules, payments, emails) are complete. |
+| `demo_content`            | Confirms that the demo meeting point, product, and schedule seed is present for training walkthroughs. |
+| `digest_schedule`         | Validates that at least one operational digest channel is configured and cron has a future run scheduled. |
+| `rest_routes`             | Checks that the public REST API routes powering the widget and partner integrations are registered. |
+
+Each check returns one of three severities:
+
+- `PASS` – everything looks good.
+- `WARNING` – not a blocker, but worth reviewing before launch.
+- `FAIL` – must be resolved before promoting to production.
+
+## Usage Examples
+
+```bash
+# Run every check and exit with code 0/1 depending on pass/fail
+wp fp-esperienze qa run
+
+# Generate machine-readable output for dashboards or alerting
+wp fp-esperienze qa run --format=json > qa-report.json
+
+# Execute a subset of checks (comma separated IDs)
+wp fp-esperienze qa run --only=experience_product_type,rest_routes
+
+# List the checks with their descriptions
+wp fp-esperienze qa list
+```
+
+## CI Integration Tips
+
+1. **WordPress bootstrap** – ensure the command runs within a WordPress
+   environment with WooCommerce active (e.g., `wp eval-file wp-load.php`).
+2. **Schedule verification** – the digest check uses `wp_next_scheduled()`. In
+   containers where WP-Cron is disabled, schedule a manual event before running
+   the command or ignore the check via `--only`.
+3. **Baseline demo data** – seed the optional demo content in staging to keep
+   the checklist and REST checks deterministic.
+4. **Alerting** – parse the JSON output and raise alerts when the `overall_status`
+   is `warning` or `fail`.
+5. **Continuous monitoring** – poll `wp-json/fp-exp/v1/system-status` with an
+   authenticated request to combine the QA signal with onboarding progress,
+   production readiness, and digest scheduling details.
+6. **Site Health dashboard** – surface the same insights in WordPress itself via
+   Tools → Site Health, which now lists FP Esperienze tests for dependencies,
+   onboarding progress, operational alerts, and production readiness.
+
+Automating the manual QA list reduces human error and gives instant feedback on
+whether the plugin is ready for merchants and partners.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ wp fp-esperienze production-check
 
 Add `--format=json` if you want to consume the report in automation pipelines.
 
+### WordPress Site Health Coverage
+
+Visit **Tools → Site Health** to review automated diagnostics tailored for FP Esperienze. The plugin now contributes dedicated tests that surface:
+
+- Dependency and filesystem prerequisites (WooCommerce, Composer autoloaders, writable directories).
+- Onboarding checklist completion so operators can quickly identify pending setup tasks.
+- Operational alert posture covering digest channels, cron scheduling, and the last dispatch status.
+- Production readiness signals reused from the REST API and WP-CLI validator, including warnings for missing tables or REST endpoints.
+
+These checks complement the CLI and REST tooling by giving administrators an at-a-glance dashboard directly inside WordPress.
+
+### Guided Onboarding Toolkit
+
+- **Interactive checklist** – the setup wizard now surfaces the required configuration tasks (meeting points, experiences, schedules, payment gateways, and emails) with live completion status.
+- **Demo data seeding** – click *Create demo data* in the wizard to generate a sample meeting point, experience, and recurring schedules to explore the booking flow immediately.
+- **Guided tour overlay** – launch the built-in tour to learn where to publish experiences, manage schedules, and preview the storefront without leaving the wizard.
+- **Persistent reminders** – lightweight notices highlight outstanding onboarding tasks on FP Esperienze admin pages until everything is configured, with a “remind me later” snooze for busy operators.
+- **Operational alerts** – configure automated booking digests (email and Slack) with thresholds from the Operational Alerts admin page.
+- **Integration toolkit** – share copy-ready widget snippets (embed, auto-height script, CSS tokens) with partners directly from the new Integration Toolkit admin page.
+
 ## Uninstall
 
 Removing the plugin via WordPress will drop all custom database tables beginning with `fp_` and delete any options or transients with the `fp_esperienze_` prefix. To preserve this data during uninstall, define the following constant in your `wp-config.php` before removing the plugin:
@@ -918,6 +938,13 @@ Check availability:
 GET /wp-json/fp-exp/v1/availability?product_id=123&date=2024-12-01
 ```
 
+Monitor onboarding progress and operational alerts (requires an authenticated user with FP Esperienze management rights):
+```
+GET /wp-json/fp-exp/v1/system-status
+```
+
+The payload includes checklist completion metrics, production readiness flags, and the scheduling state of the daily digest so external monitoring tools can flag regressions instantly.
+
 ## Frontend (Single)
 
 The plugin provides a GetYourGuide-style single experience template with the following features:
@@ -1379,6 +1406,63 @@ Queue all plugin content for translation via WP-CLI:
 ```bash
 wp fp-esperienze translate
 ```
+
+### WP-CLI Onboarding Commands
+
+Automate onboarding and daily operations directly from the terminal:
+
+```bash
+# Display checklist progress in table or JSON form
+wp fp-esperienze onboarding checklist --format=table
+
+# Seed demo data (meeting point, experience product, schedules)
+wp fp-esperienze onboarding seed-data
+
+# Generate booking, participant, and revenue totals for the past week
+wp fp-esperienze onboarding daily-report --days=7
+
+# Dispatch the configured operational digest immediately
+wp fp-esperienze onboarding send-digest --channel=all
+```
+
+The commands return non-zero exit codes on errors, making them suitable for CI pipelines or scheduled cron jobs.
+
+### WP-CLI Operations Command
+
+Run quick health checks before launching campaigns or pushing to production:
+
+```bash
+# Display operational readiness as a table
+wp fp-esperienze operations health-check
+
+# Produce JSON for monitoring dashboards
+wp fp-esperienze operations health-check --format=json
+```
+
+The command validates WooCommerce availability, digest configuration, cron scheduling, and pending onboarding tasks in one pass.
+
+### WP-CLI QA Automation Command
+
+Convert the smoke tests from `MANUAL_TESTS.md` into automated gates that can
+run in CI or pre-release hooks:
+
+```bash
+# Run the full automated checklist and exit non-zero on failures
+wp fp-esperienze qa run
+
+# Focus on specific checks (comma separated IDs)
+wp fp-esperienze qa run --only=experience_product_type,rest_routes
+
+# Produce machine readable output for dashboards
+wp fp-esperienze qa run --format=json
+
+# List the available checks and their descriptions
+wp fp-esperienze qa list
+```
+
+The QA command inspects onboarding progress, demo content seeding, REST routes,
+and operational digest scheduling, returning `WARNING` when action is
+recommended and `FAIL` when release blockers are detected.
 
 ### JavaScript Localization
 

--- a/WIDGET_INTEGRATION_GUIDE.md
+++ b/WIDGET_INTEGRATION_GUIDE.md
@@ -33,9 +33,52 @@ Add these parameters to the iframe URL:
 
 ## Examples
 
+### Copy & Paste Recipes
+
+#### WordPress Gutenberg (Custom HTML block)
+
+```html
+<!-- Add inside a "Custom HTML" block -->
+<div class="fp-esperienze-widget-wrapper" style="max-width:680px;margin:0 auto;">
+    <iframe
+        src="https://yoursite.com/wp-json/fp-exp/v1/widget/iframe/123?theme=light"
+        width="100%"
+        height="680"
+        loading="lazy"
+        style="border:1px solid var(--wp--preset--color--light-gray,#dcdcde);border-radius:12px;"
+        title="Book your experience"
+        allow="payment"
+    ></iframe>
+</div>
+```
+
+#### Webflow / Squarespace embed
+
+```html
+<div data-widget="fp-esperienze" style="max-width:640px;margin:auto;">
+  <iframe
+    id="fp-esperienze-widget"
+    src="https://yoursite.com/wp-json/fp-exp/v1/widget/iframe/123?theme=dark&return_url=https://partner.com/thanks"
+    style="width:100%;height:720px;border:0;border-radius:16px;box-shadow:0 15px 45px rgba(0,0,0,0.1);"
+    title="Experience booking"
+  ></iframe>
+</div>
+<script>
+window.addEventListener('message', function(event) {
+  if (!event.data || event.data.type !== 'fp_widget_height_change') {
+    return;
+  }
+  var frame = document.getElementById('fp-esperienze-widget');
+  if (frame) {
+    frame.style.height = event.data.height + 'px';
+  }
+});
+</script>
+```
+
 ### Basic Widget
 ```html
-<iframe src="https://mysite.com/wp-json/fp-exp/v1/widget/iframe/123" 
+<iframe src="https://mysite.com/wp-json/fp-exp/v1/widget/iframe/123"
         width="100%" height="600" frameborder="0"></iframe>
 ```
 

--- a/assets/js/integration-toolkit.js
+++ b/assets/js/integration-toolkit.js
@@ -1,0 +1,104 @@
+(function(window, document) {
+    'use strict';
+
+    function restoreLabel(button) {
+        var defaultLabel = button.getAttribute('data-default-label');
+        if (!defaultLabel) {
+            return;
+        }
+
+        window.setTimeout(function() {
+            button.textContent = defaultLabel;
+        }, 2000);
+    }
+
+    function copyUsingClipboardApi(text) {
+        if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+            return Promise.reject();
+        }
+
+        return navigator.clipboard.writeText(text);
+    }
+
+    function copyUsingFallback(text) {
+        var textarea = document.createElement('textarea');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        textarea.value = text;
+        document.body.appendChild(textarea);
+
+        textarea.focus();
+        textarea.select();
+
+        try {
+            var result = document.execCommand('copy');
+            document.body.removeChild(textarea);
+            return result ? Promise.resolve() : Promise.reject();
+        } catch (error) {
+            document.body.removeChild(textarea);
+            return Promise.reject(error);
+        }
+    }
+
+    function copyContent(source) {
+        var text = '';
+
+        if (source.value !== undefined) {
+            text = source.value;
+        } else if (source.textContent) {
+            text = source.textContent;
+        }
+
+        if (!text) {
+            return Promise.reject();
+        }
+
+        return copyUsingClipboardApi(text).catch(function() {
+            return copyUsingFallback(text);
+        });
+    }
+
+    function handleCopyClick(event) {
+        event.preventDefault();
+
+        var button = event.currentTarget;
+        var targetId = button.getAttribute('data-target');
+        if (!targetId) {
+            return;
+        }
+
+        var target = document.getElementById(targetId);
+        if (!target) {
+            return;
+        }
+
+        copyContent(target)
+            .then(function() {
+                var copiedLabel = button.getAttribute('data-copied-label');
+                if (copiedLabel) {
+                    button.textContent = copiedLabel;
+                    restoreLabel(button);
+                }
+            })
+            .catch(function() {
+                var fallbackLabel = button.getAttribute('data-fallback-label');
+                if (fallbackLabel) {
+                    button.textContent = fallbackLabel;
+                    restoreLabel(button);
+                }
+            });
+    }
+
+    function init() {
+        var buttons = document.querySelectorAll('.fp-integration-copy');
+        Array.prototype.forEach.call(buttons, function(button) {
+            button.addEventListener('click', handleCopyClick);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})(window, document);

--- a/assets/js/setup-wizard-tour.js
+++ b/assets/js/setup-wizard-tour.js
@@ -1,0 +1,93 @@
+(function($) {
+    'use strict';
+
+    const data = window.fpSetupTourData || {};
+    const steps = Array.isArray(data.steps) ? data.steps : [];
+    const i18n = data.i18n || {};
+
+    const $overlay = $('#fp-tour-overlay');
+    const $title = $('#fp-tour-title');
+    const $content = $('#fp-tour-content');
+    const $next = $('#fp-tour-next');
+    const $prev = $('#fp-tour-prev');
+    const $skip = $('#fp-tour-skip');
+    let currentIndex = 0;
+
+    function setButtonLabels() {
+        $next.text(steps.length > 1 ? (i18n.next || 'Next') : (i18n.finish || 'Done'));
+        $prev.text(i18n.previous || 'Previous');
+        $skip.text(i18n.skip || 'Skip tour');
+    }
+
+    function updateStep() {
+        if (!steps.length) {
+            closeTour();
+            return;
+        }
+
+        const step = steps[currentIndex];
+        $title.text(step.title || '');
+        $content.text(step.content || '');
+
+        if (currentIndex === steps.length - 1) {
+            $next.text(i18n.finish || 'Done');
+        } else {
+            $next.text(i18n.next || 'Next');
+        }
+
+        if (currentIndex === 0) {
+            $prev.prop('disabled', true).addClass('button-disabled');
+        } else {
+            $prev.prop('disabled', false).removeClass('button-disabled');
+        }
+    }
+
+    function openTour() {
+        if (!steps.length) {
+            return;
+        }
+
+        currentIndex = 0;
+        setButtonLabels();
+        updateStep();
+        $overlay.addClass('is-visible').attr('aria-hidden', 'false');
+    }
+
+    function closeTour() {
+        $overlay.removeClass('is-visible').attr('aria-hidden', 'true');
+    }
+
+    $(document).on('click', '#fp-start-tour', function(event) {
+        event.preventDefault();
+        openTour();
+    });
+
+    $next.on('click', function() {
+        if (currentIndex < steps.length - 1) {
+            currentIndex++;
+            updateStep();
+            return;
+        }
+
+        closeTour();
+    });
+
+    $prev.on('click', function() {
+        if (currentIndex === 0) {
+            return;
+        }
+
+        currentIndex--;
+        updateStep();
+    });
+
+    $skip.on('click', function() {
+        closeTour();
+    });
+
+    $overlay.on('click', function(event) {
+        if (event.target === event.currentTarget) {
+            closeTour();
+        }
+    });
+})(jQuery);

--- a/fp-esperienze.php
+++ b/fp-esperienze.php
@@ -316,6 +316,9 @@ if (defined('WP_CLI') && WP_CLI) {
     try {
         \WP_CLI::add_command('fp-esperienze', \FP\Esperienze\CLI\TranslateCommand::class);
         \WP_CLI::add_command('fp-esperienze production-check', \FP\Esperienze\CLI\ProductionCheckCommand::class);
+        \WP_CLI::add_command('fp-esperienze onboarding', \FP\Esperienze\CLI\OnboardingCommand::class);
+        \WP_CLI::add_command('fp-esperienze operations', \FP\Esperienze\CLI\OperationsCommand::class);
+        \WP_CLI::add_command('fp-esperienze qa', \FP\Esperienze\CLI\QualityAssuranceCommand::class);
     } catch (Throwable $e) {
         error_log('FP Esperienze: Failed to register WP-CLI command: ' . $e->getMessage());
     }

--- a/includes/Admin/OnboardingDashboardWidget.php
+++ b/includes/Admin/OnboardingDashboardWidget.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Dashboard widget that surfaces onboarding progress and quick actions.
+ *
+ * @package FP\Esperienze\Admin
+ */
+
+namespace FP\Esperienze\Admin;
+
+use FP\Esperienze\Admin\OnboardingHelper;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Register the FP Esperienze onboarding dashboard widget.
+ */
+class OnboardingDashboardWidget {
+    /**
+     * Transient key used for seed demo notices.
+     */
+    private const NOTICE_KEY = 'fp_esperienze_seed_demo_notice_';
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action('wp_dashboard_setup', [$this, 'registerWidget']);
+        add_action('admin_post_fp_esperienze_seed_demo', [$this, 'handleSeedDemo']);
+        add_action('admin_notices', [$this, 'maybeDisplayNotice']);
+    }
+
+    /**
+     * Register the onboarding widget.
+     */
+    public function registerWidget(): void {
+        if (!current_user_can('manage_woocommerce')) {
+            return;
+        }
+
+        wp_add_dashboard_widget(
+            'fp_esperienze_onboarding',
+            __('FP Esperienze onboarding', 'fp-esperienze'),
+            [$this, 'renderWidget']
+        );
+    }
+
+    /**
+     * Render widget content.
+     */
+    public function renderWidget(): void {
+        $summary = OnboardingHelper::getCompletionSummary();
+        $items = OnboardingHelper::getChecklistItems();
+        $completed = (int) ($summary['completed'] ?? 0);
+        $total = (int) ($summary['total'] ?? 0);
+        $percentage = (float) ($summary['percentage'] ?? 0.0);
+        $percentage_display = number_format_i18n($percentage, 2);
+
+        $setup_url = admin_url('admin.php?page=fp-esperienze-setup-wizard');
+        $integration_url = admin_url('admin.php?page=fp-esperienze-integration-toolkit');
+        $alerts_url = admin_url('admin.php?page=fp-esperienze-operational-alerts');
+
+        $seed_nonce = wp_create_nonce('fp_esperienze_seed_demo');
+
+        echo '<div class="fp-onboarding-widget">';
+        echo '<p class="fp-onboarding-progress">' . sprintf(
+            /* translators: 1: completed steps, 2: total steps, 3: percentage */
+            esc_html__('Progress: %1$d of %2$d prerequisites complete (%3$s%%)', 'fp-esperienze'),
+            $completed,
+            $total,
+            esc_html($percentage_display)
+        ) . '</p>';
+
+        echo '<ul class="fp-onboarding-checklist">';
+        foreach ($items as $item) {
+            $is_complete = !empty($item['completed']);
+            $icon = $is_complete ? 'dashicons-yes-alt' : 'dashicons-clock';
+            $status_class = $is_complete ? 'complete' : 'pending';
+            $label = esc_html($item['label'] ?? '');
+            $description = esc_html($item['description'] ?? '');
+
+            echo '<li class="' . esc_attr('item-' . $status_class) . '">';
+            echo '<span class="dashicons ' . esc_attr($icon) . '"></span>';
+            echo '<div class="fp-onboarding-item-text">';
+            echo '<strong>' . $label . '</strong>';
+            if ($description !== '') {
+                echo '<p>' . $description . '</p>';
+            }
+            if (!$is_complete && !empty($item['action'])) {
+                $action_url = esc_url($item['action']);
+                echo '<p><a class="button button-secondary" href="' . $action_url . '">' . esc_html__('Complete this step', 'fp-esperienze') . '</a></p>';
+            }
+            echo '</div>';
+            echo '</li>';
+        }
+        echo '</ul>';
+
+        echo '<div class="fp-onboarding-actions">';
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+        echo '<input type="hidden" name="action" value="fp_esperienze_seed_demo" />';
+        echo '<input type="hidden" name="fp_esperienze_seed_demo_nonce" value="' . esc_attr($seed_nonce) . '" />';
+        echo '<button type="submit" class="button button-primary">' . esc_html__('Generate demo content', 'fp-esperienze') . '</button>';
+        echo '</form>';
+
+        $wizard_link = '<a href="' . esc_url($setup_url) . '">' . esc_html__('setup wizard', 'fp-esperienze') . '</a>';
+        $guidance_text = sprintf(
+            /* translators: %s: link to the setup wizard */
+            __('Need guidance? Continue in the %s.', 'fp-esperienze'),
+            $wizard_link
+        );
+        echo '<p>' . wp_kses_post($guidance_text) . '</p>';
+
+        $integration_link = '<a href="' . esc_url($integration_url) . '">' . esc_html__('Integration Toolkit', 'fp-esperienze') . '</a>';
+        $alerts_link = '<a href="' . esc_url($alerts_url) . '">' . esc_html__('Operational Alerts', 'fp-esperienze') . '</a>';
+        $handoff_text = sprintf(
+            /* translators: 1: link to the integration toolkit, 2: link to operational alerts */
+            __('Share embeds via the %1$s or configure digests in %2$s.', 'fp-esperienze'),
+            $integration_link,
+            $alerts_link
+        );
+        echo '<p>' . wp_kses_post($handoff_text) . '</p>';
+
+        echo '<p class="description">' . esc_html__('Automation tip: run “wp fp-esperienze operations health-check” after each deploy to verify production readiness.', 'fp-esperienze') . '</p>';
+        echo '</div>';
+
+        echo '<style>
+            .fp-onboarding-widget {font-size:14px;}
+            .fp-onboarding-progress {font-weight:600;margin-bottom:8px;}
+            .fp-onboarding-checklist {list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px;}
+            .fp-onboarding-checklist li {display:flex;gap:12px;padding:12px;background:#fff;border:1px solid #dcdcde;border-radius:8px;}
+            .fp-onboarding-checklist li.item-complete {border-color:#00a32a;background:#f0fff4;}
+            .fp-onboarding-checklist li .dashicons {font-size:20px;width:20px;height:20px;color:#2271b1;margin-top:2px;}
+            .fp-onboarding-checklist li.item-complete .dashicons {color:#00a32a;}
+            .fp-onboarding-item-text p {margin:4px 0 0;color:#50575e;}
+            .fp-onboarding-actions {margin-top:16px;border-top:1px solid #dcdcde;padding-top:12px;}
+            .fp-onboarding-actions form {margin-bottom:12px;}
+        </style>';
+
+        echo '</div>';
+    }
+
+    /**
+     * Handle demo content generation from the dashboard widget.
+     */
+    public function handleSeedDemo(): void {
+        if (!current_user_can('manage_woocommerce')) {
+            wp_die(esc_html__('You do not have permission to perform this action.', 'fp-esperienze'));
+        }
+
+        check_admin_referer('fp_esperienze_seed_demo', 'fp_esperienze_seed_demo_nonce');
+
+        $result = OnboardingHelper::seedDemoContent();
+        $this->storeNotice($result);
+
+        $redirect = wp_get_referer();
+        if (empty($redirect)) {
+            $redirect = admin_url('index.php');
+        }
+
+        wp_safe_redirect($redirect);
+        exit;
+    }
+
+    /**
+     * Display the notice after attempting to seed demo content.
+     */
+    public function maybeDisplayNotice(): void {
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if (!$screen || $screen->base !== 'dashboard') {
+            return;
+        }
+
+        $key = $this->getNoticeKey();
+        $notice = get_transient($key);
+        if (!$notice || !is_array($notice)) {
+            return;
+        }
+
+        delete_transient($key);
+
+        $status = $notice['status'] ?? 'info';
+        $message = $notice['message'] ?? '';
+        if ($message === '') {
+            return;
+        }
+
+        switch ($status) {
+            case 'success':
+                $class = 'notice-success';
+                break;
+            case 'error':
+                $class = 'notice-error';
+                break;
+            case 'warning':
+                $class = 'notice-warning';
+                break;
+            default:
+                $class = 'notice-info';
+                break;
+        }
+
+        printf('<div class="notice %1$s"><p>%2$s</p></div>', esc_attr($class), esc_html($message));
+    }
+
+    /**
+     * Store a transient so the notice can be shown after redirect.
+     *
+     * @param array{status:string,message:string} $result Result from demo seeding.
+     */
+    private function storeNotice(array $result): void {
+        $key = $this->getNoticeKey();
+        set_transient($key, $result, MINUTE_IN_SECONDS);
+    }
+
+    /**
+     * Build a unique transient key per user to avoid leaking notices.
+     */
+    private function getNoticeKey(): string {
+        $user_id = get_current_user_id();
+
+        return self::NOTICE_KEY . $user_id;
+    }
+}

--- a/includes/Admin/OnboardingHelper.php
+++ b/includes/Admin/OnboardingHelper.php
@@ -1,0 +1,513 @@
+<?php
+/**
+ * Onboarding helper utilities shared between the setup wizard and CLI tools.
+ *
+ * @package FP\Esperienze\Admin
+ */
+
+namespace FP\Esperienze\Admin;
+
+use DateInterval;
+use DateTimeImmutable;
+use Exception;
+use FP\Esperienze\Data\MeetingPointManager;
+use FP\Esperienze\Data\ScheduleManager;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Helper responsible for onboarding related automation.
+ */
+class OnboardingHelper {
+    /**
+     * Cache checklist items for the current request.
+     *
+     * @var array<int, array<string, mixed>>|null
+     */
+    private static ?array $checklistCache = null;
+
+    /**
+     * Retrieve the onboarding checklist items with completion state.
+     *
+     * Each entry contains the following keys:
+     * - id: machine readable identifier.
+     * - label: translated human label.
+     * - description: extra context for UI rendering.
+     * - completed: whether the prerequisite is satisfied.
+     * - count: related resource count used for display.
+     * - action: optional admin URL to resolve the item.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function getChecklistItems(): array {
+        if (self::$checklistCache !== null) {
+            return self::$checklistCache;
+        }
+
+        $meetingPoints = self::countMeetingPoints();
+        $experienceProducts = self::countExperienceProducts();
+        $schedules = self::countSchedules();
+        $paymentGateways = self::countPaymentGateways();
+        $emails = self::countEnabledEmails();
+
+        $items = [
+            [
+                'id' => 'meeting_points',
+                'label' => __('Meeting points configured', 'fp-esperienze'),
+                'description' => __('Create at least one meeting point so customers know where to reach the guide.', 'fp-esperienze'),
+                'count' => $meetingPoints,
+                'completed' => $meetingPoints > 0,
+                'action' => admin_url('admin.php?page=fp-esperienze-meeting-points'),
+            ],
+            [
+                'id' => 'experience_products',
+                'label' => __('Experience products published', 'fp-esperienze'),
+                'description' => __('Publish an Experience product to expose your availability in the storefront.', 'fp-esperienze'),
+                'count' => $experienceProducts,
+                'completed' => $experienceProducts > 0,
+                'action' => admin_url('post-new.php?post_type=product'),
+            ],
+            [
+                'id' => 'active_schedules',
+                'label' => __('Schedules ready for booking', 'fp-esperienze'),
+                'description' => __('Configure at least one active schedule so time slots can be sold.', 'fp-esperienze'),
+                'count' => $schedules,
+                'completed' => $schedules > 0,
+                'action' => admin_url('edit.php?post_type=product'),
+            ],
+            [
+                'id' => 'payment_gateways',
+                'label' => __('Payment methods enabled', 'fp-esperienze'),
+                'description' => __('Enable at least one WooCommerce payment gateway to accept bookings.', 'fp-esperienze'),
+                'count' => $paymentGateways,
+                'completed' => $paymentGateways > 0,
+                'action' => admin_url('admin.php?page=wc-settings&tab=checkout'),
+            ],
+            [
+                'id' => 'email_notifications',
+                'label' => __('Order emails ready to send', 'fp-esperienze'),
+                'description' => __('Keep the WooCommerce customer processing/confirmation emails enabled so guests receive booking details.', 'fp-esperienze'),
+                'count' => $emails,
+                'completed' => $emails > 0,
+                'action' => admin_url('admin.php?page=wc-settings&tab=email'),
+            ],
+        ];
+
+        self::$checklistCache = $items;
+
+        return $items;
+    }
+
+    /**
+     * Provide a completion summary for UI and CLI usage.
+     *
+     * @return array{completed:int,total:int,percentage:float}
+     */
+    public static function getCompletionSummary(): array {
+        $items = self::getChecklistItems();
+        $total = count($items);
+        $completed = 0;
+
+        foreach ($items as $item) {
+            if (isset($item['completed']) && (bool) $item['completed']) {
+                $completed++;
+            }
+        }
+
+        $percentage = $total > 0 ? round(($completed / $total) * 100, 2) : 0.0;
+
+        return [
+            'completed' => $completed,
+            'total' => $total,
+            'percentage' => $percentage,
+        ];
+    }
+
+    /**
+     * Seed demo content (meeting point, experience product and schedule) to
+     * accelerate onboarding.
+     *
+     * @return array{status:string,message:string}
+     */
+    public static function seedDemoContent(): array {
+        $has_permission = false;
+        if (function_exists('current_user_can')) {
+            $has_permission = current_user_can('manage_woocommerce') === true;
+        }
+
+        if (!$has_permission && !self::isCli()) {
+            return [
+                'status' => 'error',
+                'message' => __('You do not have permission to create demo content.', 'fp-esperienze'),
+            ];
+        }
+
+        $already_seeded = (int) get_option('fp_esperienze_demo_content_created') === 1;
+        if ($already_seeded) {
+            return [
+                'status' => 'warning',
+                'message' => __('Demo content was already generated. You can safely customise or delete it.', 'fp-esperienze'),
+            ];
+        }
+
+        if (!self::isWooCommerceReady()) {
+            return [
+                'status' => 'error',
+                'message' => __('WooCommerce must be active to generate demo content.', 'fp-esperienze'),
+            ];
+        }
+
+        $meeting_point_id = self::ensureDemoMeetingPoint();
+        if ($meeting_point_id <= 0) {
+            return [
+                'status' => 'error',
+                'message' => __('Unable to create or reuse a meeting point for demo content.', 'fp-esperienze'),
+            ];
+        }
+
+        $product_id = self::ensureDemoExperienceProduct($meeting_point_id);
+        if ($product_id <= 0) {
+            return [
+                'status' => 'error',
+                'message' => __('Failed to create the demo experience product.', 'fp-esperienze'),
+            ];
+        }
+
+        self::ensureDemoSchedule($product_id, $meeting_point_id);
+
+        update_option('fp_esperienze_demo_content_created', 1, false);
+
+        return [
+            'status' => 'success',
+            'message' => __('Demo experience content created! Review it under Products → Experiences.', 'fp-esperienze'),
+        ];
+    }
+
+    /**
+     * Build aggregated booking statistics for the provided time frame.
+     *
+     * @param int $days Number of days to include (defaults to 1).
+     * @return array<string, mixed>
+     */
+    public static function getDailyReportData(int $days = 1): array {
+        $days = max(1, $days);
+
+        $end = new DateTimeImmutable(current_time('mysql'));
+        $start = $end->sub(new DateInterval('P' . $days . 'D'));
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'fp_bookings';
+
+        $table_exists = $wpdb->get_var(
+            $wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table))
+        );
+
+        if ($table_exists !== $table) {
+            return [
+                'range_start' => $start->format('Y-m-d'),
+                'range_end' => $end->format('Y-m-d'),
+                'by_day' => [],
+                'overall' => [
+                    'total_bookings' => 0,
+                    'participants' => 0,
+                    'revenue' => 0.0,
+                    'by_status' => [],
+                ],
+            ];
+        }
+
+        $results = (array) $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT DATE(booking_date) AS day, status, COUNT(*) AS total, SUM(participants) AS participants, SUM(total_amount) AS revenue
+                 FROM {$table}
+                 WHERE booking_date >= %s
+                 GROUP BY day, status
+                 ORDER BY day DESC",
+                $start->format('Y-m-d')
+            ),
+            'ARRAY_A'
+        );
+
+        $by_day = [];
+        $overall = [
+            'total_bookings' => 0,
+            'participants' => 0,
+            'revenue' => 0.0,
+            'by_status' => [],
+        ];
+
+        foreach ($results as $row) {
+            $day = $row['day'];
+            $status = $row['status'] ?? 'unknown';
+            $total = (int) ($row['total'] ?? 0);
+            $participants = (int) ($row['participants'] ?? 0);
+            $revenue = (float) ($row['revenue'] ?? 0.0);
+
+            if (!isset($by_day[$day])) {
+                $by_day[$day] = [
+                    'statuses' => [],
+                    'participants' => 0,
+                    'revenue' => 0.0,
+                    'bookings' => 0,
+                ];
+            }
+
+            $by_day[$day]['statuses'][$status] = (
+                $by_day[$day]['statuses'][$status] ?? 0
+            ) + $total;
+            $by_day[$day]['participants'] += $participants;
+            $by_day[$day]['revenue'] += $revenue;
+            $by_day[$day]['bookings'] += $total;
+
+            $overall['total_bookings'] += $total;
+            $overall['participants'] += $participants;
+            $overall['revenue'] += $revenue;
+            $overall['by_status'][$status] = (
+                $overall['by_status'][$status] ?? 0
+            ) + $total;
+        }
+
+        return [
+            'range_start' => $start->format('Y-m-d'),
+            'range_end' => $end->format('Y-m-d'),
+            'by_day' => $by_day,
+            'overall' => $overall,
+        ];
+    }
+
+    /**
+     * Count meeting points defined in the catalog.
+     */
+    private static function countMeetingPoints(): int {
+        if (!class_exists(MeetingPointManager::class)) {
+            return 0;
+        }
+
+        $meeting_points = MeetingPointManager::getAllMeetingPoints(false);
+
+        return count($meeting_points);
+    }
+
+    /**
+     * Count published experience products.
+     */
+    private static function countExperienceProducts(): int {
+        if (!function_exists('wc_get_products')) {
+            return 0;
+        }
+
+        $products = wc_get_products([
+            'type' => 'experience',
+            'limit' => -1,
+            'status' => ['publish', 'draft', 'pending'],
+            'return' => 'ids',
+        ]);
+
+        return is_array($products) ? count($products) : 0;
+    }
+
+    /**
+     * Count the number of active schedules.
+     */
+    private static function countSchedules(): int {
+        global $wpdb;
+        $table = $wpdb->prefix . 'fp_schedules';
+
+        $count = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE is_active = 1");
+
+        return $count;
+    }
+
+    /**
+     * Count enabled payment gateways.
+     */
+    private static function countPaymentGateways(): int {
+        if (!self::isWooCommerceReady()) {
+            return 0;
+        }
+
+        try {
+            $gateways = WC()->payment_gateways()->get_available_payment_gateways();
+        } catch (Exception $e) {
+            return 0;
+        }
+
+        return count($gateways);
+    }
+
+    /**
+     * Count enabled transactional emails that cover booking confirmations.
+     */
+    private static function countEnabledEmails(): int {
+        if (!class_exists('WC_Emails')) {
+            return 0;
+        }
+
+        $emails = \WC_Emails::instance()->get_emails();
+        $count = 0;
+
+        foreach ($emails as $email) {
+            if (!$email->is_enabled()) {
+                continue;
+            }
+
+            $identifier = method_exists($email, 'get_id') ? $email->get_id() : '';
+
+            if (in_array($identifier, ['customer_processing_order', 'customer_completed_order'], true)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Ensure WooCommerce is active and functional in the current context.
+     */
+    private static function isWooCommerceReady(): bool {
+        return function_exists('WC');
+    }
+
+    /**
+     * Detect whether the current execution context is WP-CLI.
+     */
+    private static function isCli(): bool {
+        if (!defined('WP_CLI')) {
+            return false;
+        }
+
+        $cli_flag = constant('WP_CLI');
+
+        return $cli_flag === true;
+    }
+
+    /**
+     * Create or reuse a meeting point suitable for demo data.
+     *
+     * @return int Meeting point ID or 0 on failure.
+     */
+    private static function ensureDemoMeetingPoint(): int {
+        $existing = MeetingPointManager::getAllMeetingPoints(false);
+        if ($existing !== []) {
+            $first = reset($existing);
+            if (is_object($first) && isset($first->id)) {
+                return (int) $first->id;
+            }
+        }
+
+        $data = [
+            'name' => __('Demo Waterfront Pier', 'fp-esperienze'),
+            'address' => __('Riva degli Schiavoni, 30122 Venezia VE, Italy', 'fp-esperienze'),
+            'lat' => 45.4335,
+            'lng' => 12.3462,
+            'note' => __('Meet the guide under the blue flag 15 minutes before departure.', 'fp-esperienze'),
+        ];
+
+        $meeting_point_id = MeetingPointManager::createMeetingPoint($data);
+
+        return is_int($meeting_point_id) ? $meeting_point_id : 0;
+    }
+
+    /**
+     * Create or reuse a demo experience product.
+     *
+     * @param int $meeting_point_id Meeting point ID.
+     * @return int Product ID or 0 on failure.
+     */
+    private static function ensureDemoExperienceProduct(int $meeting_point_id): int {
+        $existing = get_page_by_title('Sunset in Venice – Demo Experience', 'OBJECT', 'product');
+        if ($existing instanceof \WP_Post) {
+            wp_set_object_terms($existing->ID, 'experience', 'product_type');
+
+            /** @var int $existing_id */
+            $existing_id = $existing->ID;
+
+            return $existing_id;
+        }
+
+        /** @var int|\WP_Error $product_result */
+        $product_result = wp_insert_post([
+            'post_title' => 'Sunset in Venice – Demo Experience',
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'post_content' => __('<p>Experience a two-hour guided walk through the Venetian lagoon as the sun sets, featuring live storytelling, tasting of local cicchetti, and hidden viewpoints perfect for photos.</p>', 'fp-esperienze'),
+            'post_excerpt' => __('Guided sunset walk with tasting and live storytelling.', 'fp-esperienze'),
+        ]);
+
+        if (is_wp_error($product_result)) {
+            return 0;
+        }
+
+        /** @var int $product_id */
+        $product_id = $product_result;
+        if ($product_id <= 0) {
+            return 0;
+        }
+
+        wp_set_object_terms($product_id, 'experience', 'product_type');
+
+        update_post_meta($product_id, '_virtual', 'yes');
+        update_post_meta($product_id, '_sold_individually', 'no');
+        update_post_meta($product_id, '_manage_stock', 'no');
+        update_post_meta($product_id, '_regular_price', '79');
+        update_post_meta($product_id, '_price', '79');
+        update_post_meta($product_id, '_fp_experience_type', 'experience');
+        update_post_meta($product_id, '_fp_exp_included', __('Local guide, two cicchetti tastings, lagoon ferry ticket.', 'fp-esperienze'));
+        update_post_meta($product_id, '_fp_exp_excluded', __('Hotel pickup, personal expenses, travel insurance.', 'fp-esperienze'));
+        update_post_meta($product_id, '_experience_duration', 120);
+        update_post_meta($product_id, '_fp_exp_cutoff_minutes', 120);
+
+        // Flag the preferred meeting point for the default schedule builder UI.
+        update_post_meta($product_id, '_fp_default_meeting_point_id', $meeting_point_id);
+
+        return $product_id;
+    }
+
+    /**
+     * Ensure a recurring schedule exists for the demo experience.
+     *
+     * @param int $product_id Product ID.
+     * @param int $meeting_point_id Meeting point ID.
+     */
+    private static function ensureDemoSchedule(int $product_id, int $meeting_point_id): void {
+        global $wpdb;
+        $table = $wpdb->prefix . 'fp_schedules';
+        $existing = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM {$table} WHERE product_id = %d",
+                $product_id
+            )
+        );
+
+        if ($existing > 0) {
+            return;
+        }
+
+        ScheduleManager::createSchedule([
+            'product_id' => $product_id,
+            'schedule_type' => 'recurring',
+            'day_of_week' => 5, // Friday
+            'start_time' => '18:00:00',
+            'duration_min' => 120,
+            'capacity' => 18,
+            'lang' => 'en',
+            'meeting_point_id' => $meeting_point_id,
+            'price_adult' => 79,
+            'price_child' => 39,
+        ]);
+
+        ScheduleManager::createSchedule([
+            'product_id' => $product_id,
+            'schedule_type' => 'recurring',
+            'day_of_week' => 6, // Saturday
+            'start_time' => '18:30:00',
+            'duration_min' => 120,
+            'capacity' => 20,
+            'lang' => 'it',
+            'meeting_point_id' => $meeting_point_id,
+            'price_adult' => 79,
+            'price_child' => 39,
+        ]);
+    }
+
+}

--- a/includes/Admin/OnboardingNotice.php
+++ b/includes/Admin/OnboardingNotice.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Persistent onboarding reminder for administrators.
+ *
+ * @package FP\Esperienze\Admin
+ */
+
+namespace FP\Esperienze\Admin;
+
+use function absint;
+use function add_query_arg;
+use function admin_url;
+use function current_time;
+use function current_user_can;
+use function esc_html;
+use function esc_html__;
+use function esc_url;
+use function get_current_screen;
+use function get_current_user_id;
+use function get_user_meta;
+use function is_user_logged_in;
+use function remove_query_arg;
+use function update_user_meta;
+use function delete_user_meta;
+use function wp_get_referer;
+use function wp_nonce_url;
+use function wp_safe_redirect;
+use function wp_unslash;
+use function wp_verify_nonce;
+
+use const DAY_IN_SECONDS;
+use const WEEK_IN_SECONDS;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Display onboarding progress notice across key admin screens.
+ */
+class OnboardingNotice {
+    private const USER_META_KEY = 'fp_esperienze_onboarding_notice_dismissed_until';
+
+    /**
+     * Hook into admin lifecycle.
+     */
+    public function __construct() {
+        add_action('admin_init', [$this, 'maybeHandleDismiss']);
+        add_action('admin_notices', [$this, 'renderNotice']);
+    }
+
+    /**
+     * Handle "remind me later" dismissal links.
+     */
+    public function maybeHandleDismiss(): void {
+        if (!is_user_logged_in()) {
+            return;
+        }
+
+        if (!isset($_GET['fp_esperienze_dismiss_onboarding'])) { // phpcs:ignore WordPress.Security.NonceVerification
+            return;
+        }
+
+        if (!current_user_can('manage_woocommerce')) {
+            return;
+        }
+
+        $nonce = isset($_GET['_wpnonce']) ? wp_unslash($_GET['_wpnonce']) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+        if (!wp_verify_nonce($nonce, 'fp-esperienze-dismiss-onboarding')) {
+            return;
+        }
+
+        $snooze_days = isset($_GET['snooze']) ? absint(wp_unslash($_GET['snooze'])) : 7; // phpcs:ignore WordPress.Security.NonceVerification
+        if ($snooze_days <= 0) {
+            $snooze_days = 7;
+        }
+
+        $timestamp = current_time('timestamp') + ($snooze_days * DAY_IN_SECONDS);
+        update_user_meta(get_current_user_id(), self::USER_META_KEY, $timestamp);
+
+        $redirect = wp_get_referer();
+        if (!$redirect) {
+            $redirect = admin_url();
+        }
+
+        wp_safe_redirect(remove_query_arg(['fp_esperienze_dismiss_onboarding', '_wpnonce', 'snooze'], $redirect));
+        exit;
+    }
+
+    /**
+     * Render the onboarding notice when tasks are still pending.
+     */
+    public function renderNotice(): void {
+        if (!current_user_can('manage_woocommerce')) {
+            return;
+        }
+
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if ($screen !== null && !$this->isScreenAllowed($screen->id)) {
+            return;
+        }
+
+        $dismissed_until = (int) get_user_meta(get_current_user_id(), self::USER_META_KEY, true);
+        if ($dismissed_until > current_time('timestamp')) {
+            return;
+        }
+
+        $summary = OnboardingHelper::getCompletionSummary();
+        if ($summary['total'] === 0 || $summary['completed'] >= $summary['total']) {
+            if ($dismissed_until !== 0) {
+                delete_user_meta(get_current_user_id(), self::USER_META_KEY);
+            }
+            return;
+        }
+
+        $pending = array_filter(
+            OnboardingHelper::getChecklistItems(),
+            static fn($item) => empty($item['completed'])
+        );
+
+        if (empty($pending)) {
+            return;
+        }
+
+        $setup_url   = admin_url('admin.php?page=fp-esperienze-setup-wizard');
+        $dashboard   = admin_url('index.php');
+        $dismiss_url = wp_nonce_url(
+            add_query_arg(
+                [
+                    'fp_esperienze_dismiss_onboarding' => '1',
+                    'snooze' => WEEK_IN_SECONDS / DAY_IN_SECONDS,
+                ]
+            ),
+            'fp-esperienze-dismiss-onboarding'
+        );
+
+        echo '<div class="notice notice-warning fp-esperienze-onboarding-notice">';
+        echo '<p><strong>' . esc_html__('Complete the FP Esperienze onboarding checklist', 'fp-esperienze') . '</strong></p>';
+        printf(
+            '<p>%s</p>',
+            esc_html(
+                sprintf(
+                    // translators: 1: completed tasks, 2: total tasks.
+                    __('You have completed %1$d of %2$d onboarding tasks. Finish the remaining items to start selling your experiences.', 'fp-esperienze'),
+                    (int) $summary['completed'],
+                    (int) $summary['total']
+                )
+            )
+        );
+
+        echo '<ul class="fp-esperienze-onboarding-list">';
+        foreach ($pending as $item) {
+            $label = isset($item['label']) ? $item['label'] : '';
+            $description = isset($item['description']) ? $item['description'] : '';
+            $action = isset($item['action']) ? $item['action'] : '';
+
+            echo '<li>';
+            echo '<strong>' . esc_html($label) . '</strong>';
+            if (!empty($description)) {
+                echo '<span>' . esc_html($description) . '</span>';
+            }
+            if (!empty($action)) {
+                echo ' <a class="button-link" href="' . esc_url($action) . '">' . esc_html__('Open', 'fp-esperienze') . '</a>';
+            }
+            echo '</li>';
+        }
+        echo '</ul>';
+
+        echo '<p class="fp-esperienze-onboarding-actions">';
+        echo '<a class="button button-primary" href="' . esc_url($setup_url) . '">' . esc_html__('Launch setup wizard', 'fp-esperienze') . '</a> ';
+        echo '<a class="button" href="' . esc_url($dashboard) . '">' . esc_html__('Review checklist', 'fp-esperienze') . '</a> ';
+        echo '<a class="button-link" href="' . esc_url($dismiss_url) . '">' . esc_html__('Remind me later', 'fp-esperienze') . '</a>';
+        echo '</p>';
+
+        echo '</div>';
+    }
+
+    /**
+     * Limit the notice to relevant admin screens.
+     */
+    private function isScreenAllowed(string $screen_id): bool {
+        if ($screen_id === 'dashboard') {
+            return true;
+        }
+
+        if ($screen_id === 'toplevel_page_fp-esperienze') {
+            return true;
+        }
+
+        return str_starts_with($screen_id, 'fp-esperienze_page_');
+    }
+}

--- a/includes/Admin/OperationalAlerts.php
+++ b/includes/Admin/OperationalAlerts.php
@@ -1,0 +1,564 @@
+<?php
+/**
+ * Operational alerts and daily digest automation.
+ *
+ * @package FP\Esperienze\Admin
+ */
+
+namespace FP\Esperienze\Admin;
+
+use DateTimeImmutable;
+use FP\Esperienze\Admin\OnboardingHelper;
+use WP_Error;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Manage operational alerts (email and Slack) for booking performance.
+ */
+class OperationalAlerts {
+    public const OPTION_EMAIL_ENABLED = 'fp_esperienze_alerts_email_enabled';
+    public const OPTION_EMAIL_RECIPIENTS = 'fp_esperienze_alerts_email_recipients';
+    public const OPTION_SLACK_WEBHOOK = 'fp_esperienze_alerts_slack_webhook';
+    public const OPTION_MIN_BOOKINGS = 'fp_esperienze_alerts_min_bookings';
+    public const OPTION_LOOKBACK_DAYS = 'fp_esperienze_alerts_lookback_days';
+    public const OPTION_SEND_HOUR = 'fp_esperienze_alerts_send_hour';
+    public const OPTION_LAST_STATUS = 'fp_esperienze_alerts_last_status';
+    public const CRON_HOOK = 'fp_esperienze_send_daily_digest';
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action('admin_menu', [$this, 'registerMenu']);
+        add_action('admin_init', [$this, 'handleFormSubmission']);
+        add_action('init', [$this, 'maybeScheduleDigest']);
+        add_action(self::CRON_HOOK, [$this, 'handleScheduledDigest']);
+    }
+
+    /**
+     * Register submenu for operational alerts.
+     */
+    public function registerMenu(): void {
+        add_submenu_page(
+            'fp-esperienze',
+            __('Operational Alerts', 'fp-esperienze'),
+            __('Operational Alerts', 'fp-esperienze'),
+            'manage_woocommerce',
+            'fp-esperienze-operational-alerts',
+            [$this, 'renderPage']
+        );
+    }
+
+    /**
+     * Handle settings form submission.
+     */
+    public function handleFormSubmission(): void {
+        if (!isset($_POST['fp_esperienze_alerts_nonce'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        if (!wp_verify_nonce(wp_unslash($_POST['fp_esperienze_alerts_nonce']), 'fp_esperienze_alerts_save')) {
+            return;
+        }
+
+        if (!current_user_can('manage_woocommerce')) {
+            return;
+        }
+
+        $email_enabled = isset($_POST['fp_esperienze_alerts_email_enabled']) ? 1 : 0;
+        update_option(self::OPTION_EMAIL_ENABLED, $email_enabled);
+
+        $raw_recipients = sanitize_textarea_field(wp_unslash($_POST['fp_esperienze_alerts_email_recipients'] ?? ''));
+        update_option(self::OPTION_EMAIL_RECIPIENTS, $raw_recipients);
+
+        $slack_webhook = esc_url_raw(wp_unslash($_POST['fp_esperienze_alerts_slack_webhook'] ?? ''));
+        update_option(self::OPTION_SLACK_WEBHOOK, $slack_webhook);
+
+        $min_bookings = absint(wp_unslash($_POST['fp_esperienze_alerts_min_bookings'] ?? 0));
+        update_option(self::OPTION_MIN_BOOKINGS, $min_bookings);
+
+        $lookback_days = max(1, absint(wp_unslash($_POST['fp_esperienze_alerts_lookback_days'] ?? 1)));
+        update_option(self::OPTION_LOOKBACK_DAYS, $lookback_days);
+
+        $send_hour = absint(wp_unslash($_POST['fp_esperienze_alerts_send_hour'] ?? 7));
+        $send_hour = max(0, min(23, $send_hour));
+        update_option(self::OPTION_SEND_HOUR, $send_hour);
+
+        if (isset($_POST['fp_esperienze_alerts_send_now'])) {
+            $result = self::dispatchDigest('all', $lookback_days);
+            $this->storeLastStatus($result);
+            add_settings_error(
+                'fp_esperienze_alerts',
+                'fp_esperienze_alerts_send_now',
+                esc_html($result['message']),
+                $result['status'] === 'success' ? 'updated' : 'error'
+            );
+        } else {
+            add_settings_error(
+                'fp_esperienze_alerts',
+                'fp_esperienze_alerts_saved',
+                esc_html__('Operational alert settings saved.', 'fp-esperienze'),
+                'updated'
+            );
+        }
+
+        $this->maybeScheduleDigest(true);
+    }
+
+    /**
+     * Render settings page markup.
+     */
+    public function renderPage(): void {
+        settings_errors('fp_esperienze_alerts');
+
+        $email_enabled = (bool) get_option(self::OPTION_EMAIL_ENABLED, false);
+        $email_recipients = get_option(self::OPTION_EMAIL_RECIPIENTS, get_option('admin_email'));
+        $slack_webhook = get_option(self::OPTION_SLACK_WEBHOOK, '');
+        $min_bookings = (int) get_option(self::OPTION_MIN_BOOKINGS, 1);
+        $lookback_days = (int) get_option(self::OPTION_LOOKBACK_DAYS, 1);
+        $send_hour = (int) get_option(self::OPTION_SEND_HOUR, 7);
+        $last_status = get_option(self::OPTION_LAST_STATUS, []);
+
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Operational Alerts', 'fp-esperienze'); ?></h1>
+            <p class="description">
+                <?php esc_html_e('Receive automated booking digests and alerts when activity drops below expectations.', 'fp-esperienze'); ?>
+            </p>
+
+            <form method="post" action="">
+                <?php wp_nonce_field('fp_esperienze_alerts_save', 'fp_esperienze_alerts_nonce'); ?>
+
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row">
+                            <label for="fp_esperienze_alerts_email_enabled"><?php esc_html_e('Email digest', 'fp-esperienze'); ?></label>
+                        </th>
+                        <td>
+                            <label>
+                                <input type="checkbox" name="fp_esperienze_alerts_email_enabled" id="fp_esperienze_alerts_email_enabled" value="1" <?php checked($email_enabled); ?>>
+                                <?php esc_html_e('Send a daily digest email to the specified recipients.', 'fp-esperienze'); ?>
+                            </label>
+                            <p class="description"><?php esc_html_e('Separate multiple recipients with commas or line breaks.', 'fp-esperienze'); ?></p>
+                            <textarea name="fp_esperienze_alerts_email_recipients" id="fp_esperienze_alerts_email_recipients" rows="3" class="large-text"><?php echo esc_textarea($email_recipients); ?></textarea>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="fp_esperienze_alerts_slack_webhook"><?php esc_html_e('Slack webhook URL', 'fp-esperienze'); ?></label>
+                        </th>
+                        <td>
+                            <input type="url" name="fp_esperienze_alerts_slack_webhook" id="fp_esperienze_alerts_slack_webhook" value="<?php echo esc_attr($slack_webhook); ?>" class="regular-text" placeholder="https://hooks.slack.com/services/...">
+                            <p class="description"><?php esc_html_e('Optional: send the digest to a Slack channel via incoming webhook.', 'fp-esperienze'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="fp_esperienze_alerts_min_bookings"><?php esc_html_e('Minimum bookings threshold', 'fp-esperienze'); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" name="fp_esperienze_alerts_min_bookings" id="fp_esperienze_alerts_min_bookings" min="0" value="<?php echo esc_attr($min_bookings); ?>" class="small-text">
+                            <p class="description"><?php esc_html_e('Trigger a warning when total bookings within the period fall below this number.', 'fp-esperienze'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="fp_esperienze_alerts_lookback_days"><?php esc_html_e('Lookback window (days)', 'fp-esperienze'); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" name="fp_esperienze_alerts_lookback_days" id="fp_esperienze_alerts_lookback_days" min="1" max="30" value="<?php echo esc_attr($lookback_days); ?>" class="small-text">
+                            <p class="description"><?php esc_html_e('Include bookings from the last N days in the digest.', 'fp-esperienze'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="fp_esperienze_alerts_send_hour"><?php esc_html_e('Send time (hour)', 'fp-esperienze'); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" name="fp_esperienze_alerts_send_hour" id="fp_esperienze_alerts_send_hour" min="0" max="23" value="<?php echo esc_attr($send_hour); ?>" class="small-text">
+                            <p class="description"><?php esc_html_e('Uses the site timezone. The digest runs daily at the selected hour.', 'fp-esperienze'); ?></p>
+                        </td>
+                    </tr>
+                </table>
+
+                <p class="submit">
+                    <button type="submit" name="fp_esperienze_alerts_save" class="button button-primary"><?php esc_html_e('Save changes', 'fp-esperienze'); ?></button>
+                    <button type="submit" name="fp_esperienze_alerts_send_now" class="button"><?php esc_html_e('Send digest now', 'fp-esperienze'); ?></button>
+                </p>
+            </form>
+
+            <?php if (!empty($last_status) && is_array($last_status)) : ?>
+                <h2><?php esc_html_e('Last dispatch', 'fp-esperienze'); ?></h2>
+                <p>
+                    <strong><?php echo esc_html($last_status['timestamp'] ?? ''); ?></strong><br>
+                    <?php echo esc_html($last_status['message'] ?? ''); ?>
+                </p>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    /**
+     * Schedule or unschedule the digest cron event.
+     *
+     * @param bool $force_reschedule Force rescheduling even if already planned.
+     */
+    public function maybeScheduleDigest(bool $force_reschedule = false): void {
+        $enabled = $this->isDigestEnabled();
+        $scheduled = wp_next_scheduled(self::CRON_HOOK);
+
+        if ($enabled) {
+            if ($scheduled && $force_reschedule) {
+                wp_unschedule_event($scheduled, self::CRON_HOOK);
+                $scheduled = false;
+            }
+
+            if (!$scheduled) {
+                wp_schedule_event($this->calculateNextRunTimestamp(), 'daily', self::CRON_HOOK);
+            }
+        } elseif ($scheduled) {
+            wp_unschedule_event($scheduled, self::CRON_HOOK);
+        }
+    }
+
+    /**
+     * Handle scheduled digest execution.
+     */
+    public function handleScheduledDigest(): void {
+        $lookback = (int) get_option(self::OPTION_LOOKBACK_DAYS, 1);
+        $result = self::dispatchDigest('all', $lookback);
+        $this->storeLastStatus($result);
+
+        if ($result['status'] !== 'success') {
+            error_log('[FP Esperienze] Failed to dispatch daily digest: ' . $result['message']); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        }
+    }
+
+    /**
+     * Dispatch the digest to the configured channels.
+     *
+     * @param string $channel      Channel to use: email, slack, or all.
+     * @param int    $lookbackDays Number of days to include in the report.
+     *
+     * @return array{status:string,message:string}
+     */
+    public static function dispatchDigest(string $channel = 'all', int $lookbackDays = 1): array {
+        $lookbackDays = max(1, $lookbackDays);
+        $report = OnboardingHelper::getDailyReportData($lookbackDays);
+        $overall = $report['overall'];
+        $currency = get_option('woocommerce_currency', 'EUR');
+        $formattedRevenue = self::formatCurrency($overall['revenue'], $currency);
+
+        $summaryLine = sprintf(
+            /* translators: 1: total bookings, 2: participants, 3: formatted revenue */
+            __('Total bookings: %1$d (%2$d participants) – Revenue: %3$s', 'fp-esperienze'),
+            (int) $overall['total_bookings'],
+            (int) $overall['participants'],
+            $formattedRevenue
+        );
+
+        $lines = [
+            sprintf(
+                /* translators: %s: formatted date range */
+                __('FP Esperienze digest for %s', 'fp-esperienze'),
+                self::formatRange($report['range_start'], $report['range_end'])
+            ),
+            $summaryLine,
+            ''
+        ];
+
+        foreach ($report['by_day'] as $day => $data) {
+            $dayRevenue = self::formatCurrency($data['revenue'] ?? 0, $currency);
+            $lines[] = sprintf(
+                '%s · %d %s · %s',
+                wp_date(get_option('date_format', 'Y-m-d'), strtotime($day)),
+                (int) ($data['bookings'] ?? 0),
+                _n('booking', 'bookings', (int) ($data['bookings'] ?? 0), 'fp-esperienze'),
+                $dayRevenue
+            );
+        }
+
+        $minBookings = (int) get_option(self::OPTION_MIN_BOOKINGS, 0);
+        if ($minBookings > 0 && (int) $overall['total_bookings'] < $minBookings) {
+            $lines[] = '';
+            $lines[] = sprintf(
+                /* translators: %d: minimum bookings threshold */
+                __('⚠️ Alert: total bookings below the configured threshold of %d.', 'fp-esperienze'),
+                $minBookings
+            );
+        }
+
+        $body = implode("\n", $lines);
+        $sentChannels = [];
+        $channel = strtolower($channel);
+
+        if (in_array($channel, ['all', 'email'], true) && self::isEmailEnabled()) {
+            $sent = self::sendEmailDigest($body);
+            if ($sent instanceof WP_Error) {
+                return [
+                    'status' => 'error',
+                    'message' => $sent->get_error_message(),
+                ];
+            }
+
+            if ($sent) {
+                $sentChannels[] = 'email';
+            }
+        }
+
+        if (in_array($channel, ['all', 'slack'], true) && self::hasSlackWebhook()) {
+            $sent = self::sendSlackDigest($body, $summaryLine);
+            if ($sent instanceof WP_Error) {
+                return [
+                    'status' => 'error',
+                    'message' => $sent->get_error_message(),
+                ];
+            }
+
+            if ($sent) {
+                $sentChannels[] = 'slack';
+            }
+        }
+
+        if ($sentChannels === []) {
+            return [
+                'status' => 'warning',
+                'message' => __('No delivery channels configured. Update the operational alert settings.', 'fp-esperienze'),
+            ];
+        }
+
+        return [
+            'status' => 'success',
+            'message' => sprintf(
+                /* translators: %s: list of channels */
+                __('Digest dispatched via: %s', 'fp-esperienze'),
+                implode(', ', $sentChannels)
+            ),
+        ];
+    }
+
+    /**
+     * Determine if any delivery channel is enabled.
+     */
+    private function isDigestEnabled(): bool {
+        return self::isEmailEnabled() || self::hasSlackWebhook();
+    }
+
+    /**
+     * Store last dispatch status for display in the UI.
+     *
+     * @param array<string,string> $result Result payload.
+     */
+    private function storeLastStatus(array $result): void {
+        $timezone = wp_timezone();
+        $now = new DateTimeImmutable('now', $timezone);
+
+        update_option(
+            self::OPTION_LAST_STATUS,
+            [
+                'timestamp' => $now->format('Y-m-d H:i'),
+                'message' => $result['message'] ?? '',
+                'status' => $result['status'] ?? '',
+            ]
+        );
+    }
+
+    /**
+     * Format a revenue amount respecting WooCommerce formatting when available.
+     */
+    private static function formatCurrency(float $amount, string $currency): string {
+        if (function_exists('wc_price')) {
+            return trim(wp_strip_all_tags(wc_price($amount, ['currency' => $currency])));
+        }
+
+        return sprintf('%s %.2f', $currency, $amount);
+    }
+
+    /**
+     * Format date range for display.
+     */
+    private static function formatRange(string $start, string $end): string {
+        $format = get_option('date_format', 'Y-m-d');
+        $startDate = wp_date($format, strtotime($start));
+        $endDate = wp_date($format, strtotime($end));
+
+        if ($startDate === $endDate) {
+            return $startDate;
+        }
+
+        return $startDate . ' → ' . $endDate;
+    }
+
+    /**
+     * Send digest email.
+     *
+     * @param string $body Email body.
+     *
+     * @return bool|WP_Error
+     */
+    private static function sendEmailDigest(string $body) {
+        $recipients = self::getEmailRecipients();
+        if ($recipients === []) {
+            return new WP_Error('fp_esperienze_alerts_email', __('No email recipients configured.', 'fp-esperienze'));
+        }
+
+        $subject = __('FP Esperienze · Daily booking digest', 'fp-esperienze');
+        $headers = ['Content-Type: text/plain; charset=UTF-8'];
+
+        return wp_mail($recipients, $subject, $body, $headers);
+    }
+
+    /**
+     * Send digest to Slack webhook.
+     *
+     * @param string $body        Full digest body.
+     * @param string $summaryLine Summary used for the Slack message.
+     *
+     * @return bool|WP_Error
+     */
+    private static function sendSlackDigest(string $body, string $summaryLine) {
+        $webhook = get_option(self::OPTION_SLACK_WEBHOOK, '');
+        if ($webhook === '') {
+            return new WP_Error('fp_esperienze_alerts_slack', __('Slack webhook URL is missing.', 'fp-esperienze'));
+        }
+
+        $payload = [
+            'text' => $summaryLine,
+            'blocks' => [
+                [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => "*" . __('FP Esperienze · Daily booking digest', 'fp-esperienze') . "*\n" . $body,
+                    ],
+                ],
+            ],
+        ];
+
+        $response = wp_remote_post(
+            $webhook,
+            [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                ],
+                'body' => wp_json_encode($payload),
+                'timeout' => 10,
+            ]
+        );
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return new WP_Error('fp_esperienze_alerts_slack_http', __('Slack webhook returned a non-success status code.', 'fp-esperienze'));
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if email delivery is enabled.
+     */
+    private static function isEmailEnabled(): bool {
+        return (bool) get_option(self::OPTION_EMAIL_ENABLED, false);
+    }
+
+    /**
+     * Check if a Slack webhook is configured.
+     */
+    private static function hasSlackWebhook(): bool {
+        $webhook = get_option(self::OPTION_SLACK_WEBHOOK, '');
+
+        return is_string($webhook) && $webhook !== '';
+    }
+
+    /**
+     * Retrieve array of sanitized email recipients.
+     *
+     * @return array<int,string>
+     */
+    private static function getEmailRecipients(): array {
+        $raw = get_option(self::OPTION_EMAIL_RECIPIENTS, '');
+        if (!is_string($raw) || $raw === '') {
+            return [];
+        }
+
+        $pieces = preg_split('/[\n,]+/', $raw);
+        if (!is_array($pieces)) {
+            return [];
+        }
+
+        $emails = [];
+        foreach ($pieces as $piece) {
+            $piece = trim($piece);
+            if ($piece === '' || !is_email($piece)) {
+                continue;
+            }
+            $emails[] = $piece;
+        }
+
+        return array_unique($emails);
+    }
+
+    /**
+     * Return the list of delivery channels currently enabled.
+     *
+     * @return array<int,string>
+     */
+    public static function getEnabledChannels(): array {
+        $channels = [];
+
+        if (self::isEmailEnabled()) {
+            $channels[] = 'email';
+        }
+
+        if (self::hasSlackWebhook()) {
+            $channels[] = 'slack';
+        }
+
+        return $channels;
+    }
+
+    /**
+     * Retrieve the last digest dispatch status stored in the database.
+     *
+     * @return array<string,string>
+     */
+    public static function getLastStatus(): array {
+        $status = get_option(self::OPTION_LAST_STATUS, []);
+
+        return is_array($status) ? $status : [];
+    }
+
+    /**
+     * Determine when the next digest run is scheduled.
+     */
+    public static function getNextDigestTimestamp(): ?int {
+        $timestamp = wp_next_scheduled(self::CRON_HOOK);
+
+        if ($timestamp === false) {
+            return null;
+        }
+
+        return (int) $timestamp;
+    }
+
+    /**
+     * Calculate timestamp for the next digest run using site timezone.
+     */
+    private function calculateNextRunTimestamp(): int {
+        $hour = (int) get_option(self::OPTION_SEND_HOUR, 7);
+        $timezone = wp_timezone();
+        $now = new DateTimeImmutable('now', $timezone);
+        $next = $now->setTime($hour, 0, 0);
+
+        if ($next <= $now) {
+            $next = $next->modify('+1 day');
+        }
+
+        return $next->getTimestamp();
+    }
+}

--- a/includes/CLI/OnboardingCommand.php
+++ b/includes/CLI/OnboardingCommand.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * WP-CLI onboarding helpers for FP Esperienze.
+ *
+ * @package FP\Esperienze\CLI
+ */
+
+namespace FP\Esperienze\CLI;
+
+use FP\Esperienze\Admin\OnboardingHelper;
+use FP\Esperienze\Admin\OperationalAlerts;
+use WP_CLI;
+use WP_CLI_Command;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Provide onboarding utilities through WP-CLI.
+ */
+class OnboardingCommand extends WP_CLI_Command {
+    /**
+     * Display the onboarding checklist with completion status.
+     *
+     * ## OPTIONS
+     *
+     * [--format=<format>]
+     * : Render the output in a particular format. Accepted: table, json.
+     * ---
+     * default: table
+     * options:
+     *   - table
+     *   - json
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze onboarding checklist
+     *     wp fp-esperienze onboarding checklist --format=json
+     *
+     * @param array<int,string>       $args       Positional arguments.
+     * @param array<string,string>    $assoc_args Named arguments.
+     */
+    public function checklist(array $args, array $assoc_args): void {
+        $format = strtolower($assoc_args['format'] ?? 'table');
+
+        $items = OnboardingHelper::getChecklistItems();
+        $summary = OnboardingHelper::getCompletionSummary();
+
+        if ($format === 'json') {
+            WP_CLI::print_value([
+                'items' => $items,
+                'summary' => $summary,
+            ], ['format' => 'json']);
+            return;
+        }
+
+        $rows = [];
+        foreach ($items as $item) {
+            $rows[] = [
+                'task' => $item['label'] ?? '',
+                'status' => (isset($item['completed']) && (bool) $item['completed']) ? '✅' : '⏳',
+                'details' => ($item['description'] ?? ''),
+            ];
+        }
+
+        WP_CLI::log('== FP Esperienze Onboarding Checklist ==');
+        WP_CLI::log(sprintf(
+            'Progress: %d/%d completed (%.2f%%)',
+            $summary['completed'],
+            $summary['total'],
+            $summary['percentage']
+        ));
+        WP_CLI::log('');
+
+        if (function_exists('\\WP_CLI\\Utils\\format_items')) {
+            \WP_CLI\Utils\format_items('table', $rows, ['task', 'status', 'details']);
+        } else {
+            foreach ($rows as $row) {
+                WP_CLI::log(sprintf('%s - %s', $row['status'], $row['task']));
+            }
+        }
+    }
+
+    /**
+     * Seed demo meeting points, experiences, and schedules.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze onboarding seed-data
+     *
+     * @param array<int,string>    $args       Positional arguments.
+     * @param array<string,string> $assoc_args Named arguments.
+     */
+    public function seed_data(array $args, array $assoc_args): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        $result = OnboardingHelper::seedDemoContent();
+
+        $status = $result['status'];
+        $message = $result['message'];
+
+        switch ($status) {
+            case 'success':
+                WP_CLI::success($message);
+                break;
+            case 'warning':
+                WP_CLI::warning($message);
+                break;
+            case 'error':
+                WP_CLI::error($message, false);
+                break;
+            default:
+                WP_CLI::log($message);
+                break;
+        }
+    }
+
+    /**
+     * Print a daily booking report summarising participants and revenue.
+     *
+     * ## OPTIONS
+     *
+     * [--days=<days>]
+     * : Number of days to include (defaults to 1).
+     * ---
+     * default: 1
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze onboarding daily-report
+     *     wp fp-esperienze onboarding daily-report --days=7
+     *
+     * @param array<int,string>    $args       Positional arguments.
+     * @param array<string,string> $assoc_args Named arguments.
+     */
+    public function daily_report(array $args, array $assoc_args): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        $days = isset($assoc_args['days']) ? absint($assoc_args['days']) : 1;
+        $report = OnboardingHelper::getDailyReportData($days);
+
+        $currency = get_option('woocommerce_currency', 'EUR');
+        $formatRevenue = static function($amount) use ($currency): string {
+            if (function_exists('wc_price')) {
+                return trim(wp_strip_all_tags(wc_price((float) $amount, ['currency' => $currency])));
+            }
+
+            return sprintf('%s %.2f', $currency, (float) $amount);
+        };
+
+        $rows = [];
+        foreach ($report['by_day'] as $day => $data) {
+            $rows[] = [
+                'day' => $day,
+                'bookings' => $data['bookings'] ?? 0,
+                'participants' => $data['participants'] ?? 0,
+                'revenue' => $formatRevenue($data['revenue'] ?? 0),
+                'confirmed' => $data['statuses']['confirmed'] ?? 0,
+                'pending' => $data['statuses']['pending'] ?? 0,
+                'cancelled' => $data['statuses']['cancelled'] ?? 0,
+            ];
+        }
+
+        if ($rows === []) {
+            WP_CLI::warning(__('No bookings found for the selected period.', 'fp-esperienze'));
+        } else {
+            if (function_exists('\\WP_CLI\\Utils\\format_items')) {
+                \WP_CLI\Utils\format_items('table', $rows, ['day', 'bookings', 'participants', 'revenue', 'confirmed', 'pending', 'cancelled']);
+            } else {
+                WP_CLI::log(__('Install WP-CLI formatting utilities to render the table output.', 'fp-esperienze'));
+            }
+        }
+
+        $overall = $report['overall'];
+        WP_CLI::log('');
+        WP_CLI::log(sprintf(
+            __('Total bookings: %1$d (%2$d participants) – Revenue: %3$s', 'fp-esperienze'),
+            $overall['total_bookings'],
+            $overall['participants'],
+            $formatRevenue($overall['revenue'])
+        ));
+
+        $statuses = $overall['by_status'] ?? [];
+        if ($statuses !== []) {
+            WP_CLI::log(__('Breakdown by status:', 'fp-esperienze'));
+            foreach ($statuses as $status => $count) {
+                WP_CLI::log(sprintf(' - %s: %d', ucfirst((string) $status), (int) $count));
+            }
+        }
+    }
+
+    /**
+     * Send the operational digest via configured channels.
+     *
+     * ## OPTIONS
+     *
+     * [--channel=<channel>]
+     * : Delivery channel (email, slack, all). Defaults to all.
+     * ---
+     * default: all
+     * options:
+     *   - email
+     *   - slack
+     *   - all
+     * ---
+     *
+     * [--days=<days>]
+     * : Number of days to include (falls back to settings page value).
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze onboarding send-digest
+     *     wp fp-esperienze onboarding send-digest --channel=slack --days=3
+     *
+     * @param array<int,string>    $args       Positional arguments.
+     * @param array<string,string> $assoc_args Named arguments.
+     */
+    public function send_digest(array $args, array $assoc_args): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        $channel = strtolower($assoc_args['channel'] ?? 'all');
+        if (!in_array($channel, ['email', 'slack', 'all'], true)) {
+            WP_CLI::error(__('Invalid channel. Use email, slack, or all.', 'fp-esperienze'));
+        }
+
+        $days = isset($assoc_args['days']) ? absint($assoc_args['days']) : (int) get_option(OperationalAlerts::OPTION_LOOKBACK_DAYS, 1);
+        $days = max(1, $days);
+
+        $result = OperationalAlerts::dispatchDigest($channel, $days);
+
+        switch ($result['status']) {
+            case 'success':
+                WP_CLI::success($result['message']);
+                break;
+            case 'warning':
+                WP_CLI::warning($result['message']);
+                break;
+            default:
+                WP_CLI::error($result['message'], false);
+        }
+    }
+}

--- a/includes/CLI/OperationsCommand.php
+++ b/includes/CLI/OperationsCommand.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * WP-CLI operations health checks for FP Esperienze.
+ *
+ * @package FP\Esperienze\CLI
+ */
+
+namespace FP\Esperienze\CLI;
+
+use FP\Esperienze\Admin\OnboardingHelper;
+use FP\Esperienze\Admin\OperationalAlerts;
+use WP_CLI;
+use WP_CLI_Command;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Provide operational tooling for site reliability tasks.
+ */
+class OperationsCommand extends WP_CLI_Command {
+    /**
+     * Run the operational health checks.
+     *
+     * ## OPTIONS
+     *
+     * [--format=<format>]
+     * : Output format. Accepted values: table, json.
+     * ---
+     * default: table
+     * options:
+     *   - table
+     *   - json
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze operations health-check
+     *     wp fp-esperienze operations health-check --format=json
+     *
+     * @param array<int,string>    $args       Positional arguments.
+     * @param array<string,string> $assoc_args Named arguments.
+     */
+    public function health_check(array $args, array $assoc_args): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        $format = strtolower($assoc_args['format'] ?? 'table');
+
+        $checks = [];
+
+        $wooActive = class_exists('WooCommerce');
+        $checks[] = [
+            'check' => __('WooCommerce active', 'fp-esperienze'),
+            'result' => $wooActive ? 'pass' : 'fail',
+            'details' => $wooActive
+                ? __('WooCommerce detected and ready.', 'fp-esperienze')
+                : __('WooCommerce is not active; activate it to process bookings.', 'fp-esperienze'),
+        ];
+
+        $channels = OperationalAlerts::getEnabledChannels();
+        $channelLabels = array_map(
+            static function(string $channel): string {
+                switch ($channel) {
+                    case 'email':
+                        return __('Email', 'fp-esperienze');
+                    case 'slack':
+                        return __('Slack', 'fp-esperienze');
+                    default:
+                        return ucfirst($channel);
+                }
+            },
+            $channels
+        );
+        $hasChannels = $channels !== [];
+        $checks[] = [
+            'check' => __('Operational digest channels', 'fp-esperienze'),
+            'result' => $hasChannels ? 'pass' : 'warn',
+            'details' => $hasChannels
+                ? sprintf(__('Enabled: %s', 'fp-esperienze'), implode(', ', $channelLabels))
+                : __('No delivery channel configured. Enable email or Slack alerts from the Operational Alerts page.', 'fp-esperienze'),
+        ];
+
+        $nextDigest = OperationalAlerts::getNextDigestTimestamp();
+        $cronDisabled = defined('DISABLE_WP_CRON') && DISABLE_WP_CRON;
+        $digestResult = 'warn';
+        if ($nextDigest !== null) {
+            $digestResult = 'pass';
+        } elseif ($hasChannels) {
+            $digestResult = $cronDisabled ? 'warn' : 'fail';
+        }
+
+        $datetimeFormat = sprintf('%s %s', get_option('date_format', 'Y-m-d'), get_option('time_format', 'H:i'));
+        $digestDetails = $nextDigest !== null
+            ? sprintf(
+                __('Next run at %s.', 'fp-esperienze'),
+                wp_date($datetimeFormat, $nextDigest)
+            )
+            : __('Digest cron is not currently scheduled.', 'fp-esperienze');
+
+        if ($cronDisabled) {
+            $digestDetails .= ' ' . __('WP Cron is disabled; ensure a real cron job triggers wp-cron.php.', 'fp-esperienze');
+        }
+
+        $checks[] = [
+            'check' => __('Daily digest schedule', 'fp-esperienze'),
+            'result' => $digestResult,
+            'details' => $digestDetails,
+        ];
+
+        $lastStatus = OperationalAlerts::getLastStatus();
+        if ($lastStatus !== []) {
+            $statusKey = strtolower($lastStatus['status'] ?? '');
+            switch ($statusKey) {
+                case 'success':
+                    $statusResult = 'pass';
+                    break;
+                case 'warning':
+                    $statusResult = 'warn';
+                    break;
+                case 'error':
+                    $statusResult = 'fail';
+                    break;
+                default:
+                    $statusResult = 'warn';
+                    break;
+            }
+
+            $timestamp = $lastStatus['timestamp'] ?? '';
+            $message = $lastStatus['message'] ?? '';
+            $details = trim($timestamp !== '' ? sprintf('%s — %s', $timestamp, $message) : $message);
+            if ($details === '') {
+                $details = __('Last dispatch did not return a status message.', 'fp-esperienze');
+            }
+
+            $checks[] = [
+                'check' => __('Last digest result', 'fp-esperienze'),
+                'result' => $statusResult,
+                'details' => $details,
+            ];
+        } else {
+            $checks[] = [
+                'check' => __('Last digest result', 'fp-esperienze'),
+                'result' => 'warn',
+                'details' => __('No digest has been sent yet. Trigger one from the Operational Alerts page or via WP-CLI.', 'fp-esperienze'),
+            ];
+        }
+
+        $items = OnboardingHelper::getChecklistItems();
+        $pending = array_filter($items, static function(array $item): bool {
+            return empty($item['completed']);
+        });
+        if ($pending === []) {
+            $checks[] = [
+                'check' => __('Onboarding checklist', 'fp-esperienze'),
+                'result' => 'pass',
+                'details' => __('All onboarding prerequisites satisfied.', 'fp-esperienze'),
+            ];
+        } else {
+            $labels = array_map(static function(array $item): string {
+                return (string) ($item['label'] ?? $item['id'] ?? '');
+            }, $pending);
+
+            $checks[] = [
+                'check' => __('Onboarding checklist', 'fp-esperienze'),
+                'result' => 'warn',
+                'details' => sprintf(
+                    /* translators: %s: comma separated list of pending onboarding tasks */
+                    __('Pending: %s', 'fp-esperienze'),
+                    implode(', ', $labels)
+                ),
+            ];
+        }
+
+        $summary = [
+            'pass' => 0,
+            'warn' => 0,
+            'fail' => 0,
+        ];
+
+        foreach ($checks as $check) {
+            $key = $check['result'];
+            if (!isset($summary[$key])) {
+                $summary[$key] = 0;
+            }
+            $summary[$key]++;
+        }
+
+        if ($format === 'json') {
+            WP_CLI::print_value([
+                'checks' => $checks,
+                'summary' => [
+                    'pass' => $summary['pass'],
+                    'warn' => $summary['warn'],
+                    'fail' => $summary['fail'],
+                ],
+            ], ['format' => 'json']);
+            return;
+        }
+
+        $iconMap = [
+            'pass' => '✅',
+            'warn' => '⚠️',
+            'fail' => '❌',
+        ];
+
+        $rows = array_map(
+            static function(array $check) use ($iconMap): array {
+                $icon = $iconMap[$check['result']] ?? $iconMap['warn'];
+
+                return [
+                    'check' => $check['check'],
+                    'status' => $icon,
+                    'details' => $check['details'],
+                ];
+            },
+            $checks
+        );
+
+        WP_CLI::log('== FP Esperienze Operational Health ==');
+        WP_CLI::log('');
+
+        if (function_exists('\\WP_CLI\\Utils\\format_items')) {
+            \WP_CLI\Utils\format_items('table', $rows, ['check', 'status', 'details']);
+        } else {
+            foreach ($rows as $row) {
+                WP_CLI::log(sprintf('%s %s — %s', $row['status'], $row['check'], $row['details']));
+            }
+        }
+
+        WP_CLI::log('');
+        WP_CLI::log(sprintf(
+            __('Summary: %1$d pass · %2$d warnings · %3$d failures', 'fp-esperienze'),
+            $summary['pass'],
+            $summary['warn'],
+            $summary['fail']
+        ));
+    }
+}

--- a/includes/CLI/QualityAssuranceCommand.php
+++ b/includes/CLI/QualityAssuranceCommand.php
@@ -1,0 +1,478 @@
+<?php
+/**
+ * WP-CLI automation for the FP Esperienze manual test checklist.
+ *
+ * @package FP\Esperienze\CLI
+ */
+
+namespace FP\Esperienze\CLI;
+
+use FP\Esperienze\Admin\OnboardingHelper;
+use FP\Esperienze\Admin\OperationalAlerts;
+use Throwable;
+use WP_CLI;
+use WP_CLI_Command;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Provide automated quality assurance checks through WP-CLI.
+ */
+class QualityAssuranceCommand extends WP_CLI_Command {
+    /**
+     * Run the automated smoke checks that mirror the manual QA list.
+     *
+     * ## OPTIONS
+     *
+     * [--only=<ids>]
+     * : Comma separated list of check identifiers to run (defaults to all).
+     *
+     * [--format=<format>]
+     * : Render the output in a particular format. Accepted: table, json.
+     * ---
+     * default: table
+     * options:
+     *   - table
+     *   - json
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze qa run
+     *     wp fp-esperienze qa run --only=experience_product_type,digest_schedule
+     *     wp fp-esperienze qa run --format=json
+     *
+     * @param array<int,string>    $args       Positional arguments.
+     * @param array<string,string> $assoc_args Named arguments.
+     */
+    public function run(array $args, array $assoc_args): void {
+        $format = strtolower($assoc_args['format'] ?? 'table');
+        $only = isset($assoc_args['only']) ? $this->parseOnlyArgument($assoc_args['only']) : [];
+
+        $checks = $this->getChecks();
+        $executed = [];
+
+        foreach ($checks as $check) {
+            if ($only !== [] && !in_array($check['id'], $only, true)) {
+                continue;
+            }
+
+            $result = $this->executeCheck($check['callback']);
+
+            $executed[] = [
+                'id' => $check['id'],
+                'label' => $check['label'],
+                'description' => $check['description'],
+                'status' => $result['status'],
+                'message' => $result['message'],
+            ];
+        }
+
+        if ($executed === []) {
+            WP_CLI::warning(__('No matching QA checks were executed.', 'fp-esperienze'));
+            return;
+        }
+
+        $overall = $this->determineOverallStatus($executed);
+
+        if ($format === 'json') {
+            WP_CLI::print_value([
+                'overall_status' => $overall,
+                'checks' => $executed,
+            ], ['format' => 'json']);
+            $this->exitForStatus($overall);
+            return;
+        }
+
+        WP_CLI::log('== FP Esperienze QA Automation ==');
+        WP_CLI::log(sprintf('Overall status: %s', $this->formatStatusLabel($overall)));
+        WP_CLI::log('');
+
+        $rows = [];
+        foreach ($executed as $result) {
+            $rows[] = [
+                'check' => $result['label'],
+                'status' => sprintf('%s %s', $this->getStatusIcon($result['status']), strtoupper($result['status'])),
+                'details' => $result['message'],
+            ];
+        }
+
+        if (function_exists('\\WP_CLI\\Utils\\format_items')) {
+            \WP_CLI\Utils\format_items('table', $rows, ['check', 'status', 'details']);
+        } else {
+            foreach ($rows as $row) {
+                WP_CLI::log(sprintf('%s - %s', $row['status'], $row['check']));
+                if (!empty($row['details'])) {
+                    WP_CLI::log('  ' . $row['details']);
+                }
+            }
+        }
+
+        $this->exitForStatus($overall);
+    }
+
+    /**
+     * List the available QA checks.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-esperienze qa list
+     *
+     * @param array<int,string>    $args       Positional arguments.
+     * @param array<string,string> $assoc_args Named arguments.
+     */
+    public function list_checks(array $args, array $assoc_args): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+        $rows = [];
+        foreach ($this->getChecks() as $check) {
+            $rows[] = [
+                'id' => $check['id'],
+                'check' => $check['label'],
+                'description' => $check['description'],
+            ];
+        }
+
+        if (function_exists('\\WP_CLI\\Utils\\format_items')) {
+            \WP_CLI\Utils\format_items('table', $rows, ['id', 'check', 'description']);
+        } else {
+            foreach ($rows as $row) {
+                WP_CLI::log(sprintf('%s: %s', $row['id'], $row['check']));
+                if (!empty($row['description'])) {
+                    WP_CLI::log('  ' . $row['description']);
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse the --only option into a sanitised list of identifiers.
+     *
+     * @param string $value Raw --only argument.
+     * @return array<int,string>
+     */
+    private function parseOnlyArgument(string $value): array {
+        $parts = array_filter(array_map('trim', explode(',', $value)));
+
+        return array_values(array_unique($parts));
+    }
+
+    /**
+     * Execute a QA check safely.
+     *
+     * @param callable $callback Check callback.
+     * @return array{status:string,message:string}
+     */
+    private function executeCheck(callable $callback): array {
+        try {
+            $result = call_user_func($callback);
+        } catch (Throwable $e) {
+            return [
+                'status' => 'fail',
+                'message' => sprintf('Check failed with error: %s', $e->getMessage()),
+            ];
+        }
+
+        $status = $result['status'] ?? 'warning';
+        $message = $result['message'] ?? '';
+
+        return [
+            'status' => $status,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * Determine the overall run status.
+     *
+     * @param array<int,array<string,string>> $results Individual check outcomes.
+     * @return string
+     */
+    private function determineOverallStatus(array $results): string {
+        $overall = 'pass';
+
+        foreach ($results as $result) {
+            $status = $result['status'];
+            if ($status === 'fail' || $status === 'error') {
+                return 'fail';
+            }
+
+            if ($status === 'warning') {
+                $overall = 'warning';
+            }
+        }
+
+        return $overall;
+    }
+
+    /**
+     * Exit the command with an appropriate severity.
+     *
+     * @param string $status Overall status.
+     */
+    private function exitForStatus(string $status): void {
+        if ($status === 'pass') {
+            WP_CLI::success(__('All QA checks passed.', 'fp-esperienze'));
+            return;
+        }
+
+        if ($status === 'warning') {
+            WP_CLI::warning(__('QA checks completed with warnings. Review the table above.', 'fp-esperienze'));
+            return;
+        }
+
+        WP_CLI::error(__('QA checks failed. Resolve the failing items before releasing.', 'fp-esperienze'), false);
+    }
+
+    /**
+     * Format a status label for CLI output.
+     *
+     * @param string $status Status identifier.
+     * @return string
+     */
+    private function formatStatusLabel(string $status): string {
+        return match ($status) {
+            'pass' => __('PASS – production ready', 'fp-esperienze'),
+            'warning' => __('WARNING – needs review', 'fp-esperienze'),
+            default => __('FAIL – action required', 'fp-esperienze'),
+        };
+    }
+
+    /**
+     * Map statuses to icons.
+     *
+     * @param string $status Status identifier.
+     * @return string
+     */
+    private function getStatusIcon(string $status): string {
+        return match ($status) {
+            'pass' => '✅',
+            'warning' => '⚠️',
+            'fail', 'error' => '❌',
+            default => 'ℹ️',
+        };
+    }
+
+    /**
+     * Provide the QA check definitions.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function getChecks(): array {
+        return [
+            [
+                'id' => 'experience_product_type',
+                'label' => __('Experience product type registered', 'fp-esperienze'),
+                'description' => __('Ensures the WooCommerce "experience" product type is available so bookings can be sold.', 'fp-esperienze'),
+                'callback' => [$this, 'checkExperienceProductType'],
+            ],
+            [
+                'id' => 'onboarding_checklist',
+                'label' => __('Onboarding checklist complete', 'fp-esperienze'),
+                'description' => __('Verifies that the core onboarding prerequisites are satisfied.', 'fp-esperienze'),
+                'callback' => [$this, 'checkOnboardingChecklist'],
+            ],
+            [
+                'id' => 'demo_content',
+                'label' => __('Demo content seeded', 'fp-esperienze'),
+                'description' => __('Confirms the optional demo meeting point, experience and schedule have been generated for training.', 'fp-esperienze'),
+                'callback' => [$this, 'checkDemoContent'],
+            ],
+            [
+                'id' => 'digest_schedule',
+                'label' => __('Operational digest scheduled', 'fp-esperienze'),
+                'description' => __('Checks that at least one operational alert channel is configured and the cron event is scheduled.', 'fp-esperienze'),
+                'callback' => [$this, 'checkDigestSchedule'],
+            ],
+            [
+                'id' => 'rest_routes',
+                'label' => __('REST API routes registered', 'fp-esperienze'),
+                'description' => __('Ensures the public REST API endpoints used by the widget and integrations are available.', 'fp-esperienze'),
+                'callback' => [$this, 'checkRestRoutes'],
+            ],
+        ];
+    }
+
+    /**
+     * Ensure the experience product type exists.
+     *
+     * @return array{status:string,message:string}
+     */
+    private function checkExperienceProductType(): array {
+        if (!function_exists('wc_get_product_types')) {
+            return [
+                'status' => 'fail',
+                'message' => __('WooCommerce functions are unavailable. Activate WooCommerce before running QA checks.', 'fp-esperienze'),
+            ];
+        }
+
+        $types = wc_get_product_types();
+        if (isset($types['experience'])) {
+            return [
+                'status' => 'pass',
+                'message' => __('The experience product type is registered.', 'fp-esperienze'),
+            ];
+        }
+
+        return [
+            'status' => 'fail',
+            'message' => __('Experience product type missing. Visit the plugin settings to trigger a reinitialisation.', 'fp-esperienze'),
+        ];
+    }
+
+    /**
+     * Validate onboarding checklist completion.
+     *
+     * @return array{status:string,message:string}
+     */
+    private function checkOnboardingChecklist(): array {
+        if (!class_exists(OnboardingHelper::class)) {
+            return [
+                'status' => 'warning',
+                'message' => __('Onboarding helper unavailable. Load the admin environment to generate checklist data.', 'fp-esperienze'),
+            ];
+        }
+
+        $summary = OnboardingHelper::getCompletionSummary();
+        if (($summary['total'] ?? 0) === 0) {
+            return [
+                'status' => 'warning',
+                'message' => __('No onboarding tasks were detected. Verify the helper configuration.', 'fp-esperienze'),
+            ];
+        }
+
+        if ($summary['completed'] >= $summary['total']) {
+            return [
+                'status' => 'pass',
+                'message' => __('All onboarding prerequisites are satisfied.', 'fp-esperienze'),
+            ];
+        }
+
+        return [
+            'status' => 'warning',
+            'message' => sprintf(
+                /* translators: 1: completed tasks, 2: total tasks, 3: percentage */
+                __('%1$d of %2$d onboarding tasks complete (%.2f%%). Finish the checklist before going live.', 'fp-esperienze'),
+                (int) $summary['completed'],
+                (int) $summary['total'],
+                (float) $summary['percentage']
+            ),
+        ];
+    }
+
+    /**
+     * Confirm demo content seeding state.
+     *
+     * @return array{status:string,message:string}
+     */
+    private function checkDemoContent(): array {
+        $flag = (int) get_option('fp_esperienze_demo_content_created', 0);
+        if ($flag === 1) {
+            return [
+                'status' => 'pass',
+                'message' => __('Demo content is available for training and walkthroughs.', 'fp-esperienze'),
+            ];
+        }
+
+        return [
+            'status' => 'warning',
+            'message' => __('Demo content not found. Run "wp fp-esperienze onboarding seed-data" to generate sample data.', 'fp-esperienze'),
+        ];
+    }
+
+    /**
+     * Ensure the operational digest cron is configured.
+     *
+     * @return array{status:string,message:string}
+     */
+    private function checkDigestSchedule(): array {
+        $emailEnabled = (bool) get_option(OperationalAlerts::OPTION_EMAIL_ENABLED, false);
+        $hasSlack = (bool) get_option(OperationalAlerts::OPTION_SLACK_WEBHOOK, '') !== '';
+
+        if (!$emailEnabled && !$hasSlack) {
+            return [
+                'status' => 'warning',
+                'message' => __('No operational alert channels configured. Enable email or Slack digests.', 'fp-esperienze'),
+            ];
+        }
+
+        if (!function_exists('wp_next_scheduled')) {
+            return [
+                'status' => 'warning',
+                'message' => __('wp_next_scheduled() unavailable. Cron may be disabled in this environment.', 'fp-esperienze'),
+            ];
+        }
+
+        $timestamp = wp_next_scheduled(OperationalAlerts::CRON_HOOK);
+        if ($timestamp === false) {
+            return [
+                'status' => 'fail',
+                'message' => __('Operational digest not scheduled. Save the alert settings to reschedule the cron event.', 'fp-esperienze'),
+            ];
+        }
+
+        $formatted = function_exists('wp_date')
+            ? wp_date(get_option('date_format', 'Y-m-d') . ' ' . get_option('time_format', 'H:i'), $timestamp)
+            : date_i18n('Y-m-d H:i', $timestamp);
+
+        return [
+            'status' => 'pass',
+            'message' => sprintf(
+                /* translators: %s: formatted datetime */
+                __('Operational digest scheduled for %s.', 'fp-esperienze'),
+                $formatted
+            ),
+        ];
+    }
+
+    /**
+     * Verify key REST API routes are present.
+     *
+     * @return array{status:string,message:string}
+     */
+    private function checkRestRoutes(): array {
+        if (!function_exists('rest_get_server')) {
+            return [
+                'status' => 'warning',
+                'message' => __('REST API server unavailable. Ensure the REST API is enabled.', 'fp-esperienze'),
+            ];
+        }
+
+        $server = rest_get_server();
+        if (!$server) {
+            return [
+                'status' => 'warning',
+                'message' => __('REST API server not initialised. Trigger rest_api_init before running the QA checks.', 'fp-esperienze'),
+            ];
+        }
+
+        $routes = array_keys($server->get_routes());
+        $required = [
+            '/fp-exp/v1/availability',
+            '/fp-exp/v1/bookings',
+            '/fp-exp/v1/widget/data/(?P<product_id>\\d+)',
+            '/fp-esperienze/v1/events',
+        ];
+
+        $missing = [];
+        foreach ($required as $route) {
+            if (!in_array($route, $routes, true)) {
+                $missing[] = $route;
+            }
+        }
+
+        if ($missing === []) {
+            return [
+                'status' => 'pass',
+                'message' => __('Core REST API routes are registered.', 'fp-esperienze'),
+            ];
+        }
+
+        return [
+            'status' => 'fail',
+            'message' => sprintf(
+                /* translators: %s: comma separated route list */
+                __('Missing REST API routes: %s', 'fp-esperienze'),
+                implode(', ', $missing)
+            ),
+        ];
+    }
+}

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -10,6 +10,8 @@ namespace FP\Esperienze\Core;
 use FP\Esperienze\ProductType\Experience;
 use FP\Esperienze\Admin\MenuManager;
 use FP\Esperienze\Admin\FeatureDemoPage;
+use FP\Esperienze\Admin\OnboardingDashboardWidget;
+use FP\Esperienze\Admin\OnboardingNotice;
 use FP\Esperienze\Frontend\Shortcodes;
 use FP\Esperienze\Frontend\Templates;
 use FP\Esperienze\Frontend\SEOManager;
@@ -310,7 +312,9 @@ class Plugin {
      */
     public function initAdmin(): void {
         new MenuManager();
-        
+        new OnboardingDashboardWidget();
+        new OnboardingNotice();
+
         // Initialize feature demo page (temporary for testing new features)
         if (defined('WP_DEBUG') && WP_DEBUG) {
             FeatureDemoPage::init();
@@ -486,7 +490,8 @@ class Plugin {
         new ICSAPI();
         new SecurePDFAPI();
         new \FP\Esperienze\REST\WidgetAPI();
-        
+        new \FP\Esperienze\REST\SystemStatusAPI();
+
         // Initialize mobile API manager
         new \FP\Esperienze\REST\MobileAPIManager();
     }

--- a/includes/Core/SiteHealth.php
+++ b/includes/Core/SiteHealth.php
@@ -7,6 +7,11 @@
 
 namespace FP\Esperienze\Core;
 
+use FP\Esperienze\Admin\OnboardingHelper;
+use FP\Esperienze\Admin\OperationalAlerts;
+use FP\Esperienze\Core\ProductionValidator;
+use Throwable;
+
 use function esc_html;
 use function esc_html__;
 use function esc_url;
@@ -52,6 +57,21 @@ class SiteHealth {
             'test'  => array(__CLASS__, 'runCronTest'),
         );
 
+        $tests['direct']['fp_esperienze_onboarding'] = array(
+            'label' => esc_html__('FP Esperienze onboarding progress', 'fp-esperienze'),
+            'test'  => array(__CLASS__, 'runOnboardingTest'),
+        );
+
+        $tests['direct']['fp_esperienze_operational_alerts'] = array(
+            'label' => esc_html__('FP Esperienze operational alerts', 'fp-esperienze'),
+            'test'  => array(__CLASS__, 'runOperationalAlertsTest'),
+        );
+
+        $tests['direct']['fp_esperienze_production_readiness'] = array(
+            'label' => esc_html__('FP Esperienze production readiness', 'fp-esperienze'),
+            'test'  => array(__CLASS__, 'runProductionReadinessTest'),
+        );
+
         return $tests;
     }
 
@@ -61,7 +81,10 @@ class SiteHealth {
      * @return array
      */
     public static function runDependencyTest(): array {
-        $result = self::getBaseResult('fp_esperienze_dependencies');
+        $result = self::getBaseResult(
+            'fp_esperienze_dependencies',
+            esc_html__('All dependencies detected.', 'fp-esperienze')
+        );
 
         $issues = array();
 
@@ -94,7 +117,10 @@ class SiteHealth {
      * @return array
      */
     public static function runFilesystemTest(): array {
-        $result = self::getBaseResult('fp_esperienze_filesystem');
+        $result = self::getBaseResult(
+            'fp_esperienze_filesystem',
+            esc_html__('Required directories are writable.', 'fp-esperienze')
+        );
 
         $paths = array(
             WP_CONTENT_DIR . '/fp-private' => esc_html__('The fp-private directory must be writable.', 'fp-esperienze'),
@@ -130,7 +156,10 @@ class SiteHealth {
      * @return array
      */
     public static function runCronTest(): array {
-        $result = self::getBaseResult('fp_esperienze_scheduled_events');
+        $result = self::getBaseResult(
+            'fp_esperienze_scheduled_events',
+            esc_html__('Scheduled events are registered.', 'fp-esperienze')
+        );
 
         $events = array(
             TranslationQueue::CRON_HOOK,
@@ -157,13 +186,261 @@ class SiteHealth {
     }
 
     /**
+     * Highlight onboarding checklist completion in Site Health.
+     */
+    public static function runOnboardingTest(): array {
+        $result = self::getBaseResult(
+            'fp_esperienze_onboarding',
+            esc_html__('Onboarding checklist completed.', 'fp-esperienze')
+        );
+
+        if (!class_exists(OnboardingHelper::class)) {
+            $result['status']      = 'recommended';
+            $result['description'] = self::buildDescription(
+                array(
+                    esc_html__('Onboarding helpers are unavailable. Update FP Esperienze to the latest version.', 'fp-esperienze'),
+                )
+            );
+
+            return $result;
+        }
+
+        try {
+            $summary = OnboardingHelper::getCompletionSummary();
+            $items   = OnboardingHelper::getChecklistItems();
+        } catch (Throwable $exception) {
+            $result['status']      = 'recommended';
+            $result['description'] = self::buildDescription(
+                array(
+                    esc_html__('Unable to evaluate onboarding progress.', 'fp-esperienze'),
+                    esc_html($exception->getMessage()),
+                )
+            );
+
+            return $result;
+        }
+
+        $completed = isset($summary['completed']) ? (int) $summary['completed'] : 0;
+        $total     = isset($summary['total']) ? (int) $summary['total'] : 0;
+        $percent   = isset($summary['percentage']) ? (int) $summary['percentage'] : 0;
+
+        $messages = array(
+            sprintf(
+                esc_html__('%1$d of %2$d onboarding tasks completed (%3$d%%).', 'fp-esperienze'),
+                $completed,
+                $total,
+                $percent
+            ),
+        );
+
+        $pending = array();
+        foreach ($items as $item) {
+            $is_complete = !empty($item['completed']);
+            if ($is_complete) {
+                continue;
+            }
+
+            $label = '';
+            if (isset($item['label']) && $item['label'] !== '') {
+                $label = (string) $item['label'];
+            } elseif (isset($item['id']) && $item['id'] !== '') {
+                $label = (string) $item['id'];
+            }
+
+            if ($label !== '') {
+                $pending[] = esc_html($label);
+            }
+        }
+
+        if (!empty($pending)) {
+            $result['status'] = 'recommended';
+            $messages[]       = sprintf(
+                esc_html__('Pending tasks: %s', 'fp-esperienze'),
+                implode(', ', $pending)
+            );
+        }
+
+        $result['description'] = self::buildDescription($messages);
+
+        return $result;
+    }
+
+    /**
+     * Confirm operational alerts are configured and healthy.
+     */
+    public static function runOperationalAlertsTest(): array {
+        $result = self::getBaseResult(
+            'fp_esperienze_operational_alerts',
+            esc_html__('Operational digests configured.', 'fp-esperienze')
+        );
+
+        if (!class_exists(OperationalAlerts::class)) {
+            $result['status']      = 'recommended';
+            $result['description'] = self::buildDescription(
+                array(
+                    esc_html__('Operational alerts are unavailable. Activate the latest plugin build.', 'fp-esperienze'),
+                )
+            );
+
+            return $result;
+        }
+
+        $messages = array();
+
+        $channels = OperationalAlerts::getEnabledChannels();
+        if (empty($channels)) {
+            $result['status'] = 'recommended';
+            $messages[]       = esc_html__('No operational digest channels are configured.', 'fp-esperienze');
+        } else {
+            $channel_labels = array_map('esc_html', $channels);
+            $messages[]      = sprintf(
+                esc_html__('Enabled channels: %s', 'fp-esperienze'),
+                implode(', ', $channel_labels)
+            );
+        }
+
+        $next_run = OperationalAlerts::getNextDigestTimestamp();
+        if ($next_run === null) {
+            $result['status'] = 'recommended';
+            $messages[]       = esc_html__('The daily digest cron event is not scheduled.', 'fp-esperienze');
+        } else {
+            $messages[] = sprintf(
+                esc_html__('Next digest scheduled for %s.', 'fp-esperienze'),
+                esc_html(
+                    wp_date(
+                        get_option('date_format', 'Y-m-d') . ' ' . get_option('time_format', 'H:i'),
+                        $next_run
+                    )
+                )
+            );
+        }
+
+        if (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) {
+            $result['status'] = $result['status'] === 'critical' ? 'critical' : 'recommended';
+            $messages[]       = esc_html__('WP-Cron is disabled. Ensure a real cron job triggers the digest schedule.', 'fp-esperienze');
+        }
+
+        $last_status = OperationalAlerts::getLastStatus();
+        if (!empty($last_status)) {
+            $last_state = strtolower((string) ($last_status['status'] ?? ''));
+            $timestamp  = isset($last_status['timestamp']) ? esc_html((string) $last_status['timestamp']) : '';
+            $message    = isset($last_status['message']) ? esc_html((string) $last_status['message']) : '';
+
+            if ($timestamp !== '' && $message !== '') {
+                $messages[] = sprintf(
+                    esc_html__('Last dispatch (%1$s): %2$s', 'fp-esperienze'),
+                    $timestamp,
+                    $message
+                );
+            } elseif ($timestamp !== '') {
+                $messages[] = sprintf(
+                    esc_html__('Last dispatch at %s.', 'fp-esperienze'),
+                    $timestamp
+                );
+            } elseif ($message !== '') {
+                $messages[] = sprintf(
+                    esc_html__('Last dispatch message: %s', 'fp-esperienze'),
+                    $message
+                );
+            }
+
+            if ($last_state === 'error') {
+                $result['status'] = 'critical';
+            } elseif ($last_state === 'warning' && $result['status'] !== 'critical') {
+                $result['status'] = 'recommended';
+            }
+        }
+
+        if (empty($messages)) {
+            $messages[] = esc_html__('Operational digests configured.', 'fp-esperienze');
+        }
+
+        $result['description'] = self::buildDescription($messages);
+
+        return $result;
+    }
+
+    /**
+     * Surface production readiness from the validator inside Site Health.
+     */
+    public static function runProductionReadinessTest(): array {
+        $result = self::getBaseResult(
+            'fp_esperienze_production_readiness',
+            esc_html__('All production readiness checks passed.', 'fp-esperienze')
+        );
+
+        if (!class_exists(ProductionValidator::class)) {
+            $result['status']      = 'recommended';
+            $result['description'] = self::buildDescription(
+                array(
+                    esc_html__('Production readiness checks are unavailable. Ensure the plugin core is loaded.', 'fp-esperienze'),
+                )
+            );
+
+            return $result;
+        }
+
+        try {
+            $validation = ProductionValidator::validateProductionReadiness();
+        } catch (Throwable $exception) {
+            $result['status']      = 'recommended';
+            $result['description'] = self::buildDescription(
+                array(
+                    esc_html__('Unable to evaluate production readiness.', 'fp-esperienze'),
+                    esc_html($exception->getMessage()),
+                )
+            );
+
+            return $result;
+        }
+
+        $status = strtolower((string) ($validation['overall_status'] ?? 'warning'));
+
+        if ($status === 'fail') {
+            $result['status'] = 'critical';
+        } elseif ($status === 'warning') {
+            $result['status'] = 'recommended';
+        }
+
+        $messages = array();
+
+        if (!empty($validation['critical_issues'])) {
+            foreach ((array) $validation['critical_issues'] as $issue) {
+                $messages[] = esc_html((string) $issue);
+            }
+        }
+
+        if (!empty($validation['warnings'])) {
+            foreach ((array) $validation['warnings'] as $warning) {
+                $messages[] = esc_html((string) $warning);
+            }
+        }
+
+        if (empty($messages)) {
+            $messages[] = esc_html__('All production readiness checks passed.', 'fp-esperienze');
+        } else {
+            $checks_count = isset($validation['checks']) ? count((array) $validation['checks']) : 0;
+            if ($checks_count > 0) {
+                $messages[] = sprintf(
+                    esc_html__('Checks executed: %d', 'fp-esperienze'),
+                    $checks_count
+                );
+            }
+        }
+
+        $result['description'] = self::buildDescription($messages);
+
+        return $result;
+    }
+
+    /**
      * Prepare a base result array compliant with Site Health expectations.
      *
      * @param string $test Test identifier.
      *
      * @return array
      */
-    private static function getBaseResult(string $test): array {
+    private static function getBaseResult(string $test, string $message): array {
         return array(
             'label'       => esc_html__('FP Esperienze', 'fp-esperienze'),
             'status'      => 'good',
@@ -173,7 +450,7 @@ class SiteHealth {
             ),
             'description' => self::buildDescription(
                 array(
-                    esc_html__('All FP Esperienze checks passed.', 'fp-esperienze'),
+                    $message,
                 )
             ),
             'test'        => $test,

--- a/includes/REST/SystemStatusAPI.php
+++ b/includes/REST/SystemStatusAPI.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * System Status REST API endpoint.
+ *
+ * @package FP\Esperienze\REST
+*/
+
+namespace FP\Esperienze\REST;
+
+use FP\Esperienze\Admin\OnboardingHelper;
+use FP\Esperienze\Admin\OperationalAlerts;
+use FP\Esperienze\Core\CapabilityManager;
+use FP\Esperienze\Core\ProductionValidator;
+use Throwable;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Expose operational and onboarding insights via the REST API for monitoring tools.
+ */
+class SystemStatusAPI {
+    /**
+     * Hook REST route registration.
+     */
+    public function __construct() {
+        $this->registerRoutes();
+    }
+
+    /**
+     * Register the system status endpoint.
+     */
+    public function registerRoutes(): void {
+        register_rest_route('fp-exp/v1', '/system-status', [
+            'methods'             => WP_REST_Server::READABLE,
+            'callback'            => [$this, 'getStatus'],
+            'permission_callback' => [$this, 'permissionsCheck'],
+        ]);
+    }
+
+    /**
+     * Ensure the requester has permission to view operational data.
+     *
+     * @return bool|WP_Error
+     */
+    public function permissionsCheck() {
+        if (CapabilityManager::canManageFPEsperienze()) {
+            return true;
+        }
+
+        return new WP_Error(
+            'fp_esperienze_forbidden',
+            __('You do not have permission to view the FP Esperienze system status.', 'fp-esperienze'),
+            ['status' => rest_authorization_required_code()]
+        );
+    }
+
+    /**
+     * Return the aggregated system status payload.
+     */
+    public function getStatus(WP_REST_Request $request): WP_REST_Response {
+        $payload = [
+            'generated_at' => current_time('mysql'),
+            'onboarding'   => $this->getOnboardingStatus(),
+            'production'   => $this->getProductionStatus(),
+            'operations'   => $this->getOperationalStatus(),
+        ];
+
+        return new WP_REST_Response($payload, 200);
+    }
+
+    /**
+     * Collect onboarding checklist progress.
+     *
+     * @return array<string,mixed>
+     */
+    private function getOnboardingStatus(): array {
+        if (!class_exists(OnboardingHelper::class)) {
+            return [
+                'error' => __('Onboarding tools are unavailable.', 'fp-esperienze'),
+            ];
+        }
+
+        try {
+            $items   = OnboardingHelper::getChecklistItems();
+            $summary = OnboardingHelper::getCompletionSummary();
+        } catch (Throwable $exception) {
+            return [
+                'error'   => __('Unable to determine onboarding progress.', 'fp-esperienze'),
+                'message' => $exception->getMessage(),
+            ];
+        }
+
+        return [
+            'summary' => $summary,
+            'items'   => array_map(
+                static function(array $item): array {
+                    return [
+                        'id'          => (string) ($item['id'] ?? ''),
+                        'label'       => (string) ($item['label'] ?? ''),
+                        'description' => (string) ($item['description'] ?? ''),
+                        'completed'   => (bool) ($item['completed'] ?? false),
+                        'count'       => (int) ($item['count'] ?? 0),
+                    ];
+                },
+                $items
+            ),
+        ];
+    }
+
+    /**
+     * Collect production readiness information.
+     *
+     * @return array<string,mixed>
+     */
+    private function getProductionStatus(): array {
+        if (!class_exists(ProductionValidator::class)) {
+            return [
+                'error' => __('Production readiness checks are unavailable.', 'fp-esperienze'),
+            ];
+        }
+
+        try {
+            return ProductionValidator::validateProductionReadiness();
+        } catch (Throwable $exception) {
+            return [
+                'overall_status' => 'warning',
+                'critical_issues' => [],
+                'warnings' => [
+                    __('Failed to evaluate production readiness. Check the logs for details.', 'fp-esperienze'),
+                ],
+                'checks' => [],
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Collect operational alert configuration and health.
+     *
+     * @return array<string,mixed>
+     */
+    private function getOperationalStatus(): array {
+        if (!class_exists(OperationalAlerts::class)) {
+            return [
+                'error' => __('Operational alerting is not initialised.', 'fp-esperienze'),
+            ];
+        }
+
+        try {
+            $channels   = OperationalAlerts::getEnabledChannels();
+            $next_run   = OperationalAlerts::getNextDigestTimestamp();
+            $lastStatus = OperationalAlerts::getLastStatus();
+        } catch (Throwable $exception) {
+            return [
+                'error'   => __('Unable to load operational alert status.', 'fp-esperienze'),
+                'message' => $exception->getMessage(),
+            ];
+        }
+
+        $human_next = null;
+        if ($next_run) {
+            $human_next = wp_date(
+                get_option('date_format', 'Y-m-d') . ' ' . get_option('time_format', 'H:i'),
+                $next_run,
+                wp_timezone()
+            );
+        }
+
+        return [
+            'channels'     => $channels,
+            'next_run_gmt' => $next_run,
+            'next_run_human' => $human_next,
+            'last_status'  => $lastStatus,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add an OnboardingNotice admin helper that highlights outstanding checklist items and offers snooze and quick-action links
- bootstrap the persistent reminder alongside existing admin tooling so operators are prompted to finish setup
- document the new notice workflow in the README and onboarding automation guide for implementation and support teams

## Testing
- composer test *(fails: vendor/bin/phpstan is unavailable in this environment)*
- php -l includes/Admin/OnboardingNotice.php
- php -l includes/Core/Plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68d59e9be61c832f85148160ac98cb75