### PR TITLE
Implement paginated events API and update calendar consumers

### DIFF
--- a/includes/Admin/MenuManager.php
+++ b/includes/Admin/MenuManager.php
@@ -327,7 +327,9 @@ class MenuManager {
             ],
             'ajax_url' => admin_url('admin-ajax.php'),
             'rest_url' => rest_url('fp-esperienze/v1/'),
-            'nonce' => wp_create_nonce('fp_esperienze_admin')
+            'nonce' => wp_create_nonce('fp_esperienze_admin'),
+            'calendar_page_size' => 50,
+            'calendar_max_pages' => 20,
         ]);
     }
 

--- a/includes/Booking/BookingManager.php
+++ b/includes/Booking/BookingManager.php
@@ -1510,21 +1510,50 @@ class BookingManager {
      * @param string $end_date End date (Y-m-d format)
      * @return array Bookings within date range
      */
-    public static function getBookingsByDateRange(string $start_date, string $end_date): array {
+    public static function getBookingsByDateRange(string $start_date, string $end_date, int $limit = 50, int $offset = 0): array {
         global $wpdb;
-        
+
         $table_name = $wpdb->prefix . 'fp_bookings';
-        
+
+        $limit = max(1, $limit);
+        $offset = max(0, $offset);
+
         $sql = $wpdb->prepare(
-            "SELECT * FROM {$table_name} 
-             WHERE booking_date >= %s AND booking_date <= %s 
+            "SELECT * FROM {$table_name}
+             WHERE booking_date >= %s AND booking_date <= %s
              AND status != 'cancelled'
-             ORDER BY booking_date ASC, booking_time ASC",
+             ORDER BY booking_date ASC, booking_time ASC
+             LIMIT %d OFFSET %d",
+            $start_date,
+            $end_date,
+            $limit,
+            $offset
+        );
+
+        return $wpdb->get_results($sql);
+    }
+
+    /**
+     * Count bookings by date range.
+     *
+     * @param string $start_date Start date (Y-m-d format)
+     * @param string $end_date End date (Y-m-d format)
+     * @return int Total bookings within date range
+     */
+    public static function countBookingsByDateRange(string $start_date, string $end_date): int {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'fp_bookings';
+
+        $sql = $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$table_name}
+             WHERE booking_date >= %s AND booking_date <= %s
+             AND status != 'cancelled'",
             $start_date,
             $end_date
         );
-        
-        return $wpdb->get_results($sql);
+
+        return (int) $wpdb->get_var($sql);
     }
     
     /**


### PR DESCRIPTION
## Summary
- add pagination parameters, range limits, and cached lookups to the events REST endpoint
- expose total counts/metadata and reuse them in the admin calendar to fetch pages iteratively
- localize pagination defaults for the UI and clamp booking queries to avoid oversized loads

## Testing
- php -l includes/REST/BookingsController.php
- php -l includes/Booking/BookingManager.php
- php -l includes/Admin/MenuManager.php

------
https://chatgpt.com/codex/tasks/task_e_68d692ffb6c8832fbe8dd22958b4f49f