### PR TITLE
Add duplicate controls to schedule builder slots

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -3728,43 +3728,289 @@ body.fp-reduced-animations .fp-loading::after {
 
 /* Time slot card clean */
 .fp-time-slot-card-clean {
-    background: #fff;
-    border: 1px solid #dcdcde;
-    border-radius: 4px;
-    box-shadow: none;
-    margin-bottom: 20px;
+    background: linear-gradient(140deg, #ffffff 0%, #f5f9ff 100%);
+    border: 1px solid rgba(34, 71, 140, 0.12);
+    border-radius: 18px;
+    box-shadow: 0 32px 60px -42px rgba(22, 53, 90, 0.55);
+    margin-bottom: 24px;
     overflow: hidden;
     position: relative;
-    transition: none;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.fp-time-slot-card-clean:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 26px 75px -44px rgba(22, 53, 90, 0.6);
 }
 
 .fp-time-slot-content-clean {
     padding: 0;
 }
 
-.fp-time-slot-header-clean {
-    background: var(--fp-surface-muted);
-    padding: 20px;
-    border-bottom: 1px solid var(--fp-border-subtle);
+.fp-slot-card-inner {
     display: grid;
-    grid-template-columns: 200px 1fr auto;
-    gap: 20px;
+    grid-template-columns: 72px minmax(0, 1fr);
+    align-items: stretch;
+}
+
+.fp-slot-rail {
+    position: relative;
+    background: linear-gradient(180deg, #eef4ff 0%, #ffffff 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.fp-slot-rail__dot {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--fp-brand-primary);
+    box-shadow: 0 14px 24px -10px rgba(34, 113, 177, 0.5);
+    z-index: 1;
+}
+
+.fp-slot-rail__line {
+    position: absolute;
+    top: 18px;
+    bottom: 18px;
+    width: 4px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, rgba(34, 113, 177, 0.45) 0%, rgba(34, 113, 177, 0) 100%);
+}
+
+.fp-slot-content {
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.fp-slot-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
     align-items: flex-start;
 }
 
-.fp-time-field-clean label,
-.fp-days-field-clean label {
-    color: var(--fp-text-gray);
+.fp-slot-header__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    max-width: 100%;
 }
 
-.fp-time-field-clean input[type="time"] {
-    padding: 10px 14px;
+.fp-slot-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    background: rgba(34, 113, 177, 0.12);
+    color: var(--fp-brand-primary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
 }
 
-.fp-days-pills-clean {
+.fp-slot-subtitle {
+    margin: 0;
+    font-size: 0.875rem;
+    color: #1f2933;
+    font-weight: 600;
+}
+
+.fp-slot-status-badges {
     display: flex;
     flex-wrap: wrap;
+    gap: 8px;
+}
+
+.fp-slot-status-badge {
+    display: inline-flex;
+    align-items: center;
     gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(31, 64, 134, 0.08);
+    color: #1d2939;
+}
+
+.fp-slot-status-badge .dashicons {
+    font-size: 0.9rem;
+}
+
+.fp-slot-status-badge.is-warning {
+    background: rgba(219, 84, 97, 0.12);
+    color: #b4231d;
+}
+
+.fp-slot-status-badge.is-success {
+    background: rgba(16, 185, 129, 0.12);
+    color: #0f5132;
+}
+
+.fp-slot-status-badge.is-info {
+    background: rgba(34, 113, 177, 0.12);
+    color: var(--fp-brand-primary);
+}
+
+.fp-slot-actions-clean {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.fp-slot-actions-clean .fp-duplicate-time-slot-clean {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: 1px solid rgba(34, 113, 177, 0.26);
+    background: rgba(34, 113, 177, 0.1);
+    color: #0f3d6c;
+    font-weight: 600;
+    font-size: 0.8125rem;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.fp-slot-actions-clean .fp-duplicate-time-slot-clean:hover {
+    background: #2271b1;
+    color: #fff;
+    border-color: #1b5c8f;
+    transform: translateY(-1px);
+}
+
+.fp-slot-actions-clean .fp-duplicate-time-slot-clean:focus {
+    outline: 2px solid rgba(34, 113, 177, 0.35);
+    outline-offset: 2px;
+}
+
+.fp-slot-actions-clean .fp-duplicate-time-slot-clean .dashicons {
+    font-size: 1rem;
+}
+
+.fp-slot-actions-clean .fp-remove-time-slot-clean {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: 1px solid rgba(214, 54, 56, 0.3);
+    background: rgba(255, 246, 246, 0.85);
+    color: #a71d2a;
+    font-weight: 600;
+    font-size: 0.8125rem;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.fp-slot-actions-clean .fp-remove-time-slot-clean:hover {
+    background: #d63638;
+    color: #fff;
+    border-color: #d63638;
+    transform: translateY(-1px);
+}
+
+.fp-slot-actions-clean .fp-remove-time-slot-clean:focus {
+    outline: 2px solid #f0b5b8;
+    outline-offset: 2px;
+}
+
+.fp-slot-actions-clean .fp-remove-time-slot-clean .dashicons {
+    font-size: 1rem;
+}
+
+@media (max-width: 600px) {
+    .fp-slot-actions-clean {
+        justify-content: flex-start;
+    }
+
+    .fp-slot-actions-clean .button {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+.fp-slot-primary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 20px;
+}
+
+.fp-slot-primary__field {
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(34, 71, 140, 0.08);
+    border-radius: 16px;
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    box-shadow: 0 32px 50px -40px rgba(17, 41, 82, 0.45);
+    min-height: 100%;
+}
+
+.fp-slot-field-label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: #102a43;
+    margin: 0;
+}
+
+.fp-slot-field-label .dashicons {
+    font-size: 1rem;
+    color: var(--fp-brand-primary);
+}
+
+.fp-slot-label-text .required {
+    color: #d63638;
+}
+
+.fp-slot-time-input {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.fp-slot-time-input input[type="time"] {
+    flex: 1;
+    border: 1px solid #d7deea;
+    border-radius: 10px;
+    padding: 12px 14px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #1f2933;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fp-slot-time-input input[type="time"]:focus {
+    border-color: var(--fp-brand-primary);
+    box-shadow: 0 0 0 3px rgba(34, 113, 177, 0.25);
+    outline: none;
+}
+
+.fp-slot-hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: #52606d;
+    line-height: 1.5;
+}
+
+.fp-slot-day-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
 }
 
 .fp-day-pill-clean {
@@ -3773,125 +4019,186 @@ body.fp-reduced-animations .fp-loading::after {
 
 .fp-day-pill-clean input[type="checkbox"] {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
     opacity: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0;
     cursor: pointer;
 }
 
 .fp-day-pill-clean label {
-    display: inline-block;
-    width: 40px;
-    padding: 8px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    min-height: 68px;
+    padding: 10px 8px;
     text-align: center;
-    background-color: #f7f7f7;
-    border: 1px solid #ccd0d4;
-    border-radius: 3px;
-    font-size: 0.75rem;
+    background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+    border: 1px solid rgba(34, 71, 140, 0.15);
+    border-radius: 12px;
     font-weight: 600;
-    cursor: pointer;
-    transition: background 0.2s ease,
-                transform 0.2s ease,
-                box-shadow 0.2s ease;
-    margin: 0;
+    color: #1d2939;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: #1d2327;
+    letter-spacing: 0.12em;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.fp-slot-day__abbr {
+    font-size: 0.85rem;
+}
+
+.fp-slot-day__full {
+    font-size: 0.6rem;
+    letter-spacing: 0.16em;
+    opacity: 0.75;
 }
 
 .fp-day-pill-clean label:hover {
-    background-color: #fafafa;
-    border-color: #bbb;
+    border-color: var(--fp-brand-primary);
+    transform: translateY(-1px);
 }
 
 .fp-day-pill-clean input[type="checkbox"]:checked + label {
-    width: 40px;
-    text-align: center;
-    background-color: var(--fp-brand-primary);
-    color: #fff;
+    background: var(--fp-brand-primary);
     border-color: var(--fp-brand-primary);
+    color: #fff;
+    box-shadow: 0 20px 40px -25px rgba(34, 113, 177, 0.8);
 }
 
 .fp-day-pill-clean input[type="checkbox"]:focus-visible + label {
     outline: 2px solid var(--fp-brand-primary);
-    outline-offset: 2px;
+    outline-offset: 3px;
 }
 
-.fp-slot-actions-clean .fp-remove-time-slot-clean {
-    font-family: inherit;
-    font-size: 13px;
-    font-weight: 600;
-    justify-content: center;
+.fp-slot-insight h4 {
+    margin: 0;
+    font-size: 0.8125rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #102a43;
+}
+
+.fp-slot-insight-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.fp-slot-insight-list li {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    font-size: 0.8125rem;
+    color: #364152;
     line-height: 1.5;
 }
 
-.fp-slot-actions-clean .fp-remove-time-slot-clean:active {
-    transform: translateY(0);
-    box-shadow: 0 1px 2px rgba(214, 54, 56, 0.4);
+.fp-slot-insight-list .dashicons {
+    font-size: 1rem;
+    color: var(--fp-brand-primary);
+    margin-top: 2px;
 }
 
-/* Override toggle clean */
-.fp-override-toggle-clean {
-    padding: 15px 20px;
-    background: #fafafa;
-    border-bottom: 1px solid #e5e5e5;
-}
-
-.fp-override-toggle-clean label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-weight: 500;
-    margin: 0;
-    cursor: pointer;
-}
-
-.fp-override-toggle-clean .description {
-    display: block;
-    margin-top: 5px;
-    color: #666;
-    font-size: 0.8125rem;
-}
-
-/* Override section clean */
 .fp-overrides-section-clean {
-    padding: 20px;
-    background: #f9f9f9;
-    border-top: 1px solid #e5e5e5;
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid rgba(34, 71, 140, 0.08);
+    border-radius: 16px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    box-shadow: 0 36px 60px -48px rgba(17, 41, 82, 0.45);
+}
+
+.fp-slot-detail-header h4 {
+    margin: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #102a43;
+}
+
+.fp-slot-detail-header p {
+    margin: 6px 0 0;
+    font-size: 0.8125rem;
+    color: #52606d;
 }
 
 .fp-overrides-grid-clean {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 15px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.fp-override-field-clean {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .fp-override-field-clean label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: 5px;
-    color: #23282d;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #102a43;
 }
 
 .fp-override-field-clean input,
 .fp-override-field-clean select {
     width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #ddd;
-    border-radius: 6px;
+    padding: 10px 14px;
+    border: 1px solid #d7deea;
+    border-radius: 10px;
     font-size: 0.875rem;
-    transition: all 0.2s ease;
     background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .fp-override-field-clean input:focus,
 .fp-override-field-clean select:focus {
-    border-color: #0073aa;
+    border-color: var(--fp-brand-primary);
+    box-shadow: 0 0 0 3px rgba(34, 113, 177, 0.2);
     outline: none;
-    box-shadow: 0 0 0 2px rgba(0, 115, 170, 0.2);
+}
+
+@media (max-width: 1200px) {
+    .fp-slot-primary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 960px) {
+    .fp-slot-primary {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 782px) {
+    .fp-slot-card-inner {
+        grid-template-columns: 1fr;
+    }
+
+    .fp-slot-rail {
+        display: none;
+    }
+
+    .fp-slot-content {
+        padding: 22px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fp-time-slot-card-clean,
+    .fp-slot-actions-clean .fp-remove-time-slot-clean,
+    .fp-day-pill-clean label {
+        transition: none !important;
+        transform: none !important;
+        box-shadow: none !important;
+    }
 }
 
 /* Overrides container clean */

--- a/assets/js/modules/schedule-builder.js
+++ b/assets/js/modules/schedule-builder.js
@@ -61,6 +61,38 @@
                 $(this).closest('.fp-time-slot-row').remove();
                 self.dispatchAdminEvent('fp:updateSummaryTable');
             });
+
+            // Duplicate time slot card (clean markup)
+            $(document).off('click.fp-duplicate-slot', '.fp-duplicate-time-slot-clean');
+            $(document).on('click.fp-duplicate-slot', '.fp-duplicate-time-slot-clean', function(e) {
+                e.preventDefault();
+
+                var $button = $(this);
+                var $sourceCard = $button.closest('.fp-time-slot-card-clean');
+                if (!$sourceCard.length) {
+                    return;
+                }
+
+                $button.prop('disabled', true);
+
+                try {
+                    var slotData = self.collectTimeSlotCardData($sourceCard);
+                    var $newCard = self.addTimeSlotCardClean(slotData, $sourceCard);
+
+                    if ($newCard && $newCard.length) {
+                        self.dispatchAdminEvent('fp:showUserFeedback', {
+                            message: 'Time slot duplicated!',
+                            type: 'success'
+                        });
+                    }
+                } catch (error) {
+                    console.error('FP Esperienze: Error duplicating time slot card:', error);
+                } finally {
+                    setTimeout(function() {
+                        $button.prop('disabled', false);
+                    }, 200);
+                }
+            });
             
             // Meeting point dropdown change
             $(document).on('change', '.fp-meeting-point-select', function() {
@@ -197,6 +229,7 @@
         initModernScheduleBuilder: function() {
             this.validateContainers();
             this.initOverrideManager();
+            this.updateSlotChips();
         },
 
         /**
@@ -260,45 +293,107 @@
                 e.preventDefault();
                 self.addTimeSlotCardClean();
             });
+
+            $(document).off('click.fp-modern-duplicate-time-slot', '.fp-duplicate-time-slot-clean');
+            $(document).on('click.fp-modern-duplicate-time-slot', '.fp-duplicate-time-slot-clean', function(e) {
+                e.preventDefault();
+
+                var $button = $(this);
+                var $sourceCard = $button.closest('.fp-time-slot-card-clean');
+                if (!$sourceCard.length) {
+                    return;
+                }
+
+                $button.prop('disabled', true);
+
+                try {
+                    var slotData = self.collectTimeSlotCardData($sourceCard);
+                    var $newCard = self.addTimeSlotCardClean(slotData, $sourceCard);
+
+                    if ($newCard && $newCard.length) {
+                        self.dispatchAdminEvent('fp:showUserFeedback', {
+                            message: 'Time slot duplicated!',
+                            type: 'success'
+                        });
+                    }
+                } catch (error) {
+                    console.error('FP Esperienze: Error duplicating time slot card:', error);
+                } finally {
+                    setTimeout(function() {
+                        $button.prop('disabled', false);
+                    }, 200);
+                }
+            });
         },
 
 
         /**
          * Add time slot card (clean version)
          */
-        addTimeSlotCardClean: function() {
+        addTimeSlotCardClean: function(slotData, insertAfterCard) {
+            slotData = slotData || null;
+            insertAfterCard = insertAfterCard || null;
+
             try {
-                // The container for time slots is the element with ID fp-time-slots-container
                 var $container = $('#fp-time-slots-container');
                 if (!$container.length) {
                     console.error('FP Esperienze: Time slots container not found');
-                    return;
+                    return null;
                 }
 
                 var existingIndexes = $container
                     .find('.fp-time-slot-card-clean')
                     .map(function() {
-                        return parseInt($(this).attr('data-index'), 10);
+                        var parsed = parseInt($(this).attr('data-index'), 10);
+                        return isNaN(parsed) ? null : parsed;
                     })
-                    .get();
+                    .get()
+                    .filter(function(value) {
+                        return value !== null;
+                    });
+
                 var index = existingIndexes.length
                     ? Math.max.apply(null, existingIndexes) + 1
                     : 0;
                 var cardHTML = this.createTimeSlotCardHTMLClean(index);
-                var $newCard = $(cardHTML).attr('data-index', index);
+                if (!cardHTML) {
+                    console.error('FP Esperienze: Unable to build time slot card HTML');
+                    return null;
+                }
 
-                $container.append($newCard);
-                
-                // Show user feedback
-                this.dispatchAdminEvent('fp:showUserFeedback', {
-                    message: 'Time slot added successfully!',
-                    type: 'success'
-                });
-                
-                // Debug logging removed for production
-                
+                var $newCard = $(cardHTML).attr('data-index', index).addClass('fp-newly-added');
+
+                if (insertAfterCard && insertAfterCard.length) {
+                    insertAfterCard.after($newCard);
+                } else {
+                    $container.append($newCard);
+                }
+
+                this.populateMeetingPointsDropdown($newCard.find('.fp-meeting-point-select'));
+
+                if (slotData) {
+                    this.applyTimeSlotCardData($newCard, slotData);
+                }
+
+                setTimeout(function() {
+                    $newCard.removeClass('fp-newly-added');
+                }, 1400);
+
+                this.updateSlotChips();
+                this.dispatchAdminEvent('fp:markAsChanged');
+                this.dispatchAdminEvent('fp:updateSummaryTable');
+
+                if (!slotData) {
+                    this.dispatchAdminEvent('fp:showUserFeedback', {
+                        message: 'Time slot added successfully!',
+                        type: 'success'
+                    });
+                }
+
+                return $newCard;
             } catch (error) {
                 console.error('FP Esperienze: Error adding time slot card:', error);
+                return null;
             }
         },
 
@@ -306,62 +401,104 @@
          * Create time slot card HTML (clean version)
          */
         createTimeSlotCardHTMLClean: function(index) {
+            var slotNumber = (index + 1).toString().padStart(2, '0');
+            var slotLabel = `Slot ${slotNumber}`;
+
             return `
                 <div class="fp-time-slot-card fp-time-slot-card-clean" data-index="${index}">
                     <div class="fp-time-slot-content-clean">
-                        <div class="fp-time-slot-header-clean">
-                            <div class="fp-time-field-clean">
-                                <label for="time-${index}">
-                                    <span class="dashicons dashicons-clock"></span>
-                                    Start Time <span class="required">*</span>
-                                </label>
-                                <input type="time" id="time-${index}" name="builder_slots[${index}][start_time]" required />
+                        <div class="fp-slot-card-inner">
+                            <div class="fp-slot-rail" aria-hidden="true">
+                                <span class="fp-slot-rail__dot"></span>
+                                <span class="fp-slot-rail__line"></span>
                             </div>
+                            <div class="fp-slot-content">
+                                <header class="fp-slot-header">
+                                    <div class="fp-slot-header__meta">
+                                        <span class="fp-slot-chip">${slotLabel}</span>
+                                        <p class="fp-slot-subtitle">Recurring weekly availability</p>
+                                    </div>
+                                    <div class="fp-slot-actions-clean">
+                                        <button type="button" class="button fp-duplicate-time-slot-clean">
+                                            <span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
+                                            Duplicate slot
+                                        </button>
+                                        <button type="button" class="fp-remove-time-slot-clean button button-link-delete">
+                                            <span class="dashicons dashicons-trash" aria-hidden="true"></span>
+                                            Remove slot
+                                        </button>
+                                    </div>
+                                </header>
 
-                            <div class="fp-days-field-clean">
-                                <label>
-                                    <span class="dashicons dashicons-calendar-alt"></span>
-                                    Days of Week <span class="required">*</span>
-                                </label>
-                                <div class="fp-days-pills-clean">
-                                    ${this.createDayPills(index)}
+                                <div class="fp-slot-primary">
+                                    <div class="fp-slot-primary__field fp-time-field-clean">
+                                        <label for="time-${index}" class="fp-slot-field-label">
+                                            <span class="dashicons dashicons-clock" aria-hidden="true"></span>
+                                            <span class="fp-slot-label-text">Start time <span class="required">*</span></span>
+                                        </label>
+                                        <div class="fp-slot-time-input">
+                                            <input type="time" id="time-${index}" name="builder_slots[${index}][start_time]" required />
+                                        </div>
+                                        <p class="fp-slot-hint">Guests see this start time in their timezone.</p>
+                                    </div>
+
+                                    <div class="fp-slot-primary__field fp-days-field-clean">
+                                        <label class="fp-slot-field-label">
+                                            <span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
+                                            <span class="fp-slot-label-text">Days of week <span class="required">*</span></span>
+                                        </label>
+                                        <div class="fp-slot-day-grid fp-days-pills-clean">
+                                            ${this.createDayPills(index)}
+                                        </div>
+                                        <p class="fp-slot-hint">Select at least one day to activate this slot.</p>
+                                    </div>
+
+                                    <div class="fp-slot-primary__field fp-slot-insight">
+                                        <h4>Slot notes</h4>
+                                        <ul class="fp-slot-insight-list">
+                                            <li><span class="dashicons dashicons-update" aria-hidden="true"></span> Repeats weekly on your chosen days.</li>
+                                            <li><span class="dashicons dashicons-admin-generic" aria-hidden="true"></span> Overrides below replace product defaults.</li>
+                                            <li><span class="dashicons dashicons-visibility" aria-hidden="true"></span> Customers only see published, in-season slots.</li>
+                                        </ul>
+                                    </div>
                                 </div>
-                            </div>
 
-                            <div class="fp-slot-actions-clean">
-                                <button type="button" class="fp-remove-time-slot-clean button">
-                                    <span class="dashicons dashicons-trash"></span>
-                                    Remove
-                                </button>
-                            </div>
-                        </div>
-
-                        <div class="fp-overrides-grid-clean">
-                            <div class="fp-override-field-clean">
-                                <label>Duration (minutes) <span class="required">*</span></label>
-                                <input type="number" name="builder_slots[${index}][duration_min]" min="1" required />
-                            </div>
-                            <div class="fp-override-field-clean">
-                                <label>Capacity <span class="required">*</span></label>
-                                <input type="number" name="builder_slots[${index}][capacity]" min="1" required />
-                            </div>
-                            <div class="fp-override-field-clean">
-                                <label>Language <span class="required">*</span></label>
-                                <input type="text" name="builder_slots[${index}][lang]" maxlength="10" required />
-                            </div>
-                            <div class="fp-override-field-clean">
-                                <label>Meeting Point <span class="required">*</span></label>
-                                <select name="builder_slots[${index}][meeting_point_id]" class="fp-meeting-point-select" required>
-                                    <option value="" disabled selected>Select meeting point</option>
-                                </select>
-                            </div>
-                            <div class="fp-override-field-clean">
-                                <label>Adult Price <span class="required">*</span></label>
-                                <input type="number" name="builder_slots[${index}][price_adult]" min="0" step="0.01" required />
-                            </div>
-                            <div class="fp-override-field-clean">
-                                <label>Child Price <span class="required">*</span></label>
-                                <input type="number" name="builder_slots[${index}][price_child]" min="0" step="0.01" required />
+                                <section class="fp-overrides-section-clean" aria-label="Time slot overrides">
+                                    <div class="fp-slot-detail-header">
+                                        <div>
+                                            <h4>Booking details</h4>
+                                            <p>Adjust capacity, pricing, and duration for this specific time slot.</p>
+                                        </div>
+                                    </div>
+                                    <div class="fp-overrides-grid-clean">
+                                        <div class="fp-override-field-clean">
+                                            <label>Duration (minutes) <span class="required">*</span></label>
+                                            <input type="number" name="builder_slots[${index}][duration_min]" min="1" required />
+                                        </div>
+                                        <div class="fp-override-field-clean">
+                                            <label>Capacity <span class="required">*</span></label>
+                                            <input type="number" name="builder_slots[${index}][capacity]" min="1" required />
+                                        </div>
+                                        <div class="fp-override-field-clean">
+                                            <label>Language <span class="required">*</span></label>
+                                            <input type="text" name="builder_slots[${index}][lang]" maxlength="10" required />
+                                        </div>
+                                        <div class="fp-override-field-clean">
+                                            <label>Meeting point <span class="required">*</span></label>
+                                            <select name="builder_slots[${index}][meeting_point_id]" class="fp-meeting-point-select" required>
+                                                <option value="" disabled selected>Select meeting point</option>
+                                            </select>
+                                        </div>
+                                        <div class="fp-override-field-clean">
+                                            <label>Adult price <span class="required">*</span></label>
+                                            <input type="number" name="builder_slots[${index}][price_adult]" min="0" step="0.01" required />
+                                        </div>
+                                        <div class="fp-override-field-clean">
+                                            <label>Child price <span class="required">*</span></label>
+                                            <input type="number" name="builder_slots[${index}][price_child]" min="0" step="0.01" required />
+                                        </div>
+                                    </div>
+                                </section>
                             </div>
                         </div>
                     </div>
@@ -374,21 +511,108 @@
          */
         createDayPills: function(index) {
             const days = [
-                {value: '1', label: 'Mon'},
-                {value: '2', label: 'Tue'},
-                {value: '3', label: 'Wed'},
-                {value: '4', label: 'Thu'},
-                {value: '5', label: 'Fri'},
-                {value: '6', label: 'Sat'},
-                {value: '0', label: 'Sun'}
+                { value: '1', label: 'Mon', full: 'Monday' },
+                { value: '2', label: 'Tue', full: 'Tuesday' },
+                { value: '3', label: 'Wed', full: 'Wednesday' },
+                { value: '4', label: 'Thu', full: 'Thursday' },
+                { value: '5', label: 'Fri', full: 'Friday' },
+                { value: '6', label: 'Sat', full: 'Saturday' },
+                { value: '0', label: 'Sun', full: 'Sunday' }
             ];
 
             return days.map(day => `
                 <div class="fp-day-pill-clean">
                     <input type="checkbox" id="day-${index}-${day.value}" name="builder_slots[${index}][days][]" value="${day.value}">
-                    <label for="day-${index}-${day.value}">${day.label}</label>
+                    <label for="day-${index}-${day.value}" title="${day.full}">
+                        <span class="fp-slot-day__abbr">${day.label}</span>
+                        <span class="fp-slot-day__full">${day.full}</span>
+                    </label>
                 </div>
             `).join('');
+        },
+
+        collectTimeSlotCardData: function($card) {
+            if (!$card || !$card.length) {
+                return {};
+            }
+
+            return {
+                start_time: ($card.find('input[name*="[start_time]"]').val() || '').trim(),
+                days: $card.find('input[name*="[days][]"]:checked').map(function() {
+                    return String($(this).val());
+                }).get(),
+                duration_min: ($card.find('input[name*="[duration_min]"]').val() || '').trim(),
+                capacity: ($card.find('input[name*="[capacity]"]').val() || '').trim(),
+                lang: ($card.find('input[name*="[lang]"]').val() || '').trim(),
+                meeting_point_id: ($card.find('select[name*="[meeting_point_id]"]').val() || '').toString(),
+                price_adult: ($card.find('input[name*="[price_adult]"]').val() || '').trim(),
+                price_child: ($card.find('input[name*="[price_child]"]').val() || '').trim()
+            };
+        },
+
+        applyTimeSlotCardData: function($card, slotData) {
+            if (!$card || !$card.length || !slotData) {
+                return;
+            }
+
+            if (slotData.start_time) {
+                $card.find('input[name*="[start_time]"]').val(slotData.start_time);
+            }
+
+            $card.find('input[name*="[days][]"]').prop('checked', false);
+            if (Array.isArray(slotData.days) && slotData.days.length) {
+                slotData.days.forEach(function(dayValue) {
+                    $card.find('input[name*="[days][]"][value="' + String(dayValue) + '"]').prop('checked', true);
+                });
+            }
+
+            if (slotData.duration_min) {
+                $card.find('input[name*="[duration_min]"]').val(slotData.duration_min);
+            }
+
+            if (slotData.capacity) {
+                $card.find('input[name*="[capacity]"]').val(slotData.capacity);
+            }
+
+            if (slotData.lang) {
+                $card.find('input[name*="[lang]"]').val(slotData.lang);
+            }
+
+            if (slotData.meeting_point_id) {
+                var meetingValue = String(slotData.meeting_point_id);
+                var $select = $card.find('select[name*="[meeting_point_id]"]');
+                var meetingPoints = (window.fp_esperienze_admin && fp_esperienze_admin.fp_meeting_points) ? fp_esperienze_admin.fp_meeting_points : {};
+                var optionExists = $select.find('option').filter(function() {
+                    return String($(this).val()) === meetingValue;
+                }).length > 0;
+
+                if (!optionExists) {
+                    var label = meetingPoints && meetingPoints[meetingValue] ? meetingPoints[meetingValue] : meetingValue;
+                    $select.append($('<option>').val(meetingValue).text(label));
+                }
+
+                $select.val(meetingValue);
+            }
+
+            if (slotData.price_adult) {
+                $card.find('input[name*="[price_adult]"]').val(slotData.price_adult);
+            }
+
+            if (slotData.price_child) {
+                $card.find('input[name*="[price_child]"]').val(slotData.price_child);
+            }
+        },
+
+        updateSlotChips: function() {
+            $('#fp-time-slots-container .fp-time-slot-card-clean').each(function(position) {
+                var $chip = $(this).find('.fp-slot-chip');
+                if (!$chip.length) {
+                    return;
+                }
+
+                var slotNumber = (position + 1).toString().padStart(2, '0');
+                $chip.text('Slot ' + slotNumber);
+            });
         }
     };
 

--- a/includes/ProductType/Experience.php
+++ b/includes/ProductType/Experience.php
@@ -1149,127 +1149,179 @@ class Experience {
                         );
                 }
 
+                $slot_number_display = str_pad( (string) ( $index + 1 ), 2, '0', STR_PAD_LEFT );
                 ?>
                 <div class="fp-time-slot-content-clean">
-                        <div class="fp-slot-status-badges">
-                                <?php foreach ( $status_badges as $badge ) :
-                                        $badge_classes = array(
-                                                'fp-slot-status-badge',
-                                                sanitize_html_class( $badge['class'] )
-                                        );
-                                        ?>
-                                        <span class="<?php echo esc_attr( implode( ' ', $badge_classes ) ); ?>">
-                                                <span class="dashicons dashicons-<?php echo esc_attr( $badge['icon'] ); ?>" aria-hidden="true"></span>
-                                                <?php echo esc_html( $badge['label'] ); ?>
-                                        </span>
-                                <?php endforeach; ?>
-                        </div>
-
-                        <!-- Time slot header -->
-                        <div class="fp-time-slot-header-clean">
-                                <div class="fp-time-field-clean form-field fp-field fp-field--time">
-                                        <label for="time-<?php echo esc_attr( $index ); ?>">
-                                                <span class="dashicons dashicons-clock"></span>
-                                                <?php _e( 'Start Time', 'fp-esperienze' ); ?> <span class="required">*</span>
-                                        </label>
-					<input type="time" 
-							id="time-<?php echo esc_attr( $index ); ?>"
-							name="builder_slots[<?php echo esc_attr( $index ); ?>][start_time]" 
-							value="<?php echo esc_attr( $slot['start_time'] ?? '' ); ?>" 
-							required>
-				</div>
-				
-                                <div class="fp-days-field-clean form-field fp-field fp-field--days">
-                                        <label>
-                                                <span class="dashicons dashicons-calendar-alt"></span>
-                                                <?php _e( 'Days of Week', 'fp-esperienze' ); ?> <span class="required">*</span>
-                                        </label>
-					<div class="fp-days-pills-clean">
-						<?php foreach ( $days as $day_value => $day_label ) : ?>
-							<div class="fp-day-pill-clean">
-								<input type="checkbox" 
-										id="day-<?php echo esc_attr( $index ); ?>-<?php echo esc_attr( $day_value ); ?>"
-										name="builder_slots[<?php echo esc_attr( $index ); ?>][days][]" 
-										value="<?php echo esc_attr( $day_value ); ?>"
-										<?php checked( in_array( $day_value, $slot['days'] ?? array() ) ); ?>>
-								<label for="day-<?php echo esc_attr( $index ); ?>-<?php echo esc_attr( $day_value ); ?>">
-									<?php echo esc_html( substr( $day_label, 0, 3 ) ); ?>
-								</label>
-							</div>
-						<?php endforeach; ?>
-					</div>
-				</div>
-				
-                                <div class="fp-slot-actions-clean">
-                                        <button type="button" class="button button-link-delete fp-remove-time-slot-clean" data-index="<?php echo esc_attr( $index ); ?>" aria-label="<?php esc_attr_e( 'Remove time slot', 'fp-esperienze' ); ?>">
-                                                <span class="dashicons dashicons-trash" aria-hidden="true"></span>
-                                                <?php _e( 'Remove slot', 'fp-esperienze' ); ?>
-                                        </button>
+                        <div class="fp-slot-card-inner">
+                                <div class="fp-slot-rail" aria-hidden="true">
+                                        <span class="fp-slot-rail__dot"></span>
+                                        <span class="fp-slot-rail__line"></span>
                                 </div>
-			</div>
-			
-			<!-- Slot settings -->
-			<div class="fp-overrides-section-clean">
-				<div class="fp-overrides-grid-clean">
-					<div class="fp-override-field-clean">
-						<label><?php _e( 'Duration (minutes)', 'fp-esperienze' ); ?></label>
-						<input type="number"
-								name="builder_slots[<?php echo esc_attr( $index ); ?>][duration_min]"
-								value="<?php echo esc_attr( $slot['duration_min'] ?? $default_duration ); ?>"
-								min="1"
-								required>
-					</div>
 
-					<div class="fp-override-field-clean">
-						<label><?php _e( 'Capacity', 'fp-esperienze' ); ?></label>
-						<input type="number"
-								name="builder_slots[<?php echo esc_attr( $index ); ?>][capacity]"
-								value="<?php echo esc_attr( $slot['capacity'] ?? $default_capacity ); ?>"
-								min="1"
-								required>
-					</div>
+                                <div class="fp-slot-content">
+                                        <header class="fp-slot-header">
+                                                <div class="fp-slot-header__meta">
+                                                        <span class="fp-slot-chip">
+                                                                <?php
+                                                                printf(
+                                                                        /* translators: %s: Slot number */
+                                                                        esc_html__( 'Slot %s', 'fp-esperienze' ),
+                                                                        esc_html( $slot_number_display )
+                                                                );
+                                                                ?>
+                                                        </span>
+                                                        <p class="fp-slot-subtitle"><?php _e( 'Recurring weekly availability', 'fp-esperienze' ); ?></p>
 
-					<div class="fp-override-field-clean">
-						<label><?php _e( 'Language', 'fp-esperienze' ); ?></label>
-						<input type="text"
-								name="builder_slots[<?php echo esc_attr( $index ); ?>][lang]"
-								value="<?php echo esc_attr( $slot['lang'] ?? $default_language ); ?>"
-								maxlength="10"
-								required>
-					</div>
+                                                        <?php if ( ! empty( $status_badges ) ) : ?>
+                                                                <div class="fp-slot-status-badges">
+                                                                        <?php foreach ( $status_badges as $badge ) :
+                                                                                $badge_classes = array(
+                                                                                        'fp-slot-status-badge',
+                                                                                        sanitize_html_class( $badge['class'] )
+                                                                                );
+                                                                                ?>
+                                                                                <span class="<?php echo esc_attr( implode( ' ', $badge_classes ) ); ?>">
+                                                                                        <span class="dashicons dashicons-<?php echo esc_attr( $badge['icon'] ); ?>" aria-hidden="true"></span>
+                                                                                        <?php echo esc_html( $badge['label'] ); ?>
+                                                                                </span>
+                                                                        <?php endforeach; ?>
+                                                                </div>
+                                                        <?php endif; ?>
+                                                </div>
 
-					<div class="fp-override-field-clean">
-						<label><?php _e( 'Meeting Point', 'fp-esperienze' ); ?></label>
-						<select name="builder_slots[<?php echo esc_attr( $index ); ?>][meeting_point_id]" required>
-							<?php foreach ( $meeting_points as $mp_id => $mp_name ) : ?>
-								<option value="<?php echo esc_attr( $mp_id ); ?>" <?php selected( $slot['meeting_point_id'] ?? $default_meeting_point, $mp_id ); ?>>
-									<?php echo esc_html( $mp_name ); ?>
-								</option>
-							<?php endforeach; ?>
-						</select>
-					</div>
+                                                <div class="fp-slot-actions-clean">
+                                                        <button type="button" class="button fp-duplicate-time-slot-clean" data-index="<?php echo esc_attr( $index ); ?>" aria-label="<?php esc_attr_e( 'Duplicate time slot', 'fp-esperienze' ); ?>">
+                                                                <span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
+                                                                <?php _e( 'Duplicate slot', 'fp-esperienze' ); ?>
+                                                        </button>
+                                                        <button type="button" class="button button-link-delete fp-remove-time-slot-clean" data-index="<?php echo esc_attr( $index ); ?>" aria-label="<?php esc_attr_e( 'Remove time slot', 'fp-esperienze' ); ?>">
+                                                                <span class="dashicons dashicons-trash" aria-hidden="true"></span>
+                                                                <?php _e( 'Remove slot', 'fp-esperienze' ); ?>
+                                                        </button>
+                                                </div>
+                                        </header>
 
-					<div class="fp-override-field-clean">
-						<label><?php _e( 'Adult Price', 'fp-esperienze' ); ?> (<?php echo get_woocommerce_currency_symbol(); ?>)</label>
-						<input type="number"
-								name="builder_slots[<?php echo esc_attr( $index ); ?>][price_adult]"
-								value="<?php echo esc_attr( $slot['price_adult'] ?? $default_price_adult ); ?>"
-								min="0"
-								step="0.01"
-								required>
-					</div>
+                                        <div class="fp-slot-primary">
+                                                <div class="fp-slot-primary__field fp-time-field-clean form-field fp-field fp-field--time">
+                                                        <label for="time-<?php echo esc_attr( $index ); ?>" class="fp-slot-field-label">
+                                                                <span class="dashicons dashicons-clock" aria-hidden="true"></span>
+                                                                <span class="fp-slot-label-text"><?php _e( 'Start Time', 'fp-esperienze' ); ?> <span class="required">*</span></span>
+                                                        </label>
+                                                        <div class="fp-slot-time-input">
+                                                                <input type="time"
+                                                                                id="time-<?php echo esc_attr( $index ); ?>"
+                                                                                name="builder_slots[<?php echo esc_attr( $index ); ?>][start_time]"
+                                                                                value="<?php echo esc_attr( $slot['start_time'] ?? '' ); ?>"
+                                                                                required>
+                                                        </div>
+                                                        <p class="fp-slot-hint"><?php _e( 'Guests see this start time in their timezone.', 'fp-esperienze' ); ?></p>
+                                                </div>
 
-					<div class="fp-override-field-clean">
-						<label><?php _e( 'Child Price', 'fp-esperienze' ); ?> (<?php echo get_woocommerce_currency_symbol(); ?>)</label>
-						<input type="number"
-								name="builder_slots[<?php echo esc_attr( $index ); ?>][price_child]"
-								value="<?php echo esc_attr( $slot['price_child'] ?? $default_price_child ); ?>"
-								min="0"
-								step="0.01"
-								required>
-					</div>
-				</div>
-			</div>
+                                                <div class="fp-slot-primary__field fp-days-field-clean form-field fp-field fp-field--days">
+                                                        <label class="fp-slot-field-label">
+                                                                <span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
+                                                                <span class="fp-slot-label-text"><?php _e( 'Days of Week', 'fp-esperienze' ); ?> <span class="required">*</span></span>
+                                                        </label>
+                                                        <div class="fp-slot-day-grid fp-days-pills-clean">
+                                                                <?php foreach ( $days as $day_value => $day_label ) :
+                                                                        $day_abbr = wp_html_excerpt( $day_label, 3, '' );
+                                                                        ?>
+                                                                        <div class="fp-day-pill-clean">
+                                                                                <input type="checkbox"
+                                                                                                id="day-<?php echo esc_attr( $index ); ?>-<?php echo esc_attr( $day_value ); ?>"
+                                                                                                name="builder_slots[<?php echo esc_attr( $index ); ?>][days][]"
+                                                                                                value="<?php echo esc_attr( $day_value ); ?>"
+                                                                                                <?php checked( in_array( $day_value, $slot['days'] ?? array(), true ) ); ?>>
+                                                                                <label for="day-<?php echo esc_attr( $index ); ?>-<?php echo esc_attr( $day_value ); ?>" title="<?php echo esc_attr( $day_label ); ?>">
+                                                                                        <span class="fp-slot-day__abbr"><?php echo esc_html( $day_abbr ); ?></span>
+                                                                                        <span class="fp-slot-day__full"><?php echo esc_html( $day_label ); ?></span>
+                                                                                </label>
+                                                                        </div>
+                                                                <?php endforeach; ?>
+                                                        </div>
+                                                        <p class="fp-slot-hint"><?php _e( 'Select at least one day to activate this slot.', 'fp-esperienze' ); ?></p>
+                                                </div>
+
+                                                <div class="fp-slot-primary__field fp-slot-insight">
+                                                        <h4><?php _e( 'Slot notes', 'fp-esperienze' ); ?></h4>
+                                                        <ul class="fp-slot-insight-list">
+                                                                <li><span class="dashicons dashicons-update" aria-hidden="true"></span><?php _e( 'Repeats weekly on your chosen days.', 'fp-esperienze' ); ?></li>
+                                                                <li><span class="dashicons dashicons-admin-generic" aria-hidden="true"></span><?php _e( 'Overrides below replace product defaults.', 'fp-esperienze' ); ?></li>
+                                                                <li><span class="dashicons dashicons-visibility" aria-hidden="true"></span><?php _e( 'Customers only see published, in-season slots.', 'fp-esperienze' ); ?></li>
+                                                        </ul>
+                                                </div>
+                                        </div>
+
+                                        <section class="fp-overrides-section-clean" aria-label="<?php esc_attr_e( 'Time slot overrides', 'fp-esperienze' ); ?>">
+                                                <div class="fp-slot-detail-header">
+                                                        <div>
+                                                                <h4><?php _e( 'Booking details', 'fp-esperienze' ); ?></h4>
+                                                                <p><?php _e( 'Adjust capacity, pricing, and duration for this specific time slot.', 'fp-esperienze' ); ?></p>
+                                                        </div>
+                                                </div>
+
+                                                <div class="fp-overrides-grid-clean">
+                                                        <div class="fp-override-field-clean">
+                                                                <label><?php _e( 'Duration (minutes)', 'fp-esperienze' ); ?></label>
+                                                                <input type="number"
+                                                                                name="builder_slots[<?php echo esc_attr( $index ); ?>][duration_min]"
+                                                                                value="<?php echo esc_attr( $slot['duration_min'] ?? $default_duration ); ?>"
+                                                                                min="1"
+                                                                                required>
+                                                        </div>
+
+                                                        <div class="fp-override-field-clean">
+                                                                <label><?php _e( 'Capacity', 'fp-esperienze' ); ?></label>
+                                                                <input type="number"
+                                                                                name="builder_slots[<?php echo esc_attr( $index ); ?>][capacity]"
+                                                                                value="<?php echo esc_attr( $slot['capacity'] ?? $default_capacity ); ?>"
+                                                                                min="1"
+                                                                                required>
+                                                        </div>
+
+                                                        <div class="fp-override-field-clean">
+                                                                <label><?php _e( 'Language', 'fp-esperienze' ); ?></label>
+                                                                <input type="text"
+                                                                                name="builder_slots[<?php echo esc_attr( $index ); ?>][lang]"
+                                                                                value="<?php echo esc_attr( $slot['lang'] ?? $default_language ); ?>"
+                                                                                maxlength="10"
+                                                                                required>
+                                                        </div>
+
+                                                        <div class="fp-override-field-clean">
+                                                                <label><?php _e( 'Meeting Point', 'fp-esperienze' ); ?></label>
+                                                                <select name="builder_slots[<?php echo esc_attr( $index ); ?>][meeting_point_id]" required>
+                                                                        <?php foreach ( $meeting_points as $mp_id => $mp_name ) : ?>
+                                                                                <option value="<?php echo esc_attr( $mp_id ); ?>" <?php selected( $slot['meeting_point_id'] ?? $default_meeting_point, $mp_id ); ?>>
+                                                                                        <?php echo esc_html( $mp_name ); ?>
+                                                                                </option>
+                                                                        <?php endforeach; ?>
+                                                                </select>
+                                                        </div>
+
+                                                        <div class="fp-override-field-clean">
+                                                                <label><?php _e( 'Adult Price', 'fp-esperienze' ); ?> (<?php echo get_woocommerce_currency_symbol(); ?>)</label>
+                                                                <input type="number"
+                                                                                name="builder_slots[<?php echo esc_attr( $index ); ?>][price_adult]"
+                                                                                value="<?php echo esc_attr( $slot['price_adult'] ?? $default_price_adult ); ?>"
+                                                                                min="0"
+                                                                                step="0.01"
+                                                                                required>
+                                                        </div>
+
+                                                        <div class="fp-override-field-clean">
+                                                                <label><?php _e( 'Child Price', 'fp-esperienze' ); ?> (<?php echo get_woocommerce_currency_symbol(); ?>)</label>
+                                                                <input type="number"
+                                                                                name="builder_slots[<?php echo esc_attr( $index ); ?>][price_child]"
+                                                                                value="<?php echo esc_attr( $slot['price_child'] ?? $default_price_child ); ?>"
+                                                                                min="0"
+                                                                                step="0.01"
+                                                                                required>
+                                                        </div>
+                                                </div>
+                                        </section>
+                                </div>
+                        </div>
 			
 			<!-- Store schedule IDs for updates -->
 			<?php if ( ! empty( $slot['schedule_ids'] ) ) : ?>

--- a/languages/fp-esperienze-en_US.po
+++ b/languages/fp-esperienze-en_US.po
@@ -3901,6 +3901,36 @@ msgstr "Enter the start time for this experience slot in 24-hour format"
 msgid "Select which days of the week this time slot is available"
 msgstr "Select which days of the week this time slot is available"
 
+msgid "Slot %s"
+msgstr "Slot %s"
+
+msgid "Recurring weekly availability"
+msgstr "Recurring weekly availability"
+
+msgid "Guests see this start time in their timezone."
+msgstr "Guests see this start time in their timezone."
+
+msgid "Select at least one day to activate this slot."
+msgstr "Select at least one day to activate this slot."
+
+msgid "Slot notes"
+msgstr "Slot notes"
+
+msgid "Repeats weekly on your chosen days."
+msgstr "Repeats weekly on your chosen days."
+
+msgid "Overrides below replace product defaults."
+msgstr "Overrides below replace product defaults."
+
+msgid "Customers only see published, in-season slots."
+msgstr "Customers only see published, in-season slots."
+
+msgid "Time slot overrides"
+msgstr "Time slot overrides"
+
+msgid "Adjust capacity, pricing, and duration for this specific time slot."
+msgstr "Adjust capacity, pricing, and duration for this specific time slot."
+
 #: includes/ProductType/Experience.php:857
 #: includes/ProductType/Experience.php:868
 #: includes/ProductType/Experience.php:878
@@ -5305,4 +5335,25 @@ msgstr "Failed to add to cart. Please try again."
 
 msgid "Push token is too long. Please try again with a valid token."
 msgstr "Push token is too long. Please try again with a valid token."
+
+
+#: includes/ProductType/Experience.php:1188
+msgid "Duplicate time slot"
+msgstr "Duplicate time slot"
+
+#: includes/ProductType/Experience.php:1190 assets/js/admin.js:2365 assets/js/modules/schedule-builder.js:404
+msgid "Duplicate slot"
+msgstr "Duplicate slot"
+
+#: assets/js/admin.js:1680 assets/js/modules/schedule-builder.js:83 assets/js/modules/schedule-builder.js:301
+msgid "Time slot duplicated"
+msgstr "Time slot duplicated"
+
+#: assets/js/admin.js:1686 assets/js/modules/schedule-builder.js:89 assets/js/modules/schedule-builder.js:307
+msgid "Unable to duplicate this time slot. Please try again."
+msgstr "Unable to duplicate this time slot. Please try again."
+
+#: assets/js/admin.js:2336
+msgid "An unexpected error occurred while adding the time slot. Please try again."
+msgstr "An unexpected error occurred while adding the time slot. Please try again."
 

--- a/languages/fp-esperienze-it_IT.po
+++ b/languages/fp-esperienze-it_IT.po
@@ -3995,6 +3995,36 @@ msgid "Select which days of the week this time slot is available"
 msgstr ""
 "Seleziona quali giorni della settimana questa fascia oraria è disponibile"
 
+msgid "Slot %s"
+msgstr "Slot %s"
+
+msgid "Recurring weekly availability"
+msgstr "Disponibilità ricorrente settimanale"
+
+msgid "Guests see this start time in their timezone."
+msgstr "Gli ospiti vedono questo orario nel proprio fuso orario."
+
+msgid "Select at least one day to activate this slot."
+msgstr "Seleziona almeno un giorno per attivare questo slot."
+
+msgid "Slot notes"
+msgstr "Note sullo slot"
+
+msgid "Repeats weekly on your chosen days."
+msgstr "Si ripete settimanalmente nei giorni scelti."
+
+msgid "Overrides below replace product defaults."
+msgstr "Le personalizzazioni qui sotto sostituiscono i valori predefiniti del prodotto."
+
+msgid "Customers only see published, in-season slots."
+msgstr "I clienti vedono solo gli slot pubblicati e disponibili in stagione."
+
+msgid "Time slot overrides"
+msgstr "Personalizzazioni dello slot orario"
+
+msgid "Adjust capacity, pricing, and duration for this specific time slot."
+msgstr "Modifica capacità, prezzi e durata per questo specifico slot orario."
+
 #: includes/ProductType/Experience.php:857
 #: includes/ProductType/Experience.php:868
 #: includes/ProductType/Experience.php:878
@@ -5447,4 +5477,25 @@ msgstr "Nessun evento trovato."
 
 msgid "Push token is too long. Please try again with a valid token."
 msgstr "Il token push è troppo lungo. Riprova con un token valido."
+
+
+#: includes/ProductType/Experience.php:1188
+msgid "Duplicate time slot"
+msgstr "Duplica fascia oraria"
+
+#: includes/ProductType/Experience.php:1190 assets/js/admin.js:2365 assets/js/modules/schedule-builder.js:404
+msgid "Duplicate slot"
+msgstr "Duplica fascia"
+
+#: assets/js/admin.js:1680 assets/js/modules/schedule-builder.js:83 assets/js/modules/schedule-builder.js:301
+msgid "Time slot duplicated"
+msgstr "Fascia oraria duplicata"
+
+#: assets/js/admin.js:1686 assets/js/modules/schedule-builder.js:89 assets/js/modules/schedule-builder.js:307
+msgid "Unable to duplicate this time slot. Please try again."
+msgstr "Impossibile duplicare questa fascia oraria. Riprova."
+
+#: assets/js/admin.js:2336
+msgid "An unexpected error occurred while adding the time slot. Please try again."
+msgstr "Si è verificato un errore imprevisto durante l'aggiunta della fascia oraria. Riprova."
 

--- a/schedule-builder-preview.html
+++ b/schedule-builder-preview.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FP Esperienze Schedule Builder - UI Preview</title>
+    <link rel="stylesheet" href="https://s.w.org/wp-includes/css/dashicons.css">
+    <link rel="stylesheet" href="assets/css/admin.css">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -243,117 +245,319 @@
                     <h5>Weekly Programming</h5>
                     <p class="description">Create time slots that apply to multiple days. Override values are inherited from product defaults above.</p>
                     
-                    <!-- Time Slot 1 -->
-                    <div class="fp-time-slot-row">
-                        <div class="fp-time-slot-header">
-                            <div style="flex: 0 0 120px;">
-                                <label>Start Time <span class="required">*</span></label>
-                                <input type="time" value="09:00" required>
-                            </div>
-                            
-                            <div style="flex: 1;">
-                                <label>Days <span class="required">*</span></label>
-                                <div class="fp-days-checkboxes">
-                                    <label><input type="checkbox" checked> <span>Monday</span></label>
-                                    <label><input type="checkbox"> <span>Tuesday</span></label>
-                                    <label><input type="checkbox" checked> <span>Wednesday</span></label>
-                                    <label><input type="checkbox"> <span>Thursday</span></label>
-                                    <label><input type="checkbox" checked> <span>Friday</span></label>
-                                    <label><input type="checkbox"> <span>Saturday</span></label>
-                                    <label><input type="checkbox"> <span>Sunday</span></label>
+                    <div id="fp-time-slots-container" class="fp-time-slots-container-clean">
+                        <div class="fp-time-slot-card fp-time-slot-card-clean" data-index="0">
+                            <div class="fp-time-slot-content-clean">
+                                <div class="fp-slot-card-inner">
+                                    <div class="fp-slot-rail" aria-hidden="true">
+                                        <span class="fp-slot-rail__dot"></span>
+                                        <span class="fp-slot-rail__line"></span>
+                                    </div>
+                                    <div class="fp-slot-content">
+                                        <header class="fp-slot-header">
+                                            <div class="fp-slot-header__meta">
+                                                <span class="fp-slot-chip">Slot 01</span>
+                                                <p class="fp-slot-subtitle">Recurring weekly availability</p>
+                                                <div class="fp-slot-status-badges">
+                                                    <span class="fp-slot-status-badge is-success"><span class="dashicons dashicons-yes"></span>2 active slots</span>
+                                                    <span class="fp-slot-status-badge is-info"><span class="dashicons dashicons-calendar-alt"></span>3 days selected</span>
+                                                </div>
+                                            </div>
+                                            <div class="fp-slot-actions-clean">
+                                                <button type="button" class="button fp-duplicate-time-slot-clean">
+                                                    <span class="dashicons dashicons-admin-page"></span>
+                                                    Duplicate slot
+                                                </button>
+                                                <button type="button" class="button button-link-delete fp-remove-time-slot-clean">
+                                                    <span class="dashicons dashicons-trash"></span>
+                                                    Remove slot
+                                                </button>
+                                            </div>
+                                        </header>
+
+                                        <div class="fp-slot-primary">
+                                            <div class="fp-slot-primary__field fp-time-field-clean form-field fp-field fp-field--time">
+                                                <label for="preview-time-0" class="fp-slot-field-label">
+                                                    <span class="dashicons dashicons-clock"></span>
+                                                    <span class="fp-slot-label-text">Start Time <span class="required">*</span></span>
+                                                </label>
+                                                <div class="fp-slot-time-input">
+                                                    <input type="time" id="preview-time-0" value="09:00">
+                                                </div>
+                                                <p class="fp-slot-hint">Guests see this start time in their timezone.</p>
+                                            </div>
+
+                                            <div class="fp-slot-primary__field fp-days-field-clean form-field fp-field fp-field--days">
+                                                <label class="fp-slot-field-label">
+                                                    <span class="dashicons dashicons-calendar-alt"></span>
+                                                    <span class="fp-slot-label-text">Days of Week <span class="required">*</span></span>
+                                                </label>
+                                                <div class="fp-slot-day-grid fp-days-pills-clean">
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-0-1" checked>
+                                                        <label for="preview-day-0-1" title="Monday">
+                                                            <span class="fp-slot-day__abbr">Mon</span>
+                                                            <span class="fp-slot-day__full">Monday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-0-2">
+                                                        <label for="preview-day-0-2" title="Tuesday">
+                                                            <span class="fp-slot-day__abbr">Tue</span>
+                                                            <span class="fp-slot-day__full">Tuesday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-0-3" checked>
+                                                        <label for="preview-day-0-3" title="Wednesday">
+                                                            <span class="fp-slot-day__abbr">Wed</span>
+                                                            <span class="fp-slot-day__full">Wednesday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-0-4">
+                                                        <label for="preview-day-0-4" title="Thursday">
+                                                            <span class="fp-slot-day__abbr">Thu</span>
+                                                            <span class="fp-slot-day__full">Thursday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-0-5" checked>
+                                                        <label for="preview-day-0-5" title="Friday">
+                                                            <span class="fp-slot-day__abbr">Fri</span>
+                                                            <span class="fp-slot-day__full">Friday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-0-6">
+                                                        <label for="preview-day-0-6" title="Saturday">
+                                                            <span class="fp-slot-day__abbr">Sat</span>
+                                                            <span class="fp-slot-day__full">Saturday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-0-0">
+                                                        <label for="preview-day-0-0" title="Sunday">
+                                                            <span class="fp-slot-day__abbr">Sun</span>
+                                                            <span class="fp-slot-day__full">Sunday</span>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <p class="fp-slot-hint">Select at least one day to activate this slot.</p>
+                                            </div>
+
+                                            <div class="fp-slot-primary__field fp-slot-insight">
+                                                <h4>Slot notes</h4>
+                                                <ul class="fp-slot-insight-list">
+                                                    <li><span class="dashicons dashicons-update"></span>Repeats weekly on your chosen days.</li>
+                                                    <li><span class="dashicons dashicons-admin-generic"></span>Overrides below replace product defaults.</li>
+                                                    <li><span class="dashicons dashicons-visibility"></span>Customers only see published, in-season slots.</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+
+                                        <section class="fp-overrides-section-clean" aria-label="Time slot overrides">
+                                            <div class="fp-slot-detail-header">
+                                                <div>
+                                                    <h4>Booking details</h4>
+                                                    <p>Adjust capacity, pricing, and duration for this specific time slot.</p>
+                                                </div>
+                                            </div>
+                                            <div class="fp-overrides-grid-clean">
+                                                <div class="fp-override-field-clean">
+                                                    <label>Duration (minutes)</label>
+                                                    <input type="number" value="90" min="1">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Capacity</label>
+                                                    <input type="number" value="12" min="1">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Language</label>
+                                                    <input type="text" value="it" maxlength="10">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Meeting Point</label>
+                                                    <select>
+                                                        <option>Piazza San Marco, Venice</option>
+                                                        <option>Colosseum Entrance, Rome</option>
+                                                    </select>
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Adult Price (€)</label>
+                                                    <input type="number" value="25.00" min="0" step="0.01">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Child Price (€)</label>
+                                                    <input type="number" value="15.00" min="0" step="0.01">
+                                                </div>
+                                            </div>
+                                        </section>
+                                    </div>
                                 </div>
                             </div>
-                            
-                            <div style="flex: 0 0 auto;">
-                                <button type="button" class="fp-remove-time-slot">
-                                    🗑️ Remove
-                                </button>
-                            </div>
                         </div>
-                        
-                        <div class="fp-override-toggle">
-                            <label>
-                                <input type="checkbox"> Show advanced overrides
-                            </label>
-                            <span class="description">Override default values for this time slot</span>
+
+                        <div class="fp-time-slot-card fp-time-slot-card-clean" data-index="1">
+                            <div class="fp-time-slot-content-clean">
+                                <div class="fp-slot-card-inner">
+                                    <div class="fp-slot-rail" aria-hidden="true">
+                                        <span class="fp-slot-rail__dot"></span>
+                                        <span class="fp-slot-rail__line"></span>
+                                    </div>
+                                    <div class="fp-slot-content">
+                                        <header class="fp-slot-header">
+                                            <div class="fp-slot-header__meta">
+                                                <span class="fp-slot-chip">Slot 02</span>
+                                                <p class="fp-slot-subtitle">Recurring weekly availability</p>
+                                                <div class="fp-slot-status-badges">
+                                                    <span class="fp-slot-status-badge is-warning"><span class="dashicons dashicons-warning"></span>Needs details</span>
+                                                    <span class="fp-slot-status-badge is-info"><span class="dashicons dashicons-calendar-alt"></span>4 days selected</span>
+                                                </div>
+                                            </div>
+                                            <div class="fp-slot-actions-clean">
+                                                <button type="button" class="button fp-duplicate-time-slot-clean">
+                                                    <span class="dashicons dashicons-admin-page"></span>
+                                                    Duplicate slot
+                                                </button>
+                                                <button type="button" class="button button-link-delete fp-remove-time-slot-clean">
+                                                    <span class="dashicons dashicons-trash"></span>
+                                                    Remove slot
+                                                </button>
+                                            </div>
+                                        </header>
+
+                                        <div class="fp-slot-primary">
+                                            <div class="fp-slot-primary__field fp-time-field-clean form-field fp-field fp-field--time">
+                                                <label for="preview-time-1" class="fp-slot-field-label">
+                                                    <span class="dashicons dashicons-clock"></span>
+                                                    <span class="fp-slot-label-text">Start Time <span class="required">*</span></span>
+                                                </label>
+                                                <div class="fp-slot-time-input">
+                                                    <input type="time" id="preview-time-1" value="14:30">
+                                                </div>
+                                                <p class="fp-slot-hint">Guests see this start time in their timezone.</p>
+                                            </div>
+
+                                            <div class="fp-slot-primary__field fp-days-field-clean form-field fp-field fp-field--days">
+                                                <label class="fp-slot-field-label">
+                                                    <span class="dashicons dashicons-calendar-alt"></span>
+                                                    <span class="fp-slot-label-text">Days of Week <span class="required">*</span></span>
+                                                </label>
+                                                <div class="fp-slot-day-grid fp-days-pills-clean">
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-1-1">
+                                                        <label for="preview-day-1-1" title="Monday">
+                                                            <span class="fp-slot-day__abbr">Mon</span>
+                                                            <span class="fp-slot-day__full">Monday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-1-2" checked>
+                                                        <label for="preview-day-1-2" title="Tuesday">
+                                                            <span class="fp-slot-day__abbr">Tue</span>
+                                                            <span class="fp-slot-day__full">Tuesday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-1-3">
+                                                        <label for="preview-day-1-3" title="Wednesday">
+                                                            <span class="fp-slot-day__abbr">Wed</span>
+                                                            <span class="fp-slot-day__full">Wednesday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-1-4" checked>
+                                                        <label for="preview-day-1-4" title="Thursday">
+                                                            <span class="fp-slot-day__abbr">Thu</span>
+                                                            <span class="fp-slot-day__full">Thursday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-1-5">
+                                                        <label for="preview-day-1-5" title="Friday">
+                                                            <span class="fp-slot-day__abbr">Fri</span>
+                                                            <span class="fp-slot-day__full">Friday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-1-6" checked>
+                                                        <label for="preview-day-1-6" title="Saturday">
+                                                            <span class="fp-slot-day__abbr">Sat</span>
+                                                            <span class="fp-slot-day__full">Saturday</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="fp-day-pill-clean">
+                                                        <input type="checkbox" id="preview-day-1-0" checked>
+                                                        <label for="preview-day-1-0" title="Sunday">
+                                                            <span class="fp-slot-day__abbr">Sun</span>
+                                                            <span class="fp-slot-day__full">Sunday</span>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <p class="fp-slot-hint">Select at least one day to activate this slot.</p>
+                                            </div>
+
+                                            <div class="fp-slot-primary__field fp-slot-insight">
+                                                <h4>Slot notes</h4>
+                                                <ul class="fp-slot-insight-list">
+                                                    <li><span class="dashicons dashicons-update"></span>Repeats weekly on your chosen days.</li>
+                                                    <li><span class="dashicons dashicons-admin-generic"></span>Overrides below replace product defaults.</li>
+                                                    <li><span class="dashicons dashicons-visibility"></span>Customers only see published, in-season slots.</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+
+                                        <section class="fp-overrides-section-clean" aria-label="Time slot overrides">
+                                            <div class="fp-slot-detail-header">
+                                                <div>
+                                                    <h4>Booking details</h4>
+                                                    <p>Adjust capacity, pricing, and duration for this specific time slot.</p>
+                                                </div>
+                                            </div>
+                                            <div class="fp-overrides-grid-clean">
+                                                <div class="fp-override-field-clean">
+                                                    <label>Duration (minutes)</label>
+                                                    <input type="number" value="120" min="1">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Capacity</label>
+                                                    <input type="number" value="10" min="1">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Language</label>
+                                                    <input type="text" value="en" maxlength="10">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Meeting Point</label>
+                                                    <select>
+                                                        <option value="">Select meeting point</option>
+                                                        <option>Piazza San Marco, Venice</option>
+                                                        <option>Colosseum Entrance, Rome</option>
+                                                    </select>
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Adult Price (€)</label>
+                                                    <input type="number" value="35.00" min="0" step="0.01">
+                                                </div>
+                                                <div class="fp-override-field-clean">
+                                                    <label>Child Price (€)</label>
+                                                    <input type="number" value="18.00" min="0" step="0.01">
+                                                </div>
+                                            </div>
+                                        </section>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                    
-                    <!-- Time Slot 2 with overrides shown -->
-                    <div class="fp-time-slot-row">
-                        <div class="fp-time-slot-header">
-                            <div style="flex: 0 0 120px;">
-                                <label>Start Time <span class="required">*</span></label>
-                                <input type="time" value="14:30" required>
-                            </div>
-                            
-                            <div style="flex: 1;">
-                                <label>Days <span class="required">*</span></label>
-                                <div class="fp-days-checkboxes">
-                                    <label><input type="checkbox"> <span>Monday</span></label>
-                                    <label><input type="checkbox" checked> <span>Tuesday</span></label>
-                                    <label><input type="checkbox"> <span>Wednesday</span></label>
-                                    <label><input type="checkbox" checked> <span>Thursday</span></label>
-                                    <label><input type="checkbox"> <span>Friday</span></label>
-                                    <label><input type="checkbox" checked> <span>Saturday</span></label>
-                                    <label><input type="checkbox" checked> <span>Sunday</span></label>
-                                </div>
-                            </div>
-                            
-                            <div style="flex: 0 0 auto;">
-                                <button type="button" class="fp-remove-time-slot">
-                                    🗑️ Remove
-                                </button>
-                            </div>
-                        </div>
-                        
-                        <div class="fp-override-toggle">
-                            <label>
-                                <input type="checkbox" checked> Show advanced overrides
-                            </label>
-                            <span class="description">Override default values for this time slot</span>
-                        </div>
-                        
-                        <div class="fp-overrides-section">
-                            <div class="grid-3" style="margin-bottom: 10px;">
-                                <div>
-                                    <label>Duration (minutes)</label>
-                                    <input type="number" value="120" placeholder="Inherit (90)" min="1">
-                                </div>
-                                <div>
-                                    <label>Capacity</label>
-                                    <input type="number" value="" placeholder="Inherit (12)" min="1">
-                                </div>
-                                <div>
-                                    <label>Language</label>
-                                    <input type="text" value="" placeholder="Inherit (it)" maxlength="10">
-                                </div>
-                            </div>
-                            <div class="grid-3">
-                                <div>
-                                    <label>Meeting Point</label>
-                                    <select>
-                                        <option value="">Inherit (Piazza San Marco, Venice)</option>
-                                        <option>Colosseum Entrance, Rome</option>
-                                    </select>
-                                </div>
-                                <div>
-                                    <label>Adult Price (€)</label>
-                                    <input type="number" value="35.00" placeholder="Inherit (25.00)" min="0" step="0.01">
-                                </div>
-                                <div>
-                                    <label>Child Price (€)</label>
-                                    <input type="number" value="" placeholder="Inherit (15.00)" min="0" step="0.01">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <button type="button" class="fp-add-time-slot">
-                        ➕ Add Time Slot
+
+                    <button type="button" class="fp-add-time-slot" style="margin-top: 24px;">
+                        <span class="dashicons dashicons-plus-alt"></span>
+                        Add Time Slot
                     </button>
                 </div>
-                
+
                 <div class="toggle-section">
                     <label>
                         <input type="checkbox"> Show Advanced Mode
@@ -373,27 +577,31 @@
     <script>
         // Simple demo functionality
         document.addEventListener('DOMContentLoaded', function() {
-            // Toggle overrides sections
-            document.querySelectorAll('.fp-override-toggle input[type="checkbox"]').forEach(function(checkbox) {
-                checkbox.addEventListener('change', function() {
-                    const overridesSection = this.closest('.fp-time-slot-row').querySelector('.fp-overrides-section');
-                    if (this.checked) {
-                        overridesSection.style.display = 'block';
-                    } else {
-                        overridesSection.style.display = 'none';
+            document.querySelectorAll('.fp-slot-day-grid input[type="checkbox"]').forEach(function(input) {
+                input.addEventListener('change', function() {
+                    const card = this.closest('.fp-time-slot-card-clean');
+                    if (!card) {
+                        return;
                     }
+
+                    card.classList.add('fp-newly-added');
+                    setTimeout(function() {
+                        card.classList.remove('fp-newly-added');
+                    }, 500);
                 });
             });
-            
-            // Toggle advanced mode
-            document.querySelector('.toggle-section input[type="checkbox"]').addEventListener('change', function() {
-                const advancedMode = document.querySelector('.advanced-mode');
-                if (this.checked) {
-                    advancedMode.style.display = 'block';
-                } else {
-                    advancedMode.style.display = 'none';
-                }
-            });
+
+            const advancedToggle = document.querySelector('.toggle-section input[type="checkbox"]');
+            if (advancedToggle) {
+                advancedToggle.addEventListener('change', function() {
+                    const advancedMode = document.querySelector('.advanced-mode');
+                    if (!advancedMode) {
+                        return;
+                    }
+
+                    advancedMode.style.display = this.checked ? 'block' : 'none';
+                });
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a duplicate slot control to the schedule builder cards with refreshed responsive styling
- implement duplication handling in the admin and module scripts so copied slots inherit values, renumber chips, and show user feedback
- update the PHP renderer, preview markup, and locale files so the new control and messages are available in both languages

## Testing
- php -l includes/ProductType/Experience.php

------
https://chatgpt.com/codex/tasks/task_e_68d662fb15ac832f915060588606166e