### PR TITLE
Ensure asset versions update with file changes

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -17,6 +17,7 @@ use FP\Esperienze\Data\HoldManager;
 use FP\Esperienze\Booking\BookingManager;
 use FP\Esperienze\PDF\Voucher_Pdf;
 use FP\Esperienze\PDF\Qr;
+use FP\Esperienze\Core\AssetOptimizer;
 use FP\Esperienze\Core\CapabilityManager;
 use FP\Esperienze\Core\I18nManager;
 use FP\Esperienze\Core\WebhookManager;
@@ -233,11 +234,12 @@ class MenuManager {
             [],
             '4.1.0'
         );
+        $product_search = AssetOptimizer::getAssetInfo('js', 'product-search', 'assets/js/product-search.js');
         wp_enqueue_script(
             'fp-admin-product-search',
-            FP_ESPERIENZE_PLUGIN_URL . 'assets/js/product-search.js',
+            $product_search['url'],
             ['jquery', 'select2'],
-            FP_ESPERIENZE_VERSION,
+            $product_search['version'],
             true
         );
         
@@ -259,21 +261,23 @@ class MenuManager {
                 '3.10.5'
             );
             
+            $admin_bookings = AssetOptimizer::getAssetInfo('js', 'admin-bookings', 'assets/js/admin-bookings.js');
             wp_enqueue_script(
                 'fp-admin-bookings',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/admin-bookings.js',
+                $admin_bookings['url'],
                 ['jquery', 'fullcalendar'],
-                FP_ESPERIENZE_VERSION,
+                $admin_bookings['version'],
                 true
             );
         }
 
         if (strpos($hook, 'fp-esperienze-integration-toolkit') !== false) {
+            $integration_toolkit = AssetOptimizer::getAssetInfo('js', 'integration-toolkit', 'assets/js/integration-toolkit.js');
             wp_enqueue_script(
                 'fp-integration-toolkit',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/integration-toolkit.js',
+                $integration_toolkit['url'],
                 [],
-                FP_ESPERIENZE_VERSION,
+                $integration_toolkit['version'],
                 true
             );
         }

--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -8,6 +8,7 @@
 namespace FP\Esperienze\Admin;
 
 use FP\Esperienze\Admin\OnboardingHelper;
+use FP\Esperienze\Core\AssetOptimizer;
 
 defined('ABSPATH') || exit;
 
@@ -67,11 +68,12 @@ class SetupWizard {
         wp_enqueue_style('wp-color-picker');
         wp_enqueue_script('wp-color-picker');
 
+        $setup_tour = AssetOptimizer::getAssetInfo('js', 'setup-wizard-tour', 'assets/js/setup-wizard-tour.js');
         wp_enqueue_script(
             'fp-setup-tour',
-            FP_ESPERIENZE_PLUGIN_URL . 'assets/js/setup-wizard-tour.js',
+            $setup_tour['url'],
             ['jquery'],
-            FP_ESPERIENZE_VERSION,
+            $setup_tour['version'],
             true
         );
 

--- a/includes/Blocks/ArchiveBlock.php
+++ b/includes/Blocks/ArchiveBlock.php
@@ -7,6 +7,7 @@
 
 namespace FP\Esperienze\Blocks;
 
+use FP\Esperienze\Core\AssetOptimizer;
 use FP\Esperienze\Frontend\Shortcodes;
 
 defined('ABSPATH') || exit;
@@ -121,11 +122,13 @@ class ArchiveBlock {
             return;
         }
 
+        $archive_block = AssetOptimizer::getAssetInfo('js', 'archive-block', 'assets/js/archive-block.js');
+
         wp_enqueue_script(
             'fp-esperienze-archive-block',
-            FP_ESPERIENZE_PLUGIN_URL . 'assets/js/archive-block.js',
+            $archive_block['url'],
             ['jquery', 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'],
-            FP_ESPERIENZE_VERSION,
+            $archive_block['version'],
             true
         );
 

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -525,44 +525,31 @@ class Plugin {
         }
 
         // Enqueue CSS (minified if available)
-        $frontend_css_url = AssetOptimizer::getMinifiedAssetUrl('css', 'frontend');
-        if (!$frontend_css_url) {
-            $frontend_css_url = FP_ESPERIENZE_PLUGIN_URL . 'assets/css/frontend.css';
-        }
-        
+        $frontend_css = AssetOptimizer::getAssetInfo('css', 'frontend', 'assets/css/frontend.css');
         wp_enqueue_style(
             'fp-esperienze-frontend',
-            $frontend_css_url,
+            $frontend_css['url'],
             [],
-            FP_ESPERIENZE_VERSION
+            $frontend_css['version']
         );
 
-        // Enqueue JS (minified if available)  
-        $frontend_js_url = AssetOptimizer::getMinifiedAssetUrl('js', 'frontend');
-        if (!$frontend_js_url) {
-            wp_enqueue_script(
-                'fp-esperienze-frontend',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/frontend.js',
-                ['jquery', 'wp-i18n'],
-                FP_ESPERIENZE_VERSION,
-                true
-            );
-            
-            // Enqueue tracking script separately if not minified
+        // Enqueue JS (minified if available)
+        $frontend_js = AssetOptimizer::getAssetInfo('js', 'frontend', 'assets/js/frontend.js');
+        wp_enqueue_script(
+            'fp-esperienze-frontend',
+            $frontend_js['url'],
+            ['jquery', 'wp-i18n'],
+            $frontend_js['version'],
+            true
+        );
+
+        if (!$frontend_js['is_minified']) {
+            $tracking_js = AssetOptimizer::getAssetInfo('js', 'tracking', 'assets/js/tracking.js');
             wp_enqueue_script(
                 'fp-esperienze-tracking',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/tracking.js',
+                $tracking_js['url'],
                 ['jquery'],
-                FP_ESPERIENZE_VERSION,
-                true
-            );
-        } else {
-            // Use minified combined version
-            wp_enqueue_script(
-                'fp-esperienze-frontend',
-                $frontend_js_url,
-                ['jquery', 'wp-i18n'],
-                FP_ESPERIENZE_VERSION,
+                $tracking_js['version'],
                 true
             );
         }
@@ -580,31 +567,29 @@ class Plugin {
 
             // Only enqueue for experience products
             if ($product && $product->get_type() === 'experience') {
+                $gallery_css = AssetOptimizer::getAssetInfo('css', 'experience-gallery', 'assets/css/experience-gallery.css');
                 wp_enqueue_style(
                     'fp-esperienze-experience-gallery',
-                    FP_ESPERIENZE_PLUGIN_URL . 'assets/css/experience-gallery.css',
+                    $gallery_css['url'],
                     array('fp-esperienze-frontend'),
-                    FP_ESPERIENZE_VERSION
+                    $gallery_css['version']
                 );
 
+                $gallery_js = AssetOptimizer::getAssetInfo('js', 'experience-gallery', 'assets/js/experience-gallery.js');
                 wp_enqueue_script(
                     'fp-esperienze-experience-gallery',
-                    FP_ESPERIENZE_PLUGIN_URL . 'assets/js/experience-gallery.js',
+                    $gallery_js['url'],
                     array(),
-                    FP_ESPERIENZE_VERSION,
+                    $gallery_js['version'],
                     true
                 );
 
-                $booking_widget_url = AssetOptimizer::getMinifiedAssetUrl('js', 'booking-widget');
-                if (!$booking_widget_url) {
-                    $booking_widget_url = FP_ESPERIENZE_PLUGIN_URL . 'assets/js/booking-widget.js';
-                }
-                
+                $booking_widget = AssetOptimizer::getAssetInfo('js', 'booking-widget', 'assets/js/booking-widget.js');
                 wp_enqueue_script(
                     'fp-esperienze-booking-widget',
-                    $booking_widget_url,
+                    $booking_widget['url'],
                     ['jquery', 'wp-i18n', 'fp-esperienze-frontend'],
-                    FP_ESPERIENZE_VERSION,
+                    $booking_widget['version'],
                     true
                 );
 
@@ -650,16 +635,13 @@ class Plugin {
      */
     public function enqueueAdminScripts(): void {
         // Enqueue CSS (minified if available)
-        $admin_css_url = AssetOptimizer::getMinifiedAssetUrl('css', 'admin');
-        if (!$admin_css_url) {
-            $admin_css_url = FP_ESPERIENZE_PLUGIN_URL . 'assets/css/admin.css';
-        }
-        
+        $admin_css = AssetOptimizer::getAssetInfo('css', 'admin', 'assets/css/admin.css');
+
         wp_enqueue_style(
             'fp-esperienze-admin',
-            $admin_css_url,
+            $admin_css['url'],
             [],
-            FP_ESPERIENZE_VERSION
+            $admin_css['version']
         );
 
         // Enqueue admin controller based on modular flag
@@ -719,16 +701,13 @@ class Plugin {
             // Load modular system: first load modules, then main controller
             $this->enqueueAdminModules();
 
-            $admin_js_url = AssetOptimizer::getMinifiedAssetUrl('js', 'admin-modular');
-            if (!$admin_js_url) {
-                $admin_js_url = FP_ESPERIENZE_PLUGIN_URL . 'assets/js/admin-modular.js';
-            }
+            $admin_js = AssetOptimizer::getAssetInfo('js', 'admin-modular', 'assets/js/admin-modular.js');
 
             wp_enqueue_script(
                 'fp-esperienze-admin-modular',
-                $admin_js_url,
+                $admin_js['url'],
                 ['jquery', 'fp-esperienze-modules'],
-                FP_ESPERIENZE_VERSION,
+                $admin_js['version'],
                 true
             );
 
@@ -758,16 +737,13 @@ class Plugin {
             // Ensure the modular controller is not loaded
             wp_deregister_script('fp-esperienze-admin-modular');
 
-            $admin_js_url = AssetOptimizer::getMinifiedAssetUrl('js', 'admin');
-            if (!$admin_js_url) {
-                $admin_js_url = FP_ESPERIENZE_PLUGIN_URL . 'assets/js/admin.js';
-            }
+            $admin_js = AssetOptimizer::getAssetInfo('js', 'admin', 'assets/js/admin.js');
 
             wp_enqueue_script(
                 'fp-esperienze-admin',
-                $admin_js_url,
+                $admin_js['url'],
                 ['jquery'],
-                FP_ESPERIENZE_VERSION,
+                $admin_js['version'],
                 true
             );
 
@@ -798,11 +774,12 @@ class Plugin {
         // Enqueue reports script only on reports page
         $current_screen = get_current_screen();
         if ($current_screen && $current_screen->id === 'fp-esperienze_page_fp-esperienze-reports') {
+            $reports_js = AssetOptimizer::getAssetInfo('js', 'reports', 'assets/js/reports.js');
             wp_enqueue_script(
                 'fp-esperienze-reports',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/reports.js',
+                $reports_js['url'],
                 ['jquery'],
-                FP_ESPERIENZE_VERSION,
+                $reports_js['version'],
                 true
             );
 
@@ -831,15 +808,16 @@ class Plugin {
         
         foreach ($modules as $handle => $filename) {
             $module_handle = 'fp-esperienze-module-' . $handle;
-            
+            $module_asset = AssetOptimizer::getAssetInfo('js', 'module-' . $handle, 'assets/js/modules/' . $filename);
+
             wp_enqueue_script(
                 $module_handle,
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/modules/' . $filename,
+                $module_asset['url'],
                 ['jquery'],
-                FP_ESPERIENZE_VERSION,
+                $module_asset['version'],
                 true
             );
-            
+
             $module_handles[] = $module_handle;
         }
         
@@ -864,16 +842,13 @@ class Plugin {
      * Enqueue block editor assets
      */
     public function enqueueBlockAssets(): void {
-        $archive_block_url = AssetOptimizer::getMinifiedAssetUrl('js', 'archive-block');
-        if (!$archive_block_url) {
-            $archive_block_url = FP_ESPERIENZE_PLUGIN_URL . 'assets/js/archive-block.js';
-        }
-        
+        $archive_block = AssetOptimizer::getAssetInfo('js', 'archive-block', 'assets/js/archive-block.js');
+
         wp_enqueue_script(
             'fp-esperienze-archive-block',
-            $archive_block_url,
+            $archive_block['url'],
             ['jquery', 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-i18n'],
-            FP_ESPERIENZE_VERSION,
+            $archive_block['version'],
             true
         );
 

--- a/includes/Core/UXEnhancer.php
+++ b/includes/Core/UXEnhancer.php
@@ -46,11 +46,12 @@ class UXEnhancer {
      */
     public static function enqueueUXScripts(): void {
         if (self::shouldLoadUXScripts()) {
+            $ux_asset = AssetOptimizer::getAssetInfo('js', 'ux-enhancer', 'assets/js/ux-enhancer.js');
             wp_enqueue_script(
                 'fp-ux-enhancer',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/ux-enhancer.js',
+                $ux_asset['url'],
                 ['jquery'],
-                FP_ESPERIENZE_VERSION,
+                $ux_asset['version'],
                 true
             );
             
@@ -77,11 +78,12 @@ class UXEnhancer {
      */
     public static function enqueueAdminUXScripts(): void {
         if (self::shouldLoadAdminUXScripts()) {
+            $admin_ux_asset = AssetOptimizer::getAssetInfo('js', 'admin-ux-enhancer', 'assets/js/admin-ux-enhancer.js');
             wp_enqueue_script(
                 'fp-admin-ux-enhancer',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/admin-ux-enhancer.js',
+                $admin_ux_asset['url'],
                 ['jquery', 'jquery-ui-progressbar'],
-                FP_ESPERIENZE_VERSION,
+                $admin_ux_asset['version'],
                 true
             );
             

--- a/includes/Integrations/TrackingManager.php
+++ b/includes/Integrations/TrackingManager.php
@@ -7,6 +7,8 @@
 
 namespace FP\Esperienze\Integrations;
 
+use FP\Esperienze\Core\AssetOptimizer;
+
 defined('ABSPATH') || exit;
 
 /**
@@ -83,11 +85,12 @@ class TrackingManager {
         }
         
         if ($this->isGA4Enabled() || $this->isMetaPixelEnabled() || $this->isGoogleAdsEnabled()) {
+            $tracking_asset = AssetOptimizer::getAssetInfo('js', 'tracking', 'assets/js/tracking.js');
             wp_enqueue_script(
                 'fp-esperienze-tracking',
-                FP_ESPERIENZE_PLUGIN_URL . 'assets/js/tracking.js',
+                $tracking_asset['url'],
                 ['jquery'],
-                FP_ESPERIENZE_VERSION,
+                $tracking_asset['version'],
                 true
             );
             

--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -7,6 +7,8 @@
 
 namespace FP\Esperienze\ProductType;
 
+use FP\Esperienze\Core\AssetOptimizer;
+
 use FP\Esperienze\Data\ScheduleManager;
 use FP\Esperienze\Data\OverrideManager;
 use FP\Esperienze\Data\MeetingPointManager;
@@ -3461,13 +3463,14 @@ class Experience {
 		wp_enqueue_media();
 		wp_enqueue_script( 'jquery-ui-sortable' );
 
-		wp_enqueue_script(
-			'fp-esperienze-product-admin',
-			FP_ESPERIENZE_PLUGIN_URL . 'assets/js/admin.js',
-			array( 'jquery', 'wc-admin-product-meta-boxes' ),
-			FP_ESPERIENZE_VERSION,
-			true
-		);
+                $product_admin = AssetOptimizer::getAssetInfo( 'js', 'admin', 'assets/js/admin.js' );
+                wp_enqueue_script(
+                        'fp-esperienze-product-admin',
+                        $product_admin['url'],
+                        array( 'jquery', 'wc-admin-product-meta-boxes' ),
+                        $product_admin['version'],
+                        true
+                );
 
                 $admin_data = array(
                         'ajax_url'            => admin_url( 'admin-ajax.php' ),


### PR DESCRIPTION
## Summary
- add an `AssetOptimizer::getAssetInfo` helper that derives asset URLs and cache-busting versions from the underlying files
- switch frontend, admin, block, and setup wizard enqueues to use the new helper so browsers receive fresh script/style versions after edits
- update auxiliary loaders (UX enhancer, tracking manager, product type hooks, etc.) to reference the helper for consistent cache invalidation

## Testing
- composer test *(fails: phpstan reports existing baseline mismatch and legacy warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d65fe21aec832f8ba9cfcf8cfefe5e